### PR TITLE
🚸 Automatic discovery of nanobind when running outside `pip install`

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -29,6 +29,15 @@ find_package(
   COMPONENTS Interpreter Development.Module
   OPTIONAL_COMPONENTS Development.SABIModule)
 
+if(NOT SKBUILD)
+  # Manually detect the installed nanobind package and import it into CMake.
+  execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE NB_DIR)
+  list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
+endif()
+
 # Import nanobind through CMake's find_package mechanism
 find_package(nanobind CONFIG REQUIRED)
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(NOT SKBUILD)
   message(
-    WARNING
-      "\
+    NOTICE
+    "\
   This CMake file is meant to be executed using 'scikit-build'. Running
   it directly will almost certainly not produce the desired result. If
   you are a user trying to install this package, please use the command


### PR DESCRIPTION
## Description

This small PR makes it a little easier to get code completion for the C++-Python bindings.
Previously, it was rather hard to get CMake to find a Python-installed version of `nanobind`.
As a result, syntax highlighting and code completion did not work properly in the bindings code.

`scikit-build-core` automagically handles the location of the installed nanobind library by adding the module's CMake path to the CMake prefix path during the build.

This PR now automatically adds that CMake path even when not running via `pip install` by querying the Python interpreter that is required anyway.
So if you have `nanobind` installed in the current Python environment, it should now be correctly picked up without any manual workaround.

If it should happen that CMake picks up the wrong Python version, you can give it a hint by adding `-DPython_EXECUTABLE=<path to python interpreter>` to the CMake configure command.


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
