### PR TITLE
🩹 avoid header confusion

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,8 +110,6 @@ if(NOT TARGET ${PROJECT_NAME}-dd)
     dd/Operations.cpp
     dd/Simulation.cpp)
   target_link_libraries(${PROJECT_NAME}-dd PUBLIC ${PROJECT_NAME})
-  target_include_directories(${PROJECT_NAME}-dd PUBLIC ${PROJECT_SOURCE_DIR}/include/dd
-                                                       ${PROJECT_BINARY_DIR}/include/dd)
   add_library(MQT::CoreDD ALIAS ${PROJECT_NAME}-dd)
   add_library(MQT::${OLD_PROJECT_NAME}_dd ALIAS ${PROJECT_NAME}-dd)
 endif()
@@ -134,8 +132,6 @@ if(NOT TARGET ${PROJECT_NAME}-zx)
     zx/Utils.cpp
     zx/FunctionalityConstruction.cpp)
   target_link_libraries(${PROJECT_NAME}-zx PUBLIC ${PROJECT_NAME})
-  target_include_directories(${PROJECT_NAME}-zx PUBLIC ${PROJECT_SOURCE_DIR}/include/zx
-                                                       ${PROJECT_BINARY_DIR}/include/zx)
 
   add_subdirectory("${PROJECT_SOURCE_DIR}/extern/boost/config" "extern/boost/config"
                    EXCLUDE_FROM_ALL)
@@ -187,8 +183,6 @@ if(NOT TARGET ${PROJECT_NAME}-ecc)
     ecc/Q18Surface.cpp)
 
   target_link_libraries(${PROJECT_NAME}-ecc PUBLIC ${PROJECT_NAME})
-  target_include_directories(${PROJECT_NAME}-ecc PUBLIC ${PROJECT_SOURCE_DIR}/include/ecc
-                                                        ${PROJECT_BINARY_DIR}/include/ecc)
 
   # add MQT alias
   add_library(MQT::CoreECC ALIAS ${PROJECT_NAME}-ecc)
@@ -211,10 +205,6 @@ if(NOT TARGET ${PROJECT_NAME}-python)
     ${PROJECT_SOURCE_DIR}/include/python/qiskit/QuantumCircuit.hpp
     ${PROJECT_SOURCE_DIR}/include/python/qiskit/QasmQobjExperiment.hpp
     python/qiskit/QuantumCircuit.cpp python/qiskit/QasmQobjExperiment.cpp)
-
-  # set include directories
-  target_include_directories(${PROJECT_NAME}-python PUBLIC ${PROJECT_SOURCE_DIR}/include/python
-                                                           ${PROJECT_BINARY_DIR}/include/python)
 
   # link with main project library and pybind11 libraries
   target_link_libraries(${PROJECT_NAME}-python PRIVATE ${PROJECT_NAME} pybind11::pybind11

--- a/src/python/qiskit/QasmQobjExperiment.cpp
+++ b/src/python/qiskit/QasmQobjExperiment.cpp
@@ -1,4 +1,4 @@
-#include "qiskit/QasmQobjExperiment.hpp"
+#include "python/qiskit/QasmQobjExperiment.hpp"
 
 void qc::qiskit::QasmQobjExperiment::import(qc::QuantumComputation& qc,
                                             const py::object& circ) {

--- a/src/python/qiskit/QuantumCircuit.cpp
+++ b/src/python/qiskit/QuantumCircuit.cpp
@@ -1,4 +1,4 @@
-#include "qiskit/QuantumCircuit.hpp"
+#include "python/qiskit/QuantumCircuit.hpp"
 
 void qc::qiskit::QuantumCircuit::import(qc::QuantumComputation& qc,
                                         const py::object& circ) {


### PR DESCRIPTION
## Description

Removes the additional include directories for `MQT::Core<...>` targets to avoid mixing headers with the same name.
See https://github.com/cda-tum/ddsim/pull/253#discussion_r1232225057 for why this might be necessary.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
