### PR TITLE
Cmake structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,10 @@ include(cmake/Cache.cmake)
 
 option(BUILD_MQT_CORE_BINDINGS "Build the MQT Core Python bindings" OFF)
 if(BUILD_MQT_CORE_BINDINGS)
-  # ensure that the BINDINGS option is set in the MQT Core library
+  # ensure that the BINDINGS option is set
   set(BINDINGS
       ON
-      CACHE BOOL "Build the MQT Core Python bindings" FORCE)
+      CACHE BOOL "Enable settings related to Python bindings" FORCE)
 endif()
 
 if(NOT TARGET project_warnings)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,12 +48,6 @@ check_submodule_present(pybind11)
 check_submodule_present(pybind11_json)
 check_submodule_present(boost/config)
 check_submodule_present(boost/multiprecision)
-set(BOOST_MP_STANDALONE ON)
-
-find_package(GMP)
-if(NOT GMP_FOUND)
-  message(NOTICE "Did not find GMP. Using Boost multiprecision library instead.")
-endif()
 
 # add main library code
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,14 @@ include(cmake/CheckSubmodule.cmake)
 include(cmake/PackageAddTest.cmake)
 include(cmake/Cache.cmake)
 
+option(BUILD_MQT_CORE_BINDINGS "Build the MQT Core Python bindings" OFF)
+if(BUILD_MQT_CORE_BINDINGS)
+  # ensure that the BINDINGS option is set in the MQT Core library
+  set(BINDINGS
+      ON
+      CACHE BOOL "Build the MQT Core Python bindings" FORCE)
+endif()
+
 if(NOT TARGET project_warnings)
   # Use the warnings specified in CompilerWarnings.cmake
   add_library(project_warnings INTERFACE)

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -12,9 +12,6 @@ function(enable_project_options target_name)
     endif()
   endif()
 
-  option(BINDINGS "Configure for building Python bindings")
-  include(CheckCXXCompilerFlag)
-
   if(MSVC)
     target_compile_options(${target_name} INTERFACE /utf-8)
   else()
@@ -31,6 +28,8 @@ function(enable_project_options target_name)
     if(NOT DEPLOY)
       # only include machine-specific optimizations when building for the host machine
       target_compile_options(${target_name} INTERFACE -mtune=native)
+
+      include(CheckCXXCompilerFlag)
       check_cxx_compiler_flag(-march=native HAS_MARCH_NATIVE)
       if(HAS_MARCH_NATIVE)
         target_compile_options(${target_name} INTERFACE -march=native)
@@ -47,6 +46,7 @@ function(enable_project_options target_name)
                                -fno-optimize-sibling-calls -fno-inline-functions>)
   endif()
 
+  option(BINDINGS "Configure for building Python bindings")
   if(BINDINGS)
     target_compile_options(${target_name} INTERFACE -fvisibility=hidden)
     include(CheckPIESupported)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ git-only = [
 ]
 
 [tool.scikit-build.cmake.define]
-BINDINGS = "ON"
+BUILD_MQT_CORE_BINDINGS = "ON"
 BUILD_MQT_CORE_TESTS = "OFF"
 ENABLE_IPO = "ON"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,6 @@ if(NOT TARGET ${PROJECT_NAME}-python)
   add_library(MQT::${OLD_PROJECT_NAME}_python ALIAS ${PROJECT_NAME}-python)
 endif()
 
-if(BINDINGS)
+if(BUILD_MQT_CORE_BINDINGS)
   add_subdirectory(python)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,120 +79,17 @@ if(NOT TARGET ${PROJECT_NAME})
   add_library(MQT::${OLD_PROJECT_NAME} ALIAS ${PROJECT_NAME})
 endif()
 
-if(NOT TARGET ${PROJECT_NAME}-dd)
-  # add DD Package library
-  add_library(
-    ${PROJECT_NAME}-dd
-    ${PROJECT_SOURCE_DIR}/include/dd/Complex.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/ComplexCache.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/ComplexNumbers.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/ComplexTable.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/ComplexValue.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/ComputeTable.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/Control.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/DDpackageConfig.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/Definitions.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/Edge.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/Export.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/GateMatrixDefinitions.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/Node.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/Package.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/Package_fwd.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/ToffoliTable.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/UnaryComputeTable.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/DensityNoiseTable.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/StochasticNoiseOperationTable.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/UniqueTable.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/FunctionalityConstruction.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/NoiseFunctionality.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/Operations.hpp
-    ${PROJECT_SOURCE_DIR}/include/dd/Simulation.hpp
-    dd/Edge.cpp
-    dd/FunctionalityConstruction.cpp
-    dd/Node.cpp
-    dd/NoiseFunctionality.cpp
-    dd/Operations.cpp
-    dd/Simulation.cpp)
-  target_link_libraries(${PROJECT_NAME}-dd PUBLIC ${PROJECT_NAME})
-  add_library(MQT::CoreDD ALIAS ${PROJECT_NAME}-dd)
-  add_library(MQT::${OLD_PROJECT_NAME}_dd ALIAS ${PROJECT_NAME}-dd)
-endif()
+# add DD package library
+add_subdirectory(dd)
 
-if(NOT TARGET ${PROJECT_NAME}-zx)
-  # add ZX package library
-  add_library(
-    ${PROJECT_NAME}-zx
-    ${PROJECT_SOURCE_DIR}/include/zx/Rational.hpp
-    ${PROJECT_SOURCE_DIR}/include/zx/ZXDiagram.hpp
-    ${PROJECT_SOURCE_DIR}/include/zx/Definitions.hpp
-    ${PROJECT_SOURCE_DIR}/include/zx/Rules.hpp
-    ${PROJECT_SOURCE_DIR}/include/zx/Simplify.hpp
-    ${PROJECT_SOURCE_DIR}/include/zx/Utils.hpp
-    ${PROJECT_SOURCE_DIR}/include/zx/FunctionalityConstruction.hpp
-    zx/Rational.cpp
-    zx/ZXDiagram.cpp
-    zx/Rules.cpp
-    zx/Simplify.cpp
-    zx/Utils.cpp
-    zx/FunctionalityConstruction.cpp)
-  target_link_libraries(${PROJECT_NAME}-zx PUBLIC ${PROJECT_NAME})
+# add ZX package library
+add_subdirectory(zx)
 
-  add_subdirectory("${PROJECT_SOURCE_DIR}/extern/boost/config" "extern/boost/config"
-                   EXCLUDE_FROM_ALL)
-  target_link_libraries(${PROJECT_NAME}-zx PUBLIC Boost::config)
+# add ECC library
+add_subdirectory(ecc)
 
-  add_subdirectory("${PROJECT_SOURCE_DIR}/extern/boost/multiprecision"
-                   "extern/boost/multiprecision" EXCLUDE_FROM_ALL)
-  target_link_libraries(${PROJECT_NAME}-zx PUBLIC Boost::multiprecision)
-  # the following sets the SYSTEM flag for the include dirs of the boost libs to suppress warnings
-  # cmake-lint: disable=C0307
-  set_target_properties(
-    boost_config PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                            $<TARGET_PROPERTY:boost_config,INTERFACE_INCLUDE_DIRECTORIES>)
-  # cmake-lint: disable=C0307
-  set_target_properties(
-    boost_multiprecision
-    PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-               $<TARGET_PROPERTY:boost_multiprecision,INTERFACE_INCLUDE_DIRECTORIES>)
-
-  # # link to GMP libraries if present
-  if(GMP_FOUND)
-    target_compile_definitions(${PROJECT_NAME}-zx PUBLIC GMP)
-    target_link_libraries(${PROJECT_NAME}-zx PUBLIC GMP::gmp GMP::gmpxx)
-  endif()
-
-  # add MQT alias
-  add_library(MQT::CoreZX ALIAS ${PROJECT_NAME}-zx)
-  add_library(MQT::${OLD_PROJECT_NAME}_zx ALIAS ${PROJECT_NAME}-zx)
-endif()
-
-if(NOT TARGET ${PROJECT_NAME}-ecc)
-  # add ECC package library
-  add_library(
-    ${PROJECT_NAME}-ecc
-    ${PROJECT_SOURCE_DIR}/include/ecc/Ecc.hpp
-    ${PROJECT_SOURCE_DIR}/include/ecc/Id.hpp
-    ${PROJECT_SOURCE_DIR}/include/ecc/Q3Shor.hpp
-    ${PROJECT_SOURCE_DIR}/include/ecc/Q5Laflamme.hpp
-    ${PROJECT_SOURCE_DIR}/include/ecc/Q7Steane.hpp
-    ${PROJECT_SOURCE_DIR}/include/ecc/Q9Shor.hpp
-    ${PROJECT_SOURCE_DIR}/include/ecc/Q9Surface.hpp
-    ${PROJECT_SOURCE_DIR}/include/ecc/Q18Surface.hpp
-    ecc/Ecc.cpp
-    ecc/Q3Shor.cpp
-    ecc/Q5Laflamme.cpp
-    ecc/Q7Steane.cpp
-    ecc/Q9Shor.cpp
-    ecc/Q9Surface.cpp
-    ecc/Q18Surface.cpp)
-
-  target_link_libraries(${PROJECT_NAME}-ecc PUBLIC ${PROJECT_NAME})
-
-  # add MQT alias
-  add_library(MQT::CoreECC ALIAS ${PROJECT_NAME}-ecc)
-  add_library(MQT::${OLD_PROJECT_NAME}_ecc ALIAS ${PROJECT_NAME}-ecc)
-endif()
-
+# ** Note ** The following target will soon be removed from the project. All top-level projects
+# should switch to nanobind. After that, the pybind submodules will be removed.
 if(NOT TARGET ${PROJECT_NAME}-python)
   # add pybind11 library
   add_subdirectory("${PROJECT_SOURCE_DIR}/extern/pybind11" "extern/pybind11" EXCLUDE_FROM_ALL)

--- a/src/dd/CMakeLists.txt
+++ b/src/dd/CMakeLists.txt
@@ -1,0 +1,17 @@
+if(NOT TARGET ${PROJECT_NAME}-dd)
+  file(GLOB_RECURSE DD_HEADERS ${PROJECT_SOURCE_DIR}/include/dd/*.hpp)
+
+  # add DD Package library
+  add_library(
+    ${PROJECT_NAME}-dd
+    ${DD_HEADERS}
+    Edge.cpp
+    FunctionalityConstruction.cpp
+    Node.cpp
+    NoiseFunctionality.cpp
+    Operations.cpp
+    Simulation.cpp)
+  target_link_libraries(${PROJECT_NAME}-dd PUBLIC ${PROJECT_NAME})
+  add_library(MQT::CoreDD ALIAS ${PROJECT_NAME}-dd)
+  add_library(MQT::${OLD_PROJECT_NAME}_dd ALIAS ${PROJECT_NAME}-dd)
+endif()

--- a/src/ecc/CMakeLists.txt
+++ b/src/ecc/CMakeLists.txt
@@ -1,0 +1,21 @@
+if(NOT TARGET ${PROJECT_NAME}-ecc)
+  file(GLOB_RECURSE ECC_HEADERS ${PROJECT_SOURCE_DIR}/include/ecc/*.hpp)
+
+  # add ECC package library
+  add_library(
+    ${PROJECT_NAME}-ecc
+    ${ECC_HEADERS}
+    Ecc.cpp
+    Q3Shor.cpp
+    Q5Laflamme.cpp
+    Q7Steane.cpp
+    Q9Shor.cpp
+    Q9Surface.cpp
+    Q18Surface.cpp)
+
+  target_link_libraries(${PROJECT_NAME}-ecc PUBLIC ${PROJECT_NAME})
+
+  # add MQT alias
+  add_library(MQT::CoreECC ALIAS ${PROJECT_NAME}-ecc)
+  add_library(MQT::${OLD_PROJECT_NAME}_ecc ALIAS ${PROJECT_NAME}-ecc)
+endif()

--- a/src/zx/CMakeLists.txt
+++ b/src/zx/CMakeLists.txt
@@ -1,0 +1,48 @@
+if(NOT TARGET ${PROJECT_NAME}-zx)
+  file(GLOB_RECURSE ZX_HEADERS ${PROJECT_SOURCE_DIR}/include/zx/*.hpp)
+
+  # add ZX package library
+  add_library(
+    ${PROJECT_NAME}-zx
+    ${ZX_HEADERS}
+    Rational.cpp
+    ZXDiagram.cpp
+    Rules.cpp
+    Simplify.cpp
+    Utils.cpp
+    FunctionalityConstruction.cpp)
+  target_link_libraries(${PROJECT_NAME}-zx PUBLIC ${PROJECT_NAME})
+
+  add_subdirectory("${PROJECT_SOURCE_DIR}/extern/boost/config" "extern/boost/config"
+                   EXCLUDE_FROM_ALL)
+  target_link_libraries(${PROJECT_NAME}-zx PUBLIC Boost::config)
+
+  set(BOOST_MP_STANDALONE ON)
+  add_subdirectory("${PROJECT_SOURCE_DIR}/extern/boost/multiprecision"
+                   "extern/boost/multiprecision" EXCLUDE_FROM_ALL)
+  target_link_libraries(${PROJECT_NAME}-zx PUBLIC Boost::multiprecision)
+  # the following sets the SYSTEM flag for the include dirs of the boost libs to suppress warnings
+  # cmake-lint: disable=C0307
+  set_target_properties(
+    boost_config PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                            $<TARGET_PROPERTY:boost_config,INTERFACE_INCLUDE_DIRECTORIES>)
+  # cmake-lint: disable=C0307
+  set_target_properties(
+    boost_multiprecision
+    PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+               $<TARGET_PROPERTY:boost_multiprecision,INTERFACE_INCLUDE_DIRECTORIES>)
+
+  find_package(GMP)
+  if(NOT GMP_FOUND)
+    message(NOTICE "Did not find GMP. Using Boost multiprecision library instead.")
+  endif()
+  # # link to GMP libraries if present
+  if(GMP_FOUND)
+    target_compile_definitions(${PROJECT_NAME}-zx PUBLIC GMP)
+    target_link_libraries(${PROJECT_NAME}-zx PUBLIC GMP::gmp GMP::gmpxx)
+  endif()
+
+  # add MQT alias
+  add_library(MQT::CoreZX ALIAS ${PROJECT_NAME}-zx)
+  add_library(MQT::${OLD_PROJECT_NAME}_zx ALIAS ${PROJECT_NAME}-zx)
+endif()


### PR DESCRIPTION
## Description

This pull request moves the CMake code for building the targets for the different parts of mqt-core into their respective subfolders.

Also this PR renames the `BINDINGS` CMake variable such that it is consistent and distinguishable from the Bindings variable of other MQT projects.
## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
