### PR TITLE
♻️📝 Un-template and document complex number handling in DD package

### DIFF
--- a/include/dd/Complex.hpp
+++ b/include/dd/Complex.hpp
@@ -8,8 +8,6 @@
 #include <utility>
 
 namespace dd {
-using CTEntry = ComplexTable<>::Entry;
-
 struct Complex {
   CTEntry* r;
   CTEntry* i;
@@ -70,9 +68,9 @@ inline std::ostream& operator<<(std::ostream& os, const Complex& c) {
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables)
-inline Complex Complex::zero{&ComplexTable<>::zero, &ComplexTable<>::zero};
+inline Complex Complex::zero{&ComplexTable::zero, &ComplexTable::zero};
 // NOLINTNEXTLINE(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables)
-inline Complex Complex::one{&ComplexTable<>::one, &ComplexTable<>::zero};
+inline Complex Complex::one{&ComplexTable::one, &ComplexTable::zero};
 } // namespace dd
 
 namespace std {

--- a/include/dd/Complex.hpp
+++ b/include/dd/Complex.hpp
@@ -1,80 +1,130 @@
 #pragma once
 
-#include "ComplexTable.hpp"
-#include "ComplexValue.hpp"
+#include "dd/ComplexTable.hpp"
+#include "dd/Definitions.hpp"
 
 #include <cstddef>
 #include <iostream>
+#include <string>
 #include <utility>
 
 namespace dd {
+/// A complex number represented by two pointers to compute table entries.
 struct Complex {
+  /// Compute table entry for the real part.
   CTEntry* r;
+  /// Compute table entry for the imaginary part.
   CTEntry* i;
 
-  // NOLINTNEXTLINE(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables)
+  // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+  /// The static zero constant.
   static Complex zero;
-  // NOLINTNEXTLINE(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables)
+  /// The static one constant.
   static Complex one;
+  // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
-  void setVal(const Complex& c) const {
-    r->value = CTEntry::val(c.r);
-    i->value = CTEntry::val(c.i);
-  }
+  /**
+   * @brief Set the value based on the given complex number.
+   * @param c The value to set.
+   */
+  void setVal(const Complex& c) const;
 
-  [[nodiscard]] inline bool approximatelyEquals(const Complex& c) const {
-    return CTEntry::approximatelyEquals(r, c.r) &&
-           CTEntry::approximatelyEquals(i, c.i);
-  };
+  /**
+   * @brief Check whether the complex number is exactly equal to zero.
+   * @returns True if the complex number is exactly equal to zero, false
+   * otherwise.
+   * @see CTEntry::exactlyZero
+   */
+  [[nodiscard]] bool exactlyZero() const;
 
-  [[nodiscard]] inline bool exactlyZero() const {
-    return CTEntry::exactlyZero(r) && CTEntry::exactlyZero(i);
-  };
+  /**
+   * @brief Check whether the complex number is exactly equal to one.
+   * @returns True if the complex number is exactly equal to one, false
+   * otherwise.
+   * @see CTEntry::exactlyOne
+   * @see CTEntry::exactlyZero
+   */
+  [[nodiscard]] bool exactlyOne() const;
 
-  [[nodiscard]] inline bool exactlyOne() const {
-    return CTEntry::exactlyOne(r) && CTEntry::exactlyZero(i);
-  };
+  /**
+   * @brief Check whether the complex number is approximately equal to the
+   * given complex number.
+   * @param c The complex number to compare to.
+   * @returns True if the complex number is approximately equal to the given
+   * complex number, false otherwise.
+   * @see CTEntry::approximatelyEquals
+   */
+  [[nodiscard]] bool approximatelyEquals(const Complex& c) const;
 
-  [[nodiscard]] inline bool approximatelyZero() const {
-    return CTEntry::approximatelyZero(r) && CTEntry::approximatelyZero(i);
-  }
+  /**
+   * @brief Check whether the complex number is approximately equal to zero.
+   * @returns True if the complex number is approximately equal to zero, false
+   * otherwise.
+   * @see CTEntry::approximatelyZero
+   */
+  [[nodiscard]] bool approximatelyZero() const;
 
-  [[nodiscard]] inline bool approximatelyOne() const {
-    return CTEntry::approximatelyOne(r) && CTEntry::approximatelyZero(i);
-  }
+  /**
+   * @brief Check whether the complex number is approximately equal to one.
+   * @returns True if the complex number is approximately equal to one, false
+   * otherwise.
+   * @see CTEntry::approximatelyOne
+   * @see CTEntry::approximatelyZero
+   */
+  [[nodiscard]] bool approximatelyOne() const;
 
-  inline bool operator==(const Complex& other) const {
-    return r == other.r && i == other.i;
-  }
+  /**
+   * @brief Check for exact equality.
+   * @param other The complex number to compare to.
+   * @returns True if the complex numbers are exactly equal, false otherwise.
+   * @note Boils down to a pointer comparison.
+   */
+  [[nodiscard]] bool operator==(const Complex& other) const;
 
-  inline bool operator!=(const Complex& other) const {
-    return !operator==(other);
-  }
+  /// @see operator==
+  [[nodiscard]] bool operator!=(const Complex& other) const;
 
+  /**
+   * @brief Convert the complex number to a string.
+   * @param formatted Whether to apply special formatting to the numbers.
+   * @param precision The precision to use for the numbers.
+   * @returns The string representation of the complex number.
+   * @see ComplexValue::toString
+   */
   [[nodiscard]] std::string toString(bool formatted = true,
-                                     int precision = -1) const {
-    return ComplexValue::toString(CTEntry::val(r), CTEntry::val(i), formatted,
-                                  precision);
-  }
+                                     int precision = -1) const;
 
-  void writeBinary(std::ostream& os) const {
-    CTEntry::writeBinary(r, os);
-    CTEntry::writeBinary(i, os);
-  }
+  /**
+   * @brief Write the complex number to a binary stream.
+   * @param os The output stream to write to.
+   * @see CTEntry::writeBinary
+   */
+  void writeBinary(std::ostream& os) const;
 };
 
-inline std::ostream& operator<<(std::ostream& os, const Complex& c) {
-  return os << c.toString();
-}
+/**
+ * @brief Print a complex number to a stream.
+ * @param os The output stream to write to.
+ * @param c The complex number to print.
+ * @returns The output stream.
+ */
+std::ostream& operator<<(std::ostream& os, const Complex& c);
 
-// NOLINTNEXTLINE(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables)
-inline Complex Complex::zero{&ComplexTable::zero, &ComplexTable::zero};
-// NOLINTNEXTLINE(readability-identifier-naming,cppcoreguidelines-avoid-non-const-global-variables)
-inline Complex Complex::one{&ComplexTable::one, &ComplexTable::zero};
 } // namespace dd
 
 namespace std {
+/// Hash function for complex numbers.
 template <> struct hash<dd::Complex> {
+  /**
+   * @brief Compute the hash value for a complex number.
+   * @details Reinterprets the pointers to the real and imaginary part as
+   * integers and computes the hash value for those. Afterwards, the two hash
+   * values are combined.
+   * @param c The complex number to compute the hash value for.
+   * @returns The hash value.
+   * @see dd::murmur64
+   * @see dd::combineHash
+   */
   std::size_t operator()(dd::Complex const& c) const noexcept {
     auto h1 = dd::murmur64(reinterpret_cast<std::size_t>(c.r));
     auto h2 = dd::murmur64(reinterpret_cast<std::size_t>(c.i));

--- a/include/dd/ComplexCache.hpp
+++ b/include/dd/ComplexCache.hpp
@@ -1,125 +1,105 @@
 #pragma once
 
 #include "Complex.hpp"
-#include "ComplexTable.hpp"
 
-#include <cassert>
 #include <cstddef>
 #include <vector>
 
 namespace dd {
-
+/// A class for managing a cache of Complex numbers
 class ComplexCache {
+  /// @see ComplexTable::INITIAL_ALLOCATION_SIZE
   static constexpr std::size_t INITIAL_ALLOCATION_SIZE = 2048U;
+  /// @see ComplexTable::GROWTH_FACTOR
   static constexpr std::size_t GROWTH_FACTOR = 2U;
 
 public:
+  /**
+   * @brief Construct a new ComplexCache object
+   * @param initialAllocSize The initial allocation size
+   * @param growthFact The growth factor used for the allocation size
+   * @see ComplexTable::INITIAL_ALLOCATION_SIZE
+   * @see ComplexTable::GROWTH_FACTOR
+   */
   explicit ComplexCache(
       const std::size_t initialAllocSize = INITIAL_ALLOCATION_SIZE,
       const std::size_t growthFact = GROWTH_FACTOR)
       : initialAllocationSize(initialAllocSize), growthFactor(growthFact) {}
 
+  /// default destructor
   ~ComplexCache() = default;
 
-  // access functions
+  /// Get the number of entries in the cache
   [[nodiscard]] std::size_t getCount() const { return count; }
+  /// Get the peak number of entries in the cache
   [[nodiscard]] std::size_t getPeakCount() const { return peakCount; }
+  /// Get the number of allocations performed
   [[nodiscard]] std::size_t getAllocations() const { return allocations; }
+  /// Get the growth factor used for the allocation size
   [[nodiscard]] std::size_t getGrowthFactor() const { return growthFactor; }
 
-  [[nodiscard]] Complex getCachedComplex() {
-    // an entry is available on the stack
-    if (available != nullptr) {
-      assert(available->next != nullptr);
-      auto entry = Complex{available, available->next};
-      available = entry.i->next;
-      count += 2;
-      return entry;
-    }
+  /**
+   * @brief Get a Complex from the cache
+   * @details This method returns a fresh Complex from the cache. It first
+   * checks if there is an entry on the available list. If not, it checks
+   * whether the current chunk has enough space left. If not, it allocates a new
+   * chunk. It then returns a Complex from the current chunk. This consumes two
+   * entries from the cache.
+   * @return a Complex from the cache
+   */
+  [[nodiscard]] Complex getCachedComplex();
 
-    // new chunk has to be allocated
-    if (chunkIt == chunkEndIt) {
-      chunks.emplace_back(allocationSize);
-      allocations += allocationSize;
-      allocationSize *= growthFactor;
-      chunkID++;
-      chunkIt = chunks[chunkID].begin();
-      chunkEndIt = chunks[chunkID].end();
-    }
+  /**
+   * @brief Get a temporary Complex from the cache
+   * @details In contrast to getCachedComplex(), this method does not consume
+   * two entries from the cache. It just provides temporary access to a Complex
+   * from the cache. Any subsequent call to getCachedComplex() or this method
+   * will potentially invalidate the Complex returned by this method.
+   * @see getCachedComplex()
+   * @return
+   */
+  [[nodiscard]] Complex getTemporaryComplex();
 
-    Complex c{};
-    c.r = &(*chunkIt);
-    ++chunkIt;
-    c.i = &(*chunkIt);
-    ++chunkIt;
-    count += 2;
-    return c;
-  }
+  /**
+   * @brief Return a Complex to the available list
+   * @details This method returns a Complex to the available list. After this
+   * call, the Complex should not be used anymore. The Complex must not be
+   * Complex::zero or Complex::one. The Complex must not be in use, i.e. its
+   * reference count must be zero.
+   * @param c the Complex to return
+   */
+  void returnToCache(Complex& c);
 
-  [[nodiscard]] Complex getTemporaryComplex() {
-    // an entry is available on the stack
-    if (available != nullptr) {
-      assert(available->next != nullptr);
-      return {available, available->next};
-    }
-
-    // new chunk has to be allocated
-    if (chunkIt == chunkEndIt) {
-      chunks.emplace_back(allocationSize);
-      allocations += allocationSize;
-      allocationSize *= growthFactor;
-      chunkID++;
-      chunkIt = chunks[chunkID].begin();
-      chunkEndIt = chunks[chunkID].end();
-    }
-    return {&(*chunkIt), &(*(chunkIt + 1))};
-  }
-
-  void returnToCache(Complex& c) {
-    assert(count >= 2);
-    assert(c != Complex::zero);
-    assert(c != Complex::one);
-    assert(c.r->refCount == 0);
-    assert(c.i->refCount == 0);
-    c.i->next = available;
-    c.r->next = c.i;
-    available = c.r;
-    count -= 2;
-  }
-
-  void clear() {
-    // clear available stack
-    available = nullptr;
-
-    // release memory of all but the first chunk
-    // it could be desirable to keep the memory for later use
-    while (chunkID > 0) {
-      chunks.pop_back();
-      chunkID--;
-    }
-    // restore initial chunk setting
-    chunkIt = chunks[0].begin();
-    chunkEndIt = chunks[0].end();
-    allocationSize = initialAllocationSize * growthFactor;
-    allocations = initialAllocationSize;
-
-    count = 0;
-    peakCount = 0;
-  };
+  /**
+   * @brief Clear the cache
+   * @details This method clears the cache. It discards the available list and
+   * all but the first chunk of memory. Also resets all counters.
+   */
+  void clear();
 
 private:
+  /// the list of entries that are available for reuse
   CTEntry* available{};
+  /// the number of entries initially allocated
   std::size_t initialAllocationSize;
+  /// the growth factor for the allocation size
   std::size_t growthFactor;
+  /// the actual chunks of memory
   std::vector<std::vector<CTEntry>> chunks{
       1U, std::vector<CTEntry>(initialAllocationSize)};
+  /// the current chunk
   std::size_t chunkID{};
-  typename std::vector<CTEntry>::iterator chunkIt{chunks.front().begin()};
-  typename std::vector<CTEntry>::iterator chunkEndIt{chunks.front().end()};
+  /// the iterator for the current chunk
+  std::vector<CTEntry>::iterator chunkIt{chunks.front().begin()};
+  /// the end iterator for the current chunk
+  std::vector<CTEntry>::iterator chunkEndIt{chunks.front().end()};
+  /// the size of the next allocation
   std::size_t allocationSize{initialAllocationSize * growthFactor};
-
+  /// the total number of allocations performed
   std::size_t allocations = initialAllocationSize;
+  /// the number of entries in the cache
   std::size_t count = 0;
+  /// the peak number of entries in the cache
   std::size_t peakCount = 0;
 };
 } // namespace dd

--- a/include/dd/ComplexNumbers.hpp
+++ b/include/dd/ComplexNumbers.hpp
@@ -12,8 +12,8 @@
 
 namespace dd {
 struct ComplexNumbers {
-  ComplexTable<> complexTable{};
-  ComplexCache<> complexCache{};
+  ComplexTable complexTable{};
+  ComplexCache complexCache{};
 
   ComplexNumbers() = default;
   ~ComplexNumbers() = default;
@@ -23,7 +23,7 @@ struct ComplexNumbers {
     complexCache.clear();
   }
 
-  static void setTolerance(fp tol) { ComplexTable<>::setTolerance(tol); }
+  static void setTolerance(fp tol) { ComplexTable::setTolerance(tol); }
 
   // operations on complex numbers
   // meanings are self-evident from the names
@@ -184,15 +184,15 @@ struct ComplexNumbers {
   static void incRef(const Complex& c) {
     // `zero` and `one` are static and never altered
     if (c != Complex::zero && c != Complex::one) {
-      ComplexTable<>::incRef(c.r);
-      ComplexTable<>::incRef(c.i);
+      ComplexTable::incRef(c.r);
+      ComplexTable::incRef(c.i);
     }
   }
   static void decRef(const Complex& c) {
     // `zero` and `one` are static and never altered
     if (c != Complex::zero && c != Complex::one) {
-      ComplexTable<>::decRef(c.r);
-      ComplexTable<>::decRef(c.i);
+      ComplexTable::decRef(c.r);
+      ComplexTable::decRef(c.i);
     }
   }
   std::size_t garbageCollect(bool force = false) {

--- a/include/dd/ComplexValue.hpp
+++ b/include/dd/ComplexValue.hpp
@@ -1,256 +1,143 @@
 #pragma once
 
-#include "ComplexTable.hpp"
-#include "Definitions.hpp"
+#include "dd/Definitions.hpp"
 
-#include <algorithm>
-#include <cmath>
+#include <complex>
 #include <cstddef>
-#include <cstdlib>
-#include <iomanip>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <utility>
 
 namespace dd {
+/// A complex number represented by two floating point values.
 struct ComplexValue {
-  fp r, i;
+  /// real part
+  fp r;
+  /// imaginary part
+  fp i;
 
-  [[nodiscard]] bool approximatelyEquals(const ComplexValue& c) const {
-    return CTEntry::approximatelyEquals(r, c.r) &&
-           CTEntry::approximatelyEquals(i, c.i);
-  }
+  /**
+   * @brief Check for exact equality.
+   * @param other The other complex number to compare to.
+   * @returns True if the complex numbers are exactly equal, false otherwise.
+   */
+  [[nodiscard]] bool operator==(const ComplexValue& other) const;
 
-  [[nodiscard]] bool approximatelyZero() const {
-    return CTEntry::approximatelyZero(r) && CTEntry::approximatelyZero(i);
-  }
+  /// @see operator==
+  [[nodiscard]] bool operator!=(const ComplexValue& other) const;
 
-  [[nodiscard]] bool approximatelyOne() const {
-    return CTEntry::approximatelyOne(r) && CTEntry::approximatelyZero(i);
-  }
+  /**
+   * @brief Check whether the complex number is approximately equal to the
+   * given complex number.
+   * @param c The complex number to compare to.
+   * @returns True if the complex number is approximately equal to the given
+   * complex number, false otherwise.
+   * @see CTEntry::approximatelyEquals
+   */
+  [[nodiscard]] bool approximatelyEquals(const ComplexValue& c) const;
 
-  constexpr bool operator==(const ComplexValue& other) const {
-    // NOLINTNEXTLINE(clang-diagnostic-float-equal)
-    return r == other.r && i == other.i;
-  }
+  /**
+   * @brief Check whether the complex number is approximately equal to zero.
+   * @returns True if the complex number is approximately equal to zero, false
+   * otherwise.
+   * @see CTEntry::approximatelyZero
+   */
+  [[nodiscard]] bool approximatelyZero() const;
 
-  constexpr bool operator!=(const ComplexValue& other) const {
-    return !operator==(other);
-  }
+  /**
+   * @brief Check whether the complex number is approximately equal to one.
+   * @returns True if the complex number is approximately equal to one, false
+   * otherwise.
+   * @see CTEntry::approximatelyOne
+   * @see CTEntry::approximatelyZero
+   */
+  [[nodiscard]] bool approximatelyOne() const;
 
-  void readBinary(std::istream& is) {
-    is.read(reinterpret_cast<char*>(&r), sizeof(decltype(r)));
-    is.read(reinterpret_cast<char*>(&i), sizeof(decltype(i)));
-  }
+  /**
+   * @brief Write a binary representation of the complex number to the given
+   * output stream.
+   * @param os The output stream to write to.
+   */
+  void writeBinary(std::ostream& os) const;
 
-  void writeBinary(std::ostream& os) const {
-    os.write(reinterpret_cast<const char*>(&r), sizeof(decltype(r)));
-    os.write(reinterpret_cast<const char*>(&i), sizeof(decltype(i)));
-  }
+  /**
+   * @brief Read a binary representation of the complex number from the given
+   * input stream.
+   * @param is The input stream to read from.
+   */
+  void readBinary(std::istream& is);
 
-  void fromString(const std::string& realStr, std::string imagStr) {
-    const fp real = realStr.empty() ? 0. : std::stod(realStr);
+  /**
+   * @brief Construct a complex number from a string.
+   * @param realStr The string representation of the real part.
+   * @param imagStr The string representation of the imaginary part.
+   */
+  void fromString(const std::string& realStr, std::string imagStr);
 
-    imagStr.erase(remove(imagStr.begin(), imagStr.end(), ' '), imagStr.end());
-    imagStr.erase(remove(imagStr.begin(), imagStr.end(), 'i'), imagStr.end());
-    if (imagStr == "+" || imagStr == "-") {
-      imagStr = imagStr + "1";
-    }
-    const fp imag = imagStr.empty() ? 0. : std::stod(imagStr);
-    r = {real};
-    i = {imag};
-  }
+  /**
+   * @brief Get the closest fraction to the given number.
+   * @param x The number to approximate.
+   * @param maxDenominator The maximum denominator to use.
+   * @returns The closest fraction to the given number as a pair of numerator
+   * and denominator.
+   */
+  static std::pair<std::uint64_t, std::uint64_t>
+  getLowestFraction(double x, std::uint64_t maxDenominator = 1U << 10);
 
-  static auto getLowestFraction(const double x,
-                                const std::uint64_t maxDenominator = 1U << 10,
-                                const fp tol = ComplexTable::tolerance()) {
-    assert(x >= 0.);
+  /**
+   * @brief Pretty print the given real number to the given output stream.
+   * @param os The output stream to write to.
+   * @param num The number to print.
+   * @param imaginary Whether the number is imaginary.
+   */
+  static void printFormatted(std::ostream& os, fp num, bool imaginary = false);
 
-    std::pair<std::uint64_t, std::uint64_t> lowerBound{0U, 1U};
-    std::pair<std::uint64_t, std::uint64_t> upperBound{1U, 0U};
-
-    while ((lowerBound.second <= maxDenominator) &&
-           (upperBound.second <= maxDenominator)) {
-      auto num = lowerBound.first + upperBound.first;
-      auto den = lowerBound.second + upperBound.second;
-      auto median = static_cast<fp>(num) / static_cast<fp>(den);
-      if (std::abs(x - median) <= tol) {
-        if (den <= maxDenominator) {
-          return std::pair{num, den};
-        }
-        if (upperBound.second > lowerBound.second) {
-          return upperBound;
-        }
-        return lowerBound;
-      }
-      if (x > median) {
-        lowerBound = {num, den};
-      } else {
-        upperBound = {num, den};
-      }
-    }
-    if (lowerBound.second > maxDenominator) {
-      return upperBound;
-    }
-    return lowerBound;
-  }
-
-  static void printFormatted(std::ostream& os, fp num, bool imaginary = false) {
-    if (std::abs(num) <= ComplexTable::tolerance()) {
-      os << (std::signbit(num) ? "-" : "+") << "0" << (imaginary ? "i" : "");
-      return;
-    }
-
-    const auto absnum = std::abs(num);
-    auto fraction = getLowestFraction(absnum);
-    auto approx =
-        static_cast<fp>(fraction.first) / static_cast<fp>(fraction.second);
-    auto error = std::abs(absnum - approx);
-
-    if (error <= ComplexTable::tolerance()) { // suitable fraction a/b found
-      const std::string sign = std::signbit(num) ? "-" : (imaginary ? "+" : "");
-
-      if (fraction.first == 1U && fraction.second == 1U) {
-        os << sign << (imaginary ? "i" : "1");
-      } else if (fraction.second == 1U) {
-        os << sign << fraction.first << (imaginary ? "i" : "");
-      } else if (fraction.first == 1U) {
-        os << sign << (imaginary ? "i" : "1") << "/" << fraction.second;
-      } else {
-        os << sign << fraction.first << (imaginary ? "i" : "") << "/"
-           << fraction.second;
-      }
-
-      return;
-    }
-
-    const auto abssqrt = absnum / SQRT2_2;
-    fraction = getLowestFraction(abssqrt);
-    approx = static_cast<fp>(fraction.first) / static_cast<fp>(fraction.second);
-    error = std::abs(abssqrt - approx);
-
-    if (error <= ComplexTable::tolerance()) { // suitable fraction a/(b *
-                                              // sqrt(2)) found
-      const std::string sign = std::signbit(num) ? "-" : (imaginary ? "+" : "");
-
-      if (fraction.first == 1U && fraction.second == 1U) {
-        os << sign << (imaginary ? "i" : "1") << "/√2";
-      } else if (fraction.second == 1U) {
-        os << sign << fraction.first << (imaginary ? "i" : "") << "/√2";
-      } else if (fraction.first == 1U) {
-        os << sign << (imaginary ? "i" : "1") << "/(" << fraction.second
-           << "√2)";
-      } else {
-        os << sign << fraction.first << (imaginary ? "i" : "") << "/("
-           << fraction.second << "√2)";
-      }
-      return;
-    }
-
-    const auto abspi = absnum / PI;
-    fraction = getLowestFraction(abspi);
-    approx = static_cast<fp>(fraction.first) / static_cast<fp>(fraction.second);
-    error = std::abs(abspi - approx);
-
-    if (error <= ComplexTable::tolerance()) { // suitable fraction a/b π found
-      const std::string sign = std::signbit(num) ? "-" : (imaginary ? "+" : "");
-      const std::string imagUnit = imaginary ? "i" : "";
-
-      if (fraction.first == 1U && fraction.second == 1U) {
-        os << sign << "π" << imagUnit;
-      } else if (fraction.second == 1U) {
-        os << sign << fraction.first << "π" << imagUnit;
-      } else if (fraction.first == 1U) {
-        os << sign << "π" << imagUnit << "/" << fraction.second;
-      } else {
-        os << sign << fraction.first << "π" << imagUnit << "/"
-           << fraction.second;
-      }
-      return;
-    }
-
-    if (imaginary) { // default
-      os << (std::signbit(num) ? "" : "+") << num << "i";
-    } else {
-      os << num;
-    }
-  }
-
+  /**
+   * @brief Print the given complex number to the given output stream.
+   * @param real The real part of the complex number.
+   * @param imag The imaginary part of the complex number.
+   * @param formatted Whether to pretty print the number.
+   * @param precision The precision to use for printing numbers..
+   * @returns The string representation of the complex number.
+   */
   static std::string toString(const fp& real, const fp& imag,
-                              bool formatted = true, int precision = -1) {
-    std::ostringstream ss{};
+                              bool formatted = true, int precision = -1);
 
-    if (precision >= 0) {
-      ss << std::setprecision(precision);
-    }
-    const auto tol = ComplexTable::tolerance();
-
-    if (std::abs(real) <= tol && std::abs(imag) <= tol) {
-      return "0";
-    }
-
-    if (std::abs(real) > tol) {
-      if (formatted) {
-        printFormatted(ss, real);
-      } else {
-        ss << real;
-      }
-    }
-    if (std::abs(imag) > tol) {
-      if (formatted) {
-        if (std::abs(real - imag) <= tol) {
-          ss << "(1+i)";
-          return ss.str();
-        }
-        if (std::abs(real + imag) <= tol) {
-          ss << "(1-i)";
-          return ss.str();
-        }
-        printFormatted(ss, imag, true);
-      } else {
-        if (std::abs(real) <= tol) {
-          ss << imag;
-        } else {
-          if (imag > 0.) {
-            ss << "+";
-          }
-          ss << imag;
-        }
-        ss << "i";
-      }
-    }
-
-    return ss.str();
-  }
-
+  /// Automatically convert to std::complex<dd::fp>
   explicit operator auto() const { return std::complex<dd::fp>{r, i}; }
 
-  ComplexValue& operator+=(const ComplexValue& rhs) {
-    r += rhs.r;
-    i += rhs.i;
-    return *this;
-  }
+  /// In-place addition of two complex numbers
+  ComplexValue& operator+=(const ComplexValue& rhs);
 
-  friend ComplexValue operator+(ComplexValue lhs, const ComplexValue& rhs) {
-    lhs += rhs;
-    return lhs;
-  }
+  /// Addition of two complex numbers
+  friend ComplexValue operator+(ComplexValue lhs, const ComplexValue& rhs);
 };
 
-inline std::ostream& operator<<(std::ostream& os, const ComplexValue& c) {
-  return os << ComplexValue::toString(c.r, c.i);
-}
+/**
+ * @brief Print a complex value to the given output stream.
+ * @param os The output stream to write to.
+ * @param c The complex value to print.
+ * @returns The output stream.
+ */
+std::ostream& operator<<(std::ostream& os, const ComplexValue& c);
 } // namespace dd
 
 namespace std {
+/// Hash function for complex values
 template <> struct hash<dd::ComplexValue> {
-  std::size_t operator()(dd::ComplexValue const& c) const noexcept {
-    auto h1 = dd::murmur64(static_cast<std::size_t>(
-        std::round(c.r / dd::ComplexTable::tolerance())));
-    auto h2 = dd::murmur64(static_cast<std::size_t>(
-        std::round(c.i / dd::ComplexTable::tolerance())));
-    return dd::combineHash(h1, h2);
-  }
+  /**
+   * @brief Compute the hash value for the given complex value.
+   * @details The hash value is computed by scaling the real and imaginary part
+   * by the tolerance of the complex table, rounding the result to the nearest
+   * integer and computing the hash value of the resulting pair of integers.
+   * @param c The complex value to compute the hash value for.
+   * @returns The hash value for the given complex value.
+   * @note It is rather hard to define good hash functions for floating point
+   * numbers. This hash function is not perfect, but it is fast and should
+   * provide a good distribution of hash values. Furthermore, two floating point
+   * numbers that are within the tolerance of the complex table will always
+   * produce the same hash value.
+   */
+  std::size_t operator()(dd::ComplexValue const& c) const noexcept;
 };
 } // namespace std

--- a/include/dd/ComplexValue.hpp
+++ b/include/dd/ComplexValue.hpp
@@ -17,20 +17,17 @@ namespace dd {
 struct ComplexValue {
   fp r, i;
 
-  [[nodiscard]] constexpr bool
-  approximatelyEquals(const ComplexValue& c) const {
-    return ComplexTable<>::Entry::approximatelyEquals(r, c.r) &&
-           ComplexTable<>::Entry::approximatelyEquals(i, c.i);
+  [[nodiscard]] bool approximatelyEquals(const ComplexValue& c) const {
+    return CTEntry::approximatelyEquals(r, c.r) &&
+           CTEntry::approximatelyEquals(i, c.i);
   }
 
-  [[nodiscard]] constexpr bool approximatelyZero() const {
-    return ComplexTable<>::Entry::approximatelyZero(r) &&
-           ComplexTable<>::Entry::approximatelyZero(i);
+  [[nodiscard]] bool approximatelyZero() const {
+    return CTEntry::approximatelyZero(r) && CTEntry::approximatelyZero(i);
   }
 
-  [[nodiscard]] constexpr bool approximatelyOne() const {
-    return ComplexTable<>::Entry::approximatelyOne(r) &&
-           ComplexTable<>::Entry::approximatelyZero(i);
+  [[nodiscard]] bool approximatelyOne() const {
+    return CTEntry::approximatelyOne(r) && CTEntry::approximatelyZero(i);
   }
 
   constexpr bool operator==(const ComplexValue& other) const {
@@ -65,10 +62,9 @@ struct ComplexValue {
     i = {imag};
   }
 
-  static auto
-  getLowestFraction(const double x,
-                    const std::uint64_t maxDenominator = 1U << 10,
-                    const fp tol = dd::ComplexTable<>::tolerance()) {
+  static auto getLowestFraction(const double x,
+                                const std::uint64_t maxDenominator = 1U << 10,
+                                const fp tol = ComplexTable::tolerance()) {
     assert(x >= 0.);
 
     std::pair<std::uint64_t, std::uint64_t> lowerBound{0U, 1U};
@@ -101,7 +97,7 @@ struct ComplexValue {
   }
 
   static void printFormatted(std::ostream& os, fp num, bool imaginary = false) {
-    if (std::abs(num) <= ComplexTable<>::tolerance()) {
+    if (std::abs(num) <= ComplexTable::tolerance()) {
       os << (std::signbit(num) ? "-" : "+") << "0" << (imaginary ? "i" : "");
       return;
     }
@@ -112,7 +108,7 @@ struct ComplexValue {
         static_cast<fp>(fraction.first) / static_cast<fp>(fraction.second);
     auto error = std::abs(absnum - approx);
 
-    if (error <= ComplexTable<>::tolerance()) { // suitable fraction a/b found
+    if (error <= ComplexTable::tolerance()) { // suitable fraction a/b found
       const std::string sign = std::signbit(num) ? "-" : (imaginary ? "+" : "");
 
       if (fraction.first == 1U && fraction.second == 1U) {
@@ -134,8 +130,8 @@ struct ComplexValue {
     approx = static_cast<fp>(fraction.first) / static_cast<fp>(fraction.second);
     error = std::abs(abssqrt - approx);
 
-    if (error <= ComplexTable<>::tolerance()) { // suitable fraction a/(b *
-                                                // sqrt(2)) found
+    if (error <= ComplexTable::tolerance()) { // suitable fraction a/(b *
+                                              // sqrt(2)) found
       const std::string sign = std::signbit(num) ? "-" : (imaginary ? "+" : "");
 
       if (fraction.first == 1U && fraction.second == 1U) {
@@ -157,7 +153,7 @@ struct ComplexValue {
     approx = static_cast<fp>(fraction.first) / static_cast<fp>(fraction.second);
     error = std::abs(abspi - approx);
 
-    if (error <= ComplexTable<>::tolerance()) { // suitable fraction a/b π found
+    if (error <= ComplexTable::tolerance()) { // suitable fraction a/b π found
       const std::string sign = std::signbit(num) ? "-" : (imaginary ? "+" : "");
       const std::string imagUnit = imaginary ? "i" : "";
 
@@ -188,7 +184,7 @@ struct ComplexValue {
     if (precision >= 0) {
       ss << std::setprecision(precision);
     }
-    const auto tol = ComplexTable<>::tolerance();
+    const auto tol = ComplexTable::tolerance();
 
     if (std::abs(real) <= tol && std::abs(imag) <= tol) {
       return "0";
@@ -251,9 +247,9 @@ namespace std {
 template <> struct hash<dd::ComplexValue> {
   std::size_t operator()(dd::ComplexValue const& c) const noexcept {
     auto h1 = dd::murmur64(static_cast<std::size_t>(
-        std::round(c.r / dd::ComplexTable<>::tolerance())));
+        std::round(c.r / dd::ComplexTable::tolerance())));
     auto h2 = dd::murmur64(static_cast<std::size_t>(
-        std::round(c.i / dd::ComplexTable<>::tolerance())));
+        std::round(c.i / dd::ComplexTable::tolerance())));
     return dd::combineHash(h1, h2);
   }
 };

--- a/include/dd/Definitions.hpp
+++ b/include/dd/Definitions.hpp
@@ -15,7 +15,7 @@ using Qubit = std::int8_t;
 static_assert(std::is_signed_v<Qubit>, "Type Qubit must be signed.");
 
 // integer type used for specifying numbers of qubits
-using QubitCount = std::make_unsigned<Qubit>::type;
+using QubitCount = std::make_unsigned_t<Qubit>;
 
 // integer type used for reference counting
 // 32bit suffice for a max ref count of around 4 billion
@@ -59,8 +59,13 @@ using ProbabilityVector = std::unordered_map<std::size_t, fp>;
 
 static constexpr std::uint64_t SERIALIZATION_VERSION = 1;
 
-// 64bit mixing hash (from MurmurHash3,
-// https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp)
+/**
+ * @brief 64bit mixing hash (from MurmurHash3)
+ * @details Hash function for 64bit integers adapted from MurmurHash3
+ * @param k the number to hash
+ * @returns the hash value
+ * @see https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
+ */
 constexpr std::size_t murmur64(std::size_t k) {
   k ^= k >> 33;
   k *= 0xff51afd7ed558ccdULL;
@@ -70,8 +75,14 @@ constexpr std::size_t murmur64(std::size_t k) {
   return k;
 }
 
-// combine two 64bit hashes into one 64bit hash (boost::hash_combine,
-// https://www.boost.org/LICENSE_1_0.txt)
+/**
+ * @brief Combine two 64bit hashes into one 64bit hash
+ * @details Combines two 64bit hashes into one 64bit hash based on
+ * boost::hash_combine (https://www.boost.org/LICENSE_1_0.txt)
+ * @param lhs The first hash
+ * @param rhs The second hash
+ * @returns The combined hash
+ */
 constexpr std::size_t combineHash(std::size_t lhs, std::size_t rhs) {
   lhs ^= rhs + 0x9e3779b97f4a7c15ULL + (lhs << 6) + (lhs >> 2);
   return lhs;

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -40,7 +40,7 @@ inline fp thicknessFromMagnitude(const Complex& a) {
 }
 
 static void printPhaseFormatted(std::ostream& os, fp r) {
-  const auto tol = dd::ComplexTable<>::tolerance();
+  const auto tol = dd::ComplexTable::tolerance();
 
   r /= dd::PI;
   // special case treatment for +-i
@@ -114,35 +114,35 @@ inline std::string conditionalFormat(const Complex& a,
   const auto mag = ComplexNumbers::mag(a);
   const auto phase = ComplexNumbers::arg(a);
 
-  if (std::abs(mag) < ComplexTable<>::tolerance()) {
+  if (std::abs(mag) < ComplexTable::tolerance()) {
     return "0";
   }
 
   std::ostringstream ss{};
   // magnitude is (almost) 1
-  if (std::abs(mag - 1) < ComplexTable<>::tolerance()) {
-    if (std::abs(phase) < ComplexTable<>::tolerance()) {
+  if (std::abs(mag - 1) < ComplexTable::tolerance()) {
+    if (std::abs(phase) < ComplexTable::tolerance()) {
       return "1";
     }
-    if (std::abs(phase - dd::PI_2) < ComplexTable<>::tolerance()) {
+    if (std::abs(phase - dd::PI_2) < ComplexTable::tolerance()) {
       return "i";
     }
-    if (std::abs(phase + dd::PI_2) < ComplexTable<>::tolerance()) {
+    if (std::abs(phase + dd::PI_2) < ComplexTable::tolerance()) {
       return "-i";
     }
-    if (std::abs(std::abs(phase) - dd::PI) < ComplexTable<>::tolerance()) {
+    if (std::abs(std::abs(phase) - dd::PI) < ComplexTable::tolerance()) {
       return "-1";
     }
     printPhaseFormatted(ss, phase);
     return ss.str();
   }
 
-  if (std::abs(std::abs(phase) - dd::PI) < ComplexTable<>::tolerance()) {
+  if (std::abs(std::abs(phase) - dd::PI) < ComplexTable::tolerance()) {
     ss << "-";
     dd::ComplexValue::printFormatted(ss, mag);
     return ss.str();
   }
-  if (std::abs(phase) < ComplexTable<>::tolerance()) {
+  if (std::abs(phase) < ComplexTable::tolerance()) {
     dd::ComplexValue::printFormatted(ss, mag);
     return ss.str();
   }
@@ -237,21 +237,21 @@ static std::ostream& memoryHeader(const Edge& e, std::ostream& os,
     } else if (e.w == Complex::one) {
       os << "1";
     } else {
-      if (e.w.r == &ComplexTable<>::zero) {
+      if (e.w.r == &ComplexTable::zero) {
         os << "0";
-      } else if (e.w.r == &ComplexTable<>::sqrt2_2) {
+      } else if (e.w.r == &ComplexTable::sqrt2_2) {
         os << "\xe2\x88\x9a\xc2\xbd";
-      } else if (e.w.r == &ComplexTable<>::one) {
+      } else if (e.w.r == &ComplexTable::one) {
         os << "1";
       } else {
         os << std::hex << reinterpret_cast<std::uintptr_t>(e.w.r) << std::dec;
       }
       os << " ";
-      if (e.w.i == &ComplexTable<>::zero) {
+      if (e.w.i == &ComplexTable::zero) {
         os << "0";
-      } else if (e.w.i == &ComplexTable<>::sqrt2_2) {
+      } else if (e.w.i == &ComplexTable::sqrt2_2) {
         os << "\xe2\x88\x9a\xc2\xbd";
-      } else if (e.w.i == &ComplexTable<>::one) {
+      } else if (e.w.i == &ComplexTable::one) {
         os << "1";
       } else {
         os << std::hex << reinterpret_cast<std::uintptr_t>(e.w.i) << std::dec;
@@ -617,21 +617,21 @@ static std::ostream& memoryEdge(const Edge& from, const Edge& to,
     if (to.w == Complex::one) {
       os << "1";
     } else {
-      if (to.w.r == &ComplexTable<>::zero) {
+      if (to.w.r == &ComplexTable::zero) {
         os << "0";
-      } else if (to.w.r == &ComplexTable<>::sqrt2_2) {
+      } else if (to.w.r == &ComplexTable::sqrt2_2) {
         os << "\xe2\x88\x9a\xc2\xbd";
-      } else if (to.w.r == &ComplexTable<>::one) {
+      } else if (to.w.r == &ComplexTable::one) {
         os << "1";
       } else {
         os << std::hex << reinterpret_cast<std::uintptr_t>(to.w.r) << std::dec;
       }
       os << " ";
-      if (to.w.i == &ComplexTable<>::zero) {
+      if (to.w.i == &ComplexTable::zero) {
         os << "0";
-      } else if (to.w.i == &ComplexTable<>::sqrt2_2) {
+      } else if (to.w.i == &ComplexTable::sqrt2_2) {
         os << "\xe2\x88\x9a\xc2\xbd";
-      } else if (to.w.i == &ComplexTable<>::one) {
+      } else if (to.w.i == &ComplexTable::one) {
         os << "1";
       } else {
         os << std::hex << reinterpret_cast<std::uintptr_t>(to.w.i) << std::dec;

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -239,7 +239,7 @@ static std::ostream& memoryHeader(const Edge& e, std::ostream& os,
     } else {
       if (e.w.r == &ComplexTable::zero) {
         os << "0";
-      } else if (e.w.r == &ComplexTable::sqrt2_2) {
+      } else if (e.w.r == &ComplexTable::sqrt2over2) {
         os << "\xe2\x88\x9a\xc2\xbd";
       } else if (e.w.r == &ComplexTable::one) {
         os << "1";
@@ -249,7 +249,7 @@ static std::ostream& memoryHeader(const Edge& e, std::ostream& os,
       os << " ";
       if (e.w.i == &ComplexTable::zero) {
         os << "0";
-      } else if (e.w.i == &ComplexTable::sqrt2_2) {
+      } else if (e.w.i == &ComplexTable::sqrt2over2) {
         os << "\xe2\x88\x9a\xc2\xbd";
       } else if (e.w.i == &ComplexTable::one) {
         os << "1";
@@ -619,7 +619,7 @@ static std::ostream& memoryEdge(const Edge& from, const Edge& to,
     } else {
       if (to.w.r == &ComplexTable::zero) {
         os << "0";
-      } else if (to.w.r == &ComplexTable::sqrt2_2) {
+      } else if (to.w.r == &ComplexTable::sqrt2over2) {
         os << "\xe2\x88\x9a\xc2\xbd";
       } else if (to.w.r == &ComplexTable::one) {
         os << "1";
@@ -629,7 +629,7 @@ static std::ostream& memoryEdge(const Edge& from, const Edge& to,
       os << " ";
       if (to.w.i == &ComplexTable::zero) {
         os << "0";
-      } else if (to.w.i == &ComplexTable::sqrt2_2) {
+      } else if (to.w.i == &ComplexTable::sqrt2over2) {
         os << "\xe2\x88\x9a\xc2\xbd";
       } else if (to.w.i == &ComplexTable::one) {
         os << "1";

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -3530,8 +3530,8 @@ private:
     auto* rPtr = CTEntry::getAlignedPointer(edge.w.r);
     auto* iPtr = CTEntry::getAlignedPointer(edge.w.i);
 
-    if (weightMap.at(rPtr) > rPtr->refCount && rPtr != Complex::one.r &&
-        rPtr != Complex::zero.i && rPtr != &ComplexTable::sqrt2_2) {
+    if (weightMap.at(rPtr) > rPtr->refCount &&
+        !ComplexTable::isStaticEntry(rPtr)) {
       std::clog << "\nOffending weight: " << edge.w << "\n";
       std::clog << "Bits: " << std::hexfloat << CTEntry::val(edge.w.r) << "r "
                 << CTEntry::val(edge.w.i) << std::defaultfloat << "i\n";
@@ -3543,8 +3543,8 @@ private:
                                std::to_string(rPtr->refCount));
     }
 
-    if (weightMap.at(iPtr) > iPtr->refCount && iPtr != Complex::zero.i &&
-        iPtr != Complex::one.r && iPtr != &ComplexTable::sqrt2_2) {
+    if (weightMap.at(iPtr) > iPtr->refCount &&
+        !ComplexTable::isStaticEntry(iPtr)) {
       std::clog << "\nOffending weight: " << edge.w << "\n";
       std::clog << "Bits: " << std::hexfloat << CTEntry::val(edge.w.r) << "r "
                 << CTEntry::val(edge.w.i) << std::defaultfloat << "i\n";

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -158,8 +158,8 @@ public:
     const auto mag1 = ComplexNumbers::mag2(e.p->e[1].w);
     const auto norm2 = mag0 + mag1;
     const auto mag2Max =
-        (mag0 + ComplexTable<>::tolerance() >= mag1) ? mag0 : mag1;
-    const auto argMax = (mag0 + ComplexTable<>::tolerance() >= mag1) ? 0 : 1;
+        (mag0 + ComplexTable::tolerance() >= mag1) ? mag0 : mag1;
+    const auto argMax = (mag0 + ComplexTable::tolerance() >= mag1) ? 0 : 1;
     const auto norm = std::sqrt(norm2);
     const auto magMax = std::sqrt(mag2Max);
     const auto commonFactor = norm / magMax;
@@ -409,7 +409,7 @@ public:
           maxc = e.p->e[i].w;
         } else {
           auto mag = ComplexNumbers::mag2(e.p->e[i].w);
-          if (mag - max > ComplexTable<>::tolerance()) {
+          if (mag - max > ComplexTable::tolerance()) {
             argmax = static_cast<decltype(argmax)>(i);
             max = mag;
             maxc = e.p->e[i].w;
@@ -3100,8 +3100,8 @@ public:
       idx <<= level;
       for (std::size_t i = 0; i < (1ULL << level); i++) {
         amplitudes[idx++] =
-            std::complex<dd::fp>{dd::ComplexTable<>::Entry::val(amp.r),
-                                 dd::ComplexTable<>::Entry::val(amp.i)};
+            std::complex<dd::fp>{dd::ComplexTable::Entry::val(amp.r),
+                                 dd::ComplexTable::Entry::val(amp.i)};
       }
 
       return;
@@ -3129,8 +3129,8 @@ public:
                         std::vector<std::complex<dd::fp>>& amplitudes,
                         ComplexValue& amplitude, dd::QubitCount level,
                         std::size_t idx) {
-    auto ar = dd::ComplexTable<>::Entry::val(edge.w.r);
-    auto ai = dd::ComplexTable<>::Entry::val(edge.w.i);
+    auto ar = dd::ComplexTable::Entry::val(edge.w.r);
+    auto ai = dd::ComplexTable::Entry::val(edge.w.i);
     ComplexValue amp{ar * amplitude.r - ai * amplitude.i,
                      ar * amplitude.i + ai * amplitude.r};
 
@@ -3232,8 +3232,8 @@ public:
         }
       } while (!stack.empty());
 
-      auto w = cn.getCached(dd::ComplexTable<>::Entry::val(original.w.r),
-                            dd::ComplexTable<>::Entry::val(original.w.i));
+      auto w = cn.getCached(dd::ComplexTable::Entry::val(original.w.r),
+                            dd::ComplexTable::Entry::val(original.w.i));
       dd::ComplexNumbers::mul(w, root.w, w);
       root.w = cn.lookup(w);
       cn.returnToCache(w);
@@ -3451,7 +3451,7 @@ public:
   }
 
   template <class Edge> bool isGloballyConsistent(const Edge& e) {
-    std::map<ComplexTable<>::Entry*, std::size_t> weightCounter{};
+    std::map<ComplexTable::Entry*, std::size_t> weightCounter{};
     std::map<decltype(e.p), std::size_t> nodeCounter{};
     fillConsistencyCounter(e, weightCounter, nodeCounter);
     checkConsistencyCounter(e, weightCounter, nodeCounter);
@@ -3500,10 +3500,10 @@ private:
   }
 
   template <class Edge>
-  void fillConsistencyCounter(
-      const Edge& edge,
-      std::map<ComplexTable<>::Entry*, std::size_t>& weightMap,
-      std::map<decltype(edge.p), std::size_t>& nodeMap) {
+  void
+  fillConsistencyCounter(const Edge& edge,
+                         std::map<CTEntry*, std::size_t>& weightMap,
+                         std::map<decltype(edge.p), std::size_t>& nodeMap) {
     weightMap[CTEntry::getAlignedPointer(edge.w.r)]++;
     weightMap[CTEntry::getAlignedPointer(edge.w.i)]++;
 
@@ -3525,13 +3525,13 @@ private:
   template <class Edge>
   void checkConsistencyCounter(
       const Edge& edge,
-      const std::map<ComplexTable<>::Entry*, std::size_t>& weightMap,
+      const std::map<ComplexTable::Entry*, std::size_t>& weightMap,
       const std::map<decltype(edge.p), std::size_t>& nodeMap) {
     auto* rPtr = CTEntry::getAlignedPointer(edge.w.r);
     auto* iPtr = CTEntry::getAlignedPointer(edge.w.i);
 
     if (weightMap.at(rPtr) > rPtr->refCount && rPtr != Complex::one.r &&
-        rPtr != Complex::zero.i && rPtr != &ComplexTable<>::sqrt2_2) {
+        rPtr != Complex::zero.i && rPtr != &ComplexTable::sqrt2_2) {
       std::clog << "\nOffending weight: " << edge.w << "\n";
       std::clog << "Bits: " << std::hexfloat << CTEntry::val(edge.w.r) << "r "
                 << CTEntry::val(edge.w.i) << std::defaultfloat << "i\n";
@@ -3544,7 +3544,7 @@ private:
     }
 
     if (weightMap.at(iPtr) > iPtr->refCount && iPtr != Complex::zero.i &&
-        iPtr != Complex::one.r && iPtr != &ComplexTable<>::sqrt2_2) {
+        iPtr != Complex::one.r && iPtr != &ComplexTable::sqrt2_2) {
       std::clog << "\nOffending weight: " << edge.w << "\n";
       std::clog << "Bits: " << std::hexfloat << CTEntry::val(edge.w.r) << "r "
                 << CTEntry::val(edge.w.i) << std::defaultfloat << "i\n";

--- a/src/dd/CMakeLists.txt
+++ b/src/dd/CMakeLists.txt
@@ -5,6 +5,11 @@ if(NOT TARGET ${PROJECT_NAME}-dd)
   add_library(
     ${PROJECT_NAME}-dd
     ${DD_HEADERS}
+    Complex.cpp
+    ComplexCache.cpp
+    ComplexNumbers.cpp
+    ComplexTable.cpp
+    ComplexValue.cpp
     Edge.cpp
     FunctionalityConstruction.cpp
     Node.cpp

--- a/src/dd/Complex.cpp
+++ b/src/dd/Complex.cpp
@@ -1,0 +1,60 @@
+#include "dd/Complex.hpp"
+
+#include "dd/ComplexValue.hpp"
+
+namespace dd {
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+Complex Complex::zero{&ComplexTable::zero, &ComplexTable::zero};
+Complex Complex::one{&ComplexTable::one, &ComplexTable::zero};
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+void Complex::setVal(const Complex& c) const {
+  assert(!CTEntry::isNegativePointer(r));
+  assert(!CTEntry::isNegativePointer(i));
+  r->value = CTEntry::val(c.r);
+  i->value = CTEntry::val(c.i);
+}
+
+bool Complex::exactlyZero() const {
+  return CTEntry::exactlyZero(r) && CTEntry::exactlyZero(i);
+}
+
+bool Complex::exactlyOne() const {
+  return CTEntry::exactlyOne(r) && CTEntry::exactlyZero(i);
+}
+
+bool Complex::approximatelyEquals(const Complex& c) const {
+  return CTEntry::approximatelyEquals(r, c.r) &&
+         CTEntry::approximatelyEquals(i, c.i);
+}
+
+bool Complex::approximatelyZero() const {
+  return CTEntry::approximatelyZero(r) && CTEntry::approximatelyZero(i);
+}
+
+bool Complex::approximatelyOne() const {
+  return CTEntry::approximatelyOne(r) && CTEntry::approximatelyZero(i);
+}
+
+bool Complex::operator==(const Complex& other) const {
+  return r == other.r && i == other.i;
+}
+
+bool Complex::operator!=(const Complex& other) const {
+  return !operator==(other);
+}
+
+std::string Complex::toString(bool formatted, int precision) const {
+  return ComplexValue::toString(CTEntry::val(r), CTEntry::val(i), formatted,
+                                precision);
+}
+
+void Complex::writeBinary(std::ostream& os) const {
+  CTEntry::writeBinary(r, os);
+  CTEntry::writeBinary(i, os);
+}
+
+std::ostream& operator<<(std::ostream& os, const Complex& c) {
+  return os << c.toString();
+}
+} // namespace dd

--- a/src/dd/ComplexCache.cpp
+++ b/src/dd/ComplexCache.cpp
@@ -1,0 +1,88 @@
+#include "dd/ComplexCache.hpp"
+
+#include <cassert>
+
+namespace dd {
+
+Complex ComplexCache::getCachedComplex() {
+  // an entry is available on the stack
+  if (available != nullptr) {
+    assert(available->next != nullptr);
+    auto entry = Complex{available, available->next};
+    available = entry.i->next;
+    count += 2;
+    return entry;
+  }
+
+  // new chunk has to be allocated
+  if (chunkIt == chunkEndIt) {
+    chunks.emplace_back(allocationSize);
+    allocations += allocationSize;
+    allocationSize *= growthFactor;
+    chunkID++;
+    chunkIt = chunks[chunkID].begin();
+    chunkEndIt = chunks[chunkID].end();
+  }
+
+  Complex c{};
+  c.r = &(*chunkIt);
+  ++chunkIt;
+  c.i = &(*chunkIt);
+  ++chunkIt;
+  count += 2;
+  return c;
+}
+
+Complex ComplexCache::getTemporaryComplex() {
+  // an entry is available on the stack
+  if (available != nullptr) {
+    assert(available->next != nullptr);
+    return {available, available->next};
+  }
+
+  // new chunk has to be allocated
+  if (chunkIt == chunkEndIt) {
+    chunks.emplace_back(allocationSize);
+    allocations += allocationSize;
+    allocationSize *= growthFactor;
+    chunkID++;
+    chunkIt = chunks[chunkID].begin();
+    chunkEndIt = chunks[chunkID].end();
+  }
+  return {&(*chunkIt), &(*(chunkIt + 1))};
+}
+
+void ComplexCache::returnToCache(Complex& c) {
+  assert(count >= 2);
+  assert(c != Complex::zero);
+  assert(c != Complex::one);
+  assert(c.r->refCount == 0);
+  assert(c.i->refCount == 0);
+  c.i->next = available;
+  c.r->next = c.i;
+  available = c.r;
+  count -= 2;
+}
+
+void ComplexCache::clear() {
+  // clear available stack
+  available = nullptr;
+
+  // release memory of all but the first chunk
+  // it could be desirable to keep the memory for later use
+  // or, alternatively, to resize the first chunk to the current allocation size
+  // to get better cache locality.
+  while (chunkID > 0) {
+    chunks.pop_back();
+    chunkID--;
+  }
+  // restore initial chunk setting
+  chunkIt = chunks[0].begin();
+  chunkEndIt = chunks[0].end();
+  allocationSize = initialAllocationSize * growthFactor;
+  allocations = initialAllocationSize;
+
+  count = 0;
+  peakCount = 0;
+}
+} // namespace dd

--- a/src/dd/ComplexNumbers.cpp
+++ b/src/dd/ComplexNumbers.cpp
@@ -1,0 +1,228 @@
+#include "dd/ComplexNumbers.hpp"
+
+#include <cassert>
+#include <cmath>
+
+namespace dd {
+void ComplexNumbers::clear() {
+  complexTable.clear();
+  complexCache.clear();
+}
+
+void ComplexNumbers::setTolerance(fp tol) { ComplexTable::setTolerance(tol); }
+
+void ComplexNumbers::add(Complex& r, const Complex& a, const Complex& b) {
+  assert(r != Complex::zero);
+  assert(r != Complex::one);
+  r.r->value = CTEntry::val(a.r) + CTEntry::val(b.r);
+  r.i->value = CTEntry::val(a.i) + CTEntry::val(b.i);
+}
+
+void ComplexNumbers::sub(Complex& r, const Complex& a, const Complex& b) {
+  assert(r != Complex::zero);
+  assert(r != Complex::one);
+  r.r->value = CTEntry::val(a.r) - CTEntry::val(b.r);
+  r.i->value = CTEntry::val(a.i) - CTEntry::val(b.i);
+}
+
+void ComplexNumbers::mul(Complex& r, const Complex& a, const Complex& b) {
+  assert(r != Complex::zero);
+  assert(r != Complex::one);
+  if (a.approximatelyOne()) {
+    r.setVal(b);
+  } else if (b.approximatelyOne()) {
+    r.setVal(a);
+  } else if (a.approximatelyZero() || b.approximatelyZero()) {
+    r.r->value = 0.;
+    r.i->value = 0.;
+  } else {
+    const auto ar = CTEntry::val(a.r);
+    const auto ai = CTEntry::val(a.i);
+    const auto br = CTEntry::val(b.r);
+    const auto bi = CTEntry::val(b.i);
+
+    r.r->value = ar * br - ai * bi;
+    r.i->value = ar * bi + ai * br;
+  }
+}
+
+void ComplexNumbers::div(Complex& r, const Complex& a, const Complex& b) {
+  assert(r != Complex::zero);
+  assert(r != Complex::one);
+  if (a.approximatelyEquals(b)) {
+    r.r->value = 1.;
+    r.i->value = 0.;
+  } else if (b.approximatelyOne()) {
+    r.setVal(a);
+  } else {
+    const auto ar = CTEntry::val(a.r);
+    const auto ai = CTEntry::val(a.i);
+    const auto br = CTEntry::val(b.r);
+    const auto bi = CTEntry::val(b.i);
+
+    const auto cmag = br * br + bi * bi;
+
+    r.r->value = (ar * br + ai * bi) / cmag;
+    r.i->value = (ai * br - ar * bi) / cmag;
+  }
+}
+
+fp ComplexNumbers::mag2(const Complex& a) {
+  auto ar = CTEntry::val(a.r);
+  auto ai = CTEntry::val(a.i);
+
+  return ar * ar + ai * ai;
+}
+
+fp ComplexNumbers::mag(const Complex& a) { return std::sqrt(mag2(a)); }
+
+fp ComplexNumbers::arg(const Complex& a) {
+  auto ar = CTEntry::val(a.r);
+  auto ai = CTEntry::val(a.i);
+  return std::atan2(ai, ar);
+}
+
+Complex ComplexNumbers::conj(const Complex& a) {
+  return {a.r, CTEntry::flipPointerSign(a.i)};
+}
+
+Complex ComplexNumbers::neg(const Complex& a) {
+  return {CTEntry::flipPointerSign(a.r), CTEntry::flipPointerSign(a.i)};
+}
+
+Complex ComplexNumbers::addCached(const Complex& a, const Complex& b) {
+  auto c = getCached();
+  add(c, a, b);
+  return c;
+}
+
+Complex ComplexNumbers::subCached(const Complex& a, const Complex& b) {
+  auto c = getCached();
+  sub(c, a, b);
+  return c;
+}
+
+Complex ComplexNumbers::mulCached(const Complex& a, const Complex& b) {
+  auto c = getCached();
+  mul(c, a, b);
+  return c;
+}
+
+Complex ComplexNumbers::divCached(const Complex& a, const Complex& b) {
+  auto c = getCached();
+  div(c, a, b);
+  return c;
+}
+
+Complex ComplexNumbers::lookup(const Complex& c) {
+  if (c == Complex::zero) {
+    return Complex::zero;
+  }
+  if (c == Complex::one) {
+    return Complex::one;
+  }
+
+  const auto valr = CTEntry::val(c.r);
+  const auto vali = CTEntry::val(c.i);
+  return lookup(valr, vali);
+}
+
+Complex ComplexNumbers::lookup(const std::complex<fp>& c) {
+  return lookup(c.real(), c.imag());
+}
+
+Complex ComplexNumbers::lookup(const ComplexValue& c) {
+  return lookup(c.r, c.i);
+}
+
+Complex ComplexNumbers::lookup(const fp r, const fp i) {
+  Complex ret{};
+
+  if (const auto signR = std::signbit(r); signR) {
+    const auto absr = std::abs(r);
+    // if absolute value is close enough to zero, just return the zero entry
+    // (avoiding -0.0)
+    if (absr < ComplexTable::tolerance()) {
+      ret.r = &ComplexTable::zero;
+    } else {
+      ret.r = CTEntry::getNegativePointer(complexTable.lookup(absr));
+    }
+  } else {
+    ret.r = complexTable.lookup(r);
+  }
+
+  if (const auto signI = std::signbit(i); signI) {
+    const auto absi = std::abs(i);
+    // if absolute value is close enough to zero, just return the zero entry
+    // (avoiding -0.0)
+    if (absi < ComplexTable::tolerance()) {
+      ret.i = &ComplexTable::zero;
+    } else {
+      ret.i = CTEntry::getNegativePointer(complexTable.lookup(absi));
+    }
+  } else {
+    ret.i = complexTable.lookup(i);
+  }
+
+  return ret;
+}
+
+void ComplexNumbers::incRef(const Complex& c) {
+  if (!isStaticComplex(c)) {
+    ComplexTable::incRef(c.r);
+    ComplexTable::incRef(c.i);
+  }
+}
+
+void ComplexNumbers::decRef(const Complex& c) {
+  if (!isStaticComplex(c)) {
+    ComplexTable::decRef(c.r);
+    ComplexTable::decRef(c.i);
+  }
+}
+
+std::size_t ComplexNumbers::garbageCollect(bool force) {
+  return complexTable.garbageCollect(force);
+}
+
+Complex ComplexNumbers::getTemporary() {
+  return complexCache.getTemporaryComplex();
+}
+
+Complex ComplexNumbers::getTemporary(const fp& r, const fp& i) {
+  auto c = complexCache.getTemporaryComplex();
+  c.r->value = r;
+  c.i->value = i;
+  return c;
+}
+
+Complex ComplexNumbers::getTemporary(const ComplexValue& c) {
+  return getTemporary(c.r, c.i);
+}
+
+Complex ComplexNumbers::getCached() { return complexCache.getCachedComplex(); }
+
+Complex ComplexNumbers::getCached(const fp& r, const fp& i) {
+  auto c = complexCache.getCachedComplex();
+  c.r->value = r;
+  c.i->value = i;
+  return c;
+}
+
+Complex ComplexNumbers::getCached(const ComplexValue& c) {
+  return getCached(c.r, c.i);
+}
+
+Complex ComplexNumbers::getCached(const std::complex<fp>& c) {
+  return getCached(c.real(), c.imag());
+}
+
+void ComplexNumbers::returnToCache(Complex& c) {
+  complexCache.returnToCache(c);
+}
+
+std::size_t ComplexNumbers::cacheCount() const {
+  return complexCache.getCount();
+}
+
+} // namespace dd

--- a/src/dd/ComplexTable.cpp
+++ b/src/dd/ComplexTable.cpp
@@ -1,0 +1,495 @@
+#include "dd/ComplexTable.hpp"
+
+#include <algorithm>
+#include <iomanip>
+#include <stdexcept>
+
+namespace dd {
+
+static constexpr std::size_t LSB = static_cast<std::uintptr_t>(1U);
+
+CTEntry* CTEntry::getAlignedPointer(const Entry* e) {
+  return reinterpret_cast<Entry*>(reinterpret_cast<std::uintptr_t>(e) & ~LSB);
+}
+
+CTEntry* CTEntry::getNegativePointer(const Entry* e) {
+  return reinterpret_cast<Entry*>(reinterpret_cast<std::uintptr_t>(e) | LSB);
+}
+
+bool CTEntry::exactlyZero(const Entry* e) { return (e == &zero); }
+
+bool CTEntry::exactlyOne(const Entry* e) { return (e == &one); }
+
+CTEntry* CTEntry::flipPointerSign(const Entry* e) {
+  if (exactlyZero(e)) {
+    return reinterpret_cast<Entry*>(reinterpret_cast<std::uintptr_t>(e));
+  }
+  return reinterpret_cast<Entry*>(reinterpret_cast<std::uintptr_t>(e) ^ LSB);
+}
+
+bool CTEntry::isNegativePointer(const Entry* e) {
+  return (reinterpret_cast<std::uintptr_t>(e) & LSB) != 0U;
+}
+
+fp CTEntry::val(const Entry* e) {
+  if (isNegativePointer(e)) {
+    return -getAlignedPointer(e)->value;
+  }
+  return e->value;
+}
+
+RefCount CTEntry::ref(const Entry* e) {
+  if (isNegativePointer(e)) {
+    return -getAlignedPointer(e)->refCount;
+  }
+  return e->refCount;
+}
+
+bool CTEntry::approximatelyEquals(const fp left, const fp right) {
+  // NOLINTNEXTLINE(clang-diagnostic-float-equal)
+  return left == right || std::abs(left - right) <= TOLERANCE;
+}
+
+bool CTEntry::approximatelyEquals(const Entry* left, const Entry* right) {
+  return left == right || approximatelyEquals(val(left), val(right));
+}
+
+bool CTEntry::approximatelyZero(const fp e) { return std::abs(e) <= TOLERANCE; }
+
+bool CTEntry::approximatelyZero(const Entry* e) {
+  return e == &zero || approximatelyZero(val(e));
+}
+
+bool CTEntry::approximatelyOne(const fp e) {
+  return approximatelyEquals(e, 1.0);
+}
+
+bool CTEntry::approximatelyOne(const Entry* e) {
+  return e == &one || approximatelyOne(val(e));
+}
+
+void CTEntry::writeBinary(const Entry* e, std::ostream& os) {
+  const auto temp = val(e);
+  os.write(reinterpret_cast<const char*>(&temp), sizeof(decltype(temp)));
+}
+
+ComplexTable::ComplexTable(const std::size_t initialAllocSize,
+                           const std::size_t growthFact,
+                           const std::size_t initialGCLim)
+    : initialAllocationSize(initialAllocSize), growthFactor(growthFact),
+      initialGCLimit(initialGCLim) {
+  // add 1/2 to the complex table and increase its ref count (so that it is
+  // not collected)
+  lookup(0.5L)->refCount++;
+}
+
+CTEntry* ComplexTable::lookup(const fp val) {
+  assert(!std::isnan(val));
+  assert(val >= 0); // required anyway for the hash function
+  ++lookups;
+  if (Entry::approximatelyZero(val)) {
+    ++hits;
+    return &zero;
+  }
+
+  if (Entry::approximatelyOne(val)) {
+    ++hits;
+    return &one;
+  }
+
+  if (Entry::approximatelyEquals(val, SQRT2_2)) {
+    ++hits;
+    return &sqrt2over2;
+  }
+
+  assert(val - TOLERANCE >= 0); // should be handle above as special case
+
+  const auto lowerKey = hash(val - TOLERANCE);
+  const auto upperKey = hash(val + TOLERANCE);
+
+  if (upperKey == lowerKey) {
+    ++findOrInserts;
+    return findOrInsert(lowerKey, val);
+  }
+
+  // code below is to properly handle border cases |----(-|-)----|
+  // in case a value close to a border is looked up,
+  // only the last entry in the lower bucket and the first entry in the upper
+  // bucket need to be checked
+
+  const auto key = hash(val);
+
+  Entry* pLower; // NOLINT(cppcoreguidelines-init-variables)
+  Entry* pUpper; // NOLINT(cppcoreguidelines-init-variables)
+  if (lowerKey != key) {
+    pLower = tailTable[static_cast<std::size_t>(lowerKey)];
+    pUpper = table[static_cast<std::size_t>(key)];
+    ++lowerNeighbors;
+  } else {
+    pLower = tailTable[static_cast<std::size_t>(key)];
+    pUpper = table[static_cast<std::size_t>(upperKey)];
+    ++upperNeighbors;
+  }
+
+  const bool lowerMatchFound =
+      (pLower != nullptr && Entry::approximatelyEquals(val, pLower->value));
+  const bool upperMatchFound =
+      (pUpper != nullptr && Entry::approximatelyEquals(val, pUpper->value));
+
+  if (lowerMatchFound && upperMatchFound) {
+    ++hits;
+    const auto diffToLower = std::abs(pLower->value - val);
+    const auto diffToUpper = std::abs(pUpper->value - val);
+    // val is actually closer to p_lower than to p_upper
+    if (diffToLower < diffToUpper) {
+      return pLower;
+    }
+    return pUpper;
+  }
+
+  if (lowerMatchFound) {
+    ++hits;
+    return pLower;
+  }
+
+  if (upperMatchFound) {
+    ++hits;
+    return pUpper;
+  }
+
+  // value was not found in the table -> get a new entry and add it to the
+  // central bucket
+  return insert(key, val);
+}
+
+CTEntry* ComplexTable::getEntry() {
+  // an entry is available on the stack
+  if (!availableEmpty()) {
+    auto* entry = available;
+    available = entry->next;
+    // returned entries could have a ref count != 0
+    entry->refCount = 0;
+    return entry;
+  }
+
+  // new chunk has to be allocated
+  if (chunkIt == chunkEndIt) {
+    chunks.emplace_back(allocationSize);
+    allocations += allocationSize;
+    allocationSize *= growthFactor;
+    chunkID++;
+    chunkIt = chunks[chunkID].begin();
+    chunkEndIt = chunks[chunkID].end();
+  }
+
+  auto* entry = &(*chunkIt);
+  ++chunkIt;
+  return entry;
+}
+
+void ComplexTable::returnEntry(Entry* entry) {
+  entry->next = available;
+  available = entry;
+}
+
+void ComplexTable::incRef(Entry* entry) {
+  // get valid pointer
+  auto* entryPtr = Entry::getAlignedPointer(entry);
+
+  if (entryPtr == nullptr) {
+    return;
+  }
+
+  if (isStaticEntry(entryPtr)) {
+    return;
+  }
+
+  if (entryPtr->refCount == std::numeric_limits<RefCount>::max()) {
+    std::clog << "[WARN] MAXREFCNT reached for " << entryPtr->value
+              << ". Number will never be collected.\n";
+    return;
+  }
+
+  // increase reference count
+  entryPtr->refCount++;
+}
+
+void ComplexTable::decRef(Entry* entry) {
+  // get valid pointer
+  auto* entryPtr = Entry::getAlignedPointer(entry);
+
+  if (entryPtr == nullptr) {
+    return;
+  }
+
+  if (isStaticEntry(entryPtr)) {
+    return;
+  }
+
+  if (entryPtr->refCount == std::numeric_limits<RefCount>::max()) {
+    return;
+  }
+
+  if (entryPtr->refCount == 0) {
+    throw std::runtime_error("In ComplexTable: RefCount of entry " +
+                             std::to_string(entryPtr->value) +
+                             " is zero before decrement");
+  }
+
+  // decrease reference count
+  entryPtr->refCount--;
+}
+
+bool ComplexTable::possiblyNeedsCollection() const { return count >= gcLimit; }
+std::size_t ComplexTable::garbageCollect(const bool force) {
+  gcCalls++;
+  // nothing to be done if garbage collection is not forced, and the limit has
+  // not been reached, or the current count is minimal (the complex table
+  // always contains at least 0.5)
+  if ((!force && !possiblyNeedsCollection()) || count <= 1) {
+    return 0;
+  }
+
+  gcRuns++;
+  std::size_t collected = 0;
+  std::size_t remaining = 0;
+  for (std::size_t key = 0; key < table.size(); ++key) {
+    Entry* p = table[key];
+    Entry* lastp = nullptr;
+    while (p != nullptr) {
+      if (p->refCount == 0) {
+        Entry* next = p->next;
+        if (lastp == nullptr) {
+          table[key] = next;
+        } else {
+          lastp->next = next;
+        }
+        returnEntry(p);
+        p = next;
+        collected++;
+      } else {
+        lastp = p;
+        p = p->next;
+        remaining++;
+      }
+      tailTable[key] = lastp;
+    }
+  }
+  // The garbage collection limit changes dynamically depending on the number
+  // of remaining (active) nodes. If it were not changed, garbage collection
+  // would run through the complete table on each successive call once the
+  // number of remaining entries reaches the garbage collection limit. It is
+  // increased whenever the number of remaining entries is rather close to the
+  // garbage collection threshold and decreased if the number of remaining
+  // entries is much lower than the current limit.
+  if (remaining > gcLimit / 10 * 9) {
+    gcLimit = remaining + initialGCLimit;
+  } else if (remaining < gcLimit / 128) {
+    gcLimit /= 2;
+  }
+  count = remaining;
+  return collected;
+}
+
+void ComplexTable::clear() {
+  // clear table buckets
+  for (auto& bucket : table) {
+    bucket = nullptr;
+  }
+  for (auto& entry : tailTable) {
+    entry = nullptr;
+  }
+
+  // clear available stack
+  available = nullptr;
+
+  // release memory of all but the first chunk
+  // it could be desirable to keep the memory for later use
+  while (chunkID > 0) {
+    chunks.pop_back();
+    chunkID--;
+  }
+  // restore initial chunk setting
+  chunkIt = chunks[0].begin();
+  chunkEndIt = chunks[0].end();
+  allocationSize = initialAllocationSize * growthFactor;
+  allocations = initialAllocationSize;
+
+  for (auto& entry : chunks[0]) {
+    entry.refCount = 0;
+  }
+
+  count = 0;
+  peakCount = 0;
+
+  collisions = 0;
+  insertCollisions = 0;
+  hits = 0;
+  findOrInserts = 0;
+  lookups = 0;
+  inserts = 0;
+  lowerNeighbors = 0;
+  upperNeighbors = 0;
+
+  gcCalls = 0;
+  gcRuns = 0;
+  gcLimit = initialGCLimit;
+}
+
+void ComplexTable::print() {
+  const auto precision = std::cout.precision();
+  std::cout.precision(std::numeric_limits<dd::fp>::max_digits10);
+  for (std::size_t key = 0; key < table.size(); ++key) {
+    auto* p = table[key];
+    if (p != nullptr) {
+      std::cout << key << ": \n";
+    }
+
+    while (p != nullptr) {
+      std::cout << "\t\t" << p->value << " "
+                << reinterpret_cast<std::uintptr_t>(p) << " " << p->refCount
+                << "\n";
+      p = p->next;
+    }
+
+    if (table[key] != nullptr) {
+      std::cout << "\n";
+    }
+  }
+  std::cout.precision(precision);
+}
+
+fp ComplexTable::hitRatio() const {
+  return static_cast<fp>(hits) / static_cast<fp>(lookups);
+}
+
+fp ComplexTable::colRatio() const {
+  return static_cast<fp>(collisions) / static_cast<fp>(lookups);
+}
+
+std::map<std::string, std::size_t, std::less<>> ComplexTable::getStatistics() {
+  return {
+      {"hits", hits},
+      {"collisions", collisions},
+      {"lookups", lookups},
+      {"inserts", inserts},
+      {"insertCollisions", insertCollisions},
+      {"findOrInserts", findOrInserts},
+      {"upperNeighbors", upperNeighbors},
+      {"lowerNeighbors", lowerNeighbors},
+      {"gcCalls", gcCalls},
+      {"gcRuns", gcRuns},
+  };
+}
+
+std::ostream& ComplexTable::printStatistics(std::ostream& os) const {
+  os << "hits: " << hits << ", collisions: " << collisions
+     << ", looks: " << lookups << ", inserts: " << inserts
+     << ", insertCollisions: " << insertCollisions
+     << ", findOrInserts: " << findOrInserts
+     << ", upperNeighbors: " << upperNeighbors
+     << ", lowerNeighbors: " << lowerNeighbors << ", hitRatio: " << hitRatio()
+     << ", colRatio: " << colRatio() << ", gc calls: " << gcCalls
+     << ", gc runs: " << gcRuns << "\n";
+  return os;
+}
+
+std::ostream& ComplexTable::printBucketDistribution(std::ostream& os) {
+  for (auto* bucket : table) {
+    if (bucket == nullptr) {
+      os << "0\n";
+      continue;
+    }
+    std::size_t bucketCount = 0;
+    while (bucket != nullptr) {
+      ++bucketCount;
+      bucket = bucket->next;
+    }
+    os << bucketCount << "\n";
+  }
+  os << "\n";
+  return os;
+}
+
+ComplexTable::Entry* ComplexTable::findOrInsert(const std::int64_t key,
+                                                const fp val) {
+  const fp valTol = val + TOLERANCE;
+
+  auto* curr = table[static_cast<std::size_t>(key)];
+  Entry* prev = nullptr;
+
+  while (curr != nullptr && curr->value <= valTol) {
+    if (Entry::approximatelyEquals(curr->value, val)) {
+      // check if val is actually closer to the next element in the list (if
+      // there is one)
+      if (curr->next != nullptr) {
+        const auto& next = curr->next;
+        // potential candidate in range
+        if (valTol >= next->value) {
+          const auto diffToCurr = std::abs(curr->value - val);
+          const auto diffToNext = std::abs(next->value - val);
+          // val is actually closer to next than to curr
+          if (diffToNext < diffToCurr) {
+            ++hits;
+            return next;
+          }
+        }
+      }
+      ++hits;
+      return curr;
+    }
+    ++collisions;
+    prev = curr;
+    curr = curr->next;
+  }
+
+  ++inserts;
+  auto* entry = getEntry();
+  entry->value = val;
+
+  if (prev == nullptr) {
+    // table bucket is empty
+    table[static_cast<std::size_t>(key)] = entry;
+  } else {
+    prev->next = entry;
+  }
+  entry->next = curr;
+  if (curr == nullptr) {
+    tailTable[static_cast<std::size_t>(key)] = entry;
+  }
+  count++;
+  peakCount = std::max(peakCount, count);
+  return entry;
+}
+
+ComplexTable::Entry* ComplexTable::insert(const std::int64_t key,
+                                          const fp val) {
+  ++inserts;
+  auto* entry = getEntry();
+  entry->value = val;
+
+  auto* curr = table[static_cast<std::size_t>(key)];
+  Entry* prev = nullptr;
+
+  while (curr != nullptr && curr->value <= val) {
+    ++insertCollisions;
+    prev = curr;
+    curr = curr->next;
+  }
+
+  if (prev == nullptr) {
+    // table bucket is empty
+    table[static_cast<std::size_t>(key)] = entry;
+  } else {
+    prev->next = entry;
+  }
+  entry->next = curr;
+  if (curr == nullptr) {
+    tailTable[static_cast<std::size_t>(key)] = entry;
+  }
+  count++;
+  peakCount = std::max(peakCount, count);
+  return entry;
+}
+
+} // namespace dd

--- a/src/dd/ComplexValue.cpp
+++ b/src/dd/ComplexValue.cpp
@@ -1,0 +1,240 @@
+#include "dd/ComplexValue.hpp"
+
+#include "dd/ComplexTable.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+
+namespace dd {
+bool ComplexValue::operator==(const ComplexValue& other) const {
+  // NOLINTNEXTLINE(clang-diagnostic-float-equal)
+  return r == other.r && i == other.i;
+}
+
+bool ComplexValue::operator!=(const ComplexValue& other) const {
+  return !operator==(other);
+}
+
+bool ComplexValue::approximatelyEquals(const ComplexValue& c) const {
+  return CTEntry::approximatelyEquals(r, c.r) &&
+         CTEntry::approximatelyEquals(i, c.i);
+}
+
+bool ComplexValue::approximatelyZero() const {
+  return CTEntry::approximatelyZero(r) && CTEntry::approximatelyZero(i);
+}
+
+bool ComplexValue::approximatelyOne() const {
+  return CTEntry::approximatelyOne(r) && CTEntry::approximatelyZero(i);
+}
+
+void ComplexValue::writeBinary(std::ostream& os) const {
+  os.write(reinterpret_cast<const char*>(&r), sizeof(decltype(r)));
+  os.write(reinterpret_cast<const char*>(&i), sizeof(decltype(i)));
+}
+
+void ComplexValue::readBinary(std::istream& is) {
+  is.read(reinterpret_cast<char*>(&r), sizeof(decltype(r)));
+  is.read(reinterpret_cast<char*>(&i), sizeof(decltype(i)));
+}
+
+void ComplexValue::fromString(const std::string& realStr, std::string imagStr) {
+  r = realStr.empty() ? 0. : std::stod(realStr);
+
+  imagStr.erase(remove(imagStr.begin(), imagStr.end(), ' '), imagStr.end());
+  imagStr.erase(remove(imagStr.begin(), imagStr.end(), 'i'), imagStr.end());
+  if (imagStr == "+" || imagStr == "-") {
+    imagStr = imagStr + "1";
+  }
+  i = imagStr.empty() ? 0. : std::stod(imagStr);
+}
+
+std::pair<std::uint64_t, std::uint64_t>
+ComplexValue::getLowestFraction(const double x,
+                                const std::uint64_t maxDenominator) {
+  assert(x >= 0.);
+  const auto tol = ComplexTable::tolerance();
+
+  std::pair<std::uint64_t, std::uint64_t> lowerBound{0U, 1U};
+  std::pair<std::uint64_t, std::uint64_t> upperBound{1U, 0U};
+
+  while ((lowerBound.second <= maxDenominator) &&
+         (upperBound.second <= maxDenominator)) {
+    auto num = lowerBound.first + upperBound.first;
+    auto den = lowerBound.second + upperBound.second;
+    auto median = static_cast<fp>(num) / static_cast<fp>(den);
+    if (std::abs(x - median) <= tol) {
+      if (den <= maxDenominator) {
+        return std::pair{num, den};
+      }
+      if (upperBound.second > lowerBound.second) {
+        return upperBound;
+      }
+      return lowerBound;
+    }
+    if (x > median) {
+      lowerBound = {num, den};
+    } else {
+      upperBound = {num, den};
+    }
+  }
+  if (lowerBound.second > maxDenominator) {
+    return upperBound;
+  }
+  return lowerBound;
+}
+
+void ComplexValue::printFormatted(std::ostream& os, fp num, bool imaginary) {
+  if (std::abs(num) <= ComplexTable::tolerance()) {
+    os << (std::signbit(num) ? "-" : "+") << "0" << (imaginary ? "i" : "");
+    return;
+  }
+
+  const auto absnum = std::abs(num);
+  auto fraction = getLowestFraction(absnum);
+  auto approx =
+      static_cast<fp>(fraction.first) / static_cast<fp>(fraction.second);
+  auto error = std::abs(absnum - approx);
+
+  if (error <= ComplexTable::tolerance()) { // suitable fraction a/b found
+    const std::string sign = std::signbit(num) ? "-" : (imaginary ? "+" : "");
+
+    if (fraction.first == 1U && fraction.second == 1U) {
+      os << sign << (imaginary ? "i" : "1");
+    } else if (fraction.second == 1U) {
+      os << sign << fraction.first << (imaginary ? "i" : "");
+    } else if (fraction.first == 1U) {
+      os << sign << (imaginary ? "i" : "1") << "/" << fraction.second;
+    } else {
+      os << sign << fraction.first << (imaginary ? "i" : "") << "/"
+         << fraction.second;
+    }
+
+    return;
+  }
+
+  const auto abssqrt = absnum / SQRT2_2;
+  fraction = getLowestFraction(abssqrt);
+  approx = static_cast<fp>(fraction.first) / static_cast<fp>(fraction.second);
+  error = std::abs(abssqrt - approx);
+
+  if (error <= ComplexTable::tolerance()) { // suitable fraction a/(b *
+    // sqrt(2)) found
+    const std::string sign = std::signbit(num) ? "-" : (imaginary ? "+" : "");
+
+    if (fraction.first == 1U && fraction.second == 1U) {
+      os << sign << (imaginary ? "i" : "1") << "/√2";
+    } else if (fraction.second == 1U) {
+      os << sign << fraction.first << (imaginary ? "i" : "") << "/√2";
+    } else if (fraction.first == 1U) {
+      os << sign << (imaginary ? "i" : "1") << "/(" << fraction.second << "√2)";
+    } else {
+      os << sign << fraction.first << (imaginary ? "i" : "") << "/("
+         << fraction.second << "√2)";
+    }
+    return;
+  }
+
+  const auto abspi = absnum / PI;
+  fraction = getLowestFraction(abspi);
+  approx = static_cast<fp>(fraction.first) / static_cast<fp>(fraction.second);
+  error = std::abs(abspi - approx);
+
+  if (error <= ComplexTable::tolerance()) { // suitable fraction a/b π found
+    const std::string sign = std::signbit(num) ? "-" : (imaginary ? "+" : "");
+    const std::string imagUnit = imaginary ? "i" : "";
+
+    if (fraction.first == 1U && fraction.second == 1U) {
+      os << sign << "π" << imagUnit;
+    } else if (fraction.second == 1U) {
+      os << sign << fraction.first << "π" << imagUnit;
+    } else if (fraction.first == 1U) {
+      os << sign << "π" << imagUnit << "/" << fraction.second;
+    } else {
+      os << sign << fraction.first << "π" << imagUnit << "/" << fraction.second;
+    }
+    return;
+  }
+
+  if (imaginary) { // default
+    os << (std::signbit(num) ? "" : "+") << num << "i";
+  } else {
+    os << num;
+  }
+}
+
+std::string ComplexValue::toString(const fp& real, const fp& imag,
+                                   bool formatted, int precision) {
+  std::ostringstream ss{};
+
+  if (precision >= 0) {
+    ss << std::setprecision(precision);
+  }
+  const auto tol = ComplexTable::tolerance();
+
+  if (std::abs(real) <= tol && std::abs(imag) <= tol) {
+    return "0";
+  }
+
+  if (std::abs(real) > tol) {
+    if (formatted) {
+      printFormatted(ss, real);
+    } else {
+      ss << real;
+    }
+  }
+  if (std::abs(imag) > tol) {
+    if (formatted) {
+      if (std::abs(real - imag) <= tol) {
+        ss << "(1+i)";
+        return ss.str();
+      }
+      if (std::abs(real + imag) <= tol) {
+        ss << "(1-i)";
+        return ss.str();
+      }
+      printFormatted(ss, imag, true);
+    } else {
+      if (std::abs(real) <= tol) {
+        ss << imag;
+      } else {
+        if (imag > 0.) {
+          ss << "+";
+        }
+        ss << imag;
+      }
+      ss << "i";
+    }
+  }
+
+  return ss.str();
+}
+
+ComplexValue& ComplexValue::operator+=(const ComplexValue& rhs) {
+  r += rhs.r;
+  i += rhs.i;
+  return *this;
+}
+
+ComplexValue operator+(ComplexValue lhs, const ComplexValue& rhs) {
+  lhs += rhs;
+  return lhs;
+}
+
+std::ostream& operator<<(std::ostream& os, const ComplexValue& c) {
+  return os << ComplexValue::toString(c.r, c.i);
+}
+} // namespace dd
+
+namespace std {
+std::size_t
+hash<dd::ComplexValue>::operator()(const dd::ComplexValue& c) const noexcept {
+  auto h1 = dd::murmur64(static_cast<std::size_t>(
+      std::round(c.r / dd::ComplexTable::tolerance())));
+  auto h2 = dd::murmur64(static_cast<std::size_t>(
+      std::round(c.i / dd::ComplexTable::tolerance())));
+  return dd::combineHash(h1, h2);
+}
+} // namespace std

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -268,7 +268,7 @@ void extractProbabilityVectorRecursive(
       pzero /= norm;
       pone /= norm;
 
-      if (dd::ComplexTable<>::Entry::approximatelyOne(pone)) {
+      if (CTEntry::approximatelyOne(pone)) {
         const qc::MatrixDD xGate = dd->makeGateDD(
             dd::Xmat, static_cast<dd::QubitCount>(state.p->v + 1),
             static_cast<dd::Qubit>(targets[0U]));
@@ -279,7 +279,7 @@ void extractProbabilityVectorRecursive(
         continue;
       }
 
-      if (!dd::ComplexTable<>::Entry::approximatelyOne(pzero)) {
+      if (!CTEntry::approximatelyOne(pzero)) {
         throw qc::QFRException("Reset on non basis state encountered. This is "
                                "not supported in this method.");
       }
@@ -332,11 +332,11 @@ void extractProbabilityVectorRecursive(
           }
         }
         const auto prob0 = commonFactor * pzero;
-        if (!dd::ComplexTable<>::Entry::approximatelyZero(prob0)) {
+        if (!CTEntry::approximatelyZero(prob0)) {
           probVector[idx0] = prob0;
         }
         const auto prob1 = commonFactor * pone;
-        if (!dd::ComplexTable<>::Entry::approximatelyZero(prob1)) {
+        if (!CTEntry::approximatelyZero(prob1)) {
           probVector[idx1] = prob1;
         }
 
@@ -345,10 +345,8 @@ void extractProbabilityVectorRecursive(
         return;
       }
 
-      const bool nonZeroP0 =
-          !dd::ComplexTable<>::Entry::approximatelyZero(pzero);
-      const bool nonZeroP1 =
-          !dd::ComplexTable<>::Entry::approximatelyZero(pone);
+      const bool nonZeroP0 = !CTEntry::approximatelyZero(pzero);
+      const bool nonZeroP1 = !CTEntry::approximatelyZero(pone);
 
       // in case both outcomes are non-zero the reference count of the state has
       // to be increased once more in order to avoid reference counting errors

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -90,7 +90,7 @@ TEST_P(QFT, Functionality) {
             static_cast<unsigned int>(std::ceil(std::pow(2, nqubits) / 4)));
 
   // top edge weight should equal sqrt(0.5)^n
-  EXPECT_NEAR(dd::ComplexTable<>::Entry::val(func.w.r),
+  EXPECT_NEAR(dd::CTEntry::val(func.w.r),
               static_cast<dd::fp>(std::pow(1.L / std::sqrt(2.L), nqubits)),
               dd->cn.complexTable.tolerance());
 
@@ -131,7 +131,7 @@ TEST_P(QFT, FunctionalityRecursive) {
             static_cast<unsigned int>(std::ceil(std::pow(2, nqubits) / 4)));
 
   // top edge weight should equal sqrt(0.5)^n
-  EXPECT_NEAR(dd::ComplexTable<>::Entry::val(func.w.r),
+  EXPECT_NEAR(dd::CTEntry::val(func.w.r),
               static_cast<dd::fp>(std::pow(1.L / std::sqrt(2.L), nqubits)),
               dd->cn.complexTable.tolerance());
 
@@ -169,10 +169,8 @@ TEST_P(QFT, Simulation) {
   dd->garbageCollect(true);
 
   // top edge weight should equal 1
-  EXPECT_NEAR(dd::ComplexTable<>::Entry::val(sim.w.r), 1,
-              dd->cn.complexTable.tolerance());
-  EXPECT_NEAR(dd::ComplexTable<>::Entry::val(sim.w.i), 0,
-              dd->cn.complexTable.tolerance());
+  EXPECT_NEAR(dd::CTEntry::val(sim.w.r), 1, dd->cn.complexTable.tolerance());
+  EXPECT_NEAR(dd::CTEntry::val(sim.w.i), 0, dd->cn.complexTable.tolerance());
 
   // first column should consist only of sqrt(0.5)^n's
   for (std::uint64_t i = 0; i < std::pow(static_cast<long double>(2), nqubits);

--- a/test/dd/test_complex.cpp
+++ b/test/dd/test_complex.cpp
@@ -120,7 +120,8 @@ TEST(DDComplexTest, SortedBuckets) {
 
   for (auto const& number : numbers) {
     ASSERT_EQ(theBucket, ct->hash(number));
-    ct->lookup(number);
+    const auto* entry = ct->lookup(number);
+    ASSERT_NE(entry, nullptr);
   }
 
   CTEntry* p = ct->getTable().at(theBucket);

--- a/test/dd/test_complex.cpp
+++ b/test/dd/test_complex.cpp
@@ -97,25 +97,24 @@ TEST(DDComplexTest, ComplexNumberArithmetic) {
 
 TEST(DDComplexTest, NearZeroLookup) {
   auto cn = std::make_unique<ComplexNumbers>();
-  auto c = cn->getTemporary(ComplexTable<>::tolerance() / 10.,
-                            ComplexTable<>::tolerance() / 10.);
+  auto c = cn->getTemporary(ComplexTable::tolerance() / 10.,
+                            ComplexTable::tolerance() / 10.);
   auto d = cn->lookup(c);
   EXPECT_EQ(d.r, Complex::zero.r);
   EXPECT_EQ(d.i, Complex::zero.i);
 }
 
 TEST(DDComplexTest, SortedBuckets) {
-  auto ct = std::make_unique<ComplexTable<>>();
+  auto ct = std::make_unique<ComplexTable>();
   const fp num = 0.25;
 
-  const std::array<dd::fp, 7> numbers = {
-      num + 2. * ComplexTable<>::tolerance(),
-      num - 2. * ComplexTable<>::tolerance(),
-      num + 4. * ComplexTable<>::tolerance(),
-      num,
-      num - 4. * ComplexTable<>::tolerance(),
-      num + 6. * ComplexTable<>::tolerance(),
-      num + 8. * ComplexTable<>::tolerance()};
+  const std::array<dd::fp, 7> numbers = {num + 2. * ComplexTable::tolerance(),
+                                         num - 2. * ComplexTable::tolerance(),
+                                         num + 4. * ComplexTable::tolerance(),
+                                         num,
+                                         num - 4. * ComplexTable::tolerance(),
+                                         num + 6. * ComplexTable::tolerance(),
+                                         num + 8. * ComplexTable::tolerance()};
 
   const auto theBucket = static_cast<std::size_t>(ct->hash(num));
 
@@ -148,28 +147,28 @@ TEST(DDComplexTest, GarbageCollectSomeInBucket) {
   ASSERT_NE(lookup.r, nullptr);
   ASSERT_NE(lookup.i, nullptr);
 
-  const fp num2 = num + 2. * ComplexTable<>::tolerance();
+  const fp num2 = num + 2. * ComplexTable::tolerance();
   const auto lookup2 = cn->lookup(num2, 0.0);
   ASSERT_NE(lookup2.r, nullptr);
   ASSERT_NE(lookup2.i, nullptr);
   ComplexNumbers::incRef(lookup2);
 
   // num2 should be placed in same bucket as num
-  auto key = ComplexTable<>::hash(num);
-  auto key2 = ComplexTable<>::hash(num2);
+  auto key = ComplexTable::hash(num);
+  auto key2 = ComplexTable::hash(num2);
   ASSERT_EQ(key, key2);
 
   const auto& table = cn->complexTable.getTable();
   const auto* p = table[static_cast<std::size_t>(key)];
-  EXPECT_NEAR(p->value, num, ComplexTable<>::tolerance());
+  EXPECT_NEAR(p->value, num, ComplexTable::tolerance());
 
   ASSERT_NE(p->next, nullptr);
-  EXPECT_NEAR((p->next)->value, num2, ComplexTable<>::tolerance());
+  EXPECT_NEAR((p->next)->value, num2, ComplexTable::tolerance());
 
   cn->garbageCollect(true); // num should be collected
   const auto* q = table[static_cast<std::size_t>(key)];
   ASSERT_NE(q, nullptr);
-  EXPECT_NEAR(q->value, num2, ComplexTable<>::tolerance());
+  EXPECT_NEAR(q->value, num2, ComplexTable::tolerance());
   EXPECT_EQ(q->next, nullptr);
 }
 
@@ -177,13 +176,13 @@ TEST(DDComplexTest, LookupInNeighbouringBuckets) {
   std::clog << "Current rounding mode: " << std::numeric_limits<fp>::round_style
             << "\n";
   auto cn = std::make_unique<ComplexNumbers>();
-  constexpr std::size_t nbucket = ComplexTable<>::MASK + 1;
-  auto preHash = [](const fp val) { return val * ComplexTable<>::MASK; };
+  constexpr std::size_t nbucket = ComplexTable::MASK + 1;
+  auto preHash = [](const fp val) { return val * ComplexTable::MASK; };
 
   // lower border of a bucket
   const fp numBucketBorder =
-      (0.25 * ComplexTable<>::MASK - 0.5) / (ComplexTable<>::MASK);
-  const auto hashBucketBorder = ComplexTable<>::hash(numBucketBorder);
+      (0.25 * ComplexTable::MASK - 0.5) / (ComplexTable::MASK);
+  const auto hashBucketBorder = ComplexTable::hash(numBucketBorder);
   std::cout.flush();
   std::clog << "numBucketBorder          = "
             << std::setprecision(std::numeric_limits<fp>::max_digits10)
@@ -195,19 +194,19 @@ TEST(DDComplexTest, LookupInNeighbouringBuckets) {
   EXPECT_EQ(hashBucketBorder, nbucket / 4);
 
   // insert a number slightly away from the border
-  const fp numAbove = numBucketBorder + 2 * ComplexTable<>::tolerance();
+  const fp numAbove = numBucketBorder + 2 * ComplexTable::tolerance();
   const auto lookupAbove = cn->lookup(numAbove, 0.0);
   ASSERT_NE(lookupAbove.r, nullptr);
   ASSERT_NE(lookupAbove.i, nullptr);
-  const auto key = ComplexTable<>::hash(numAbove);
+  const auto key = ComplexTable::hash(numAbove);
   EXPECT_EQ(key, nbucket / 4);
 
   // insert a number barely in the bucket below
-  const fp numBarelyBelow = numBucketBorder - ComplexTable<>::tolerance() / 10;
+  const fp numBarelyBelow = numBucketBorder - ComplexTable::tolerance() / 10;
   const auto lookupBarelyBelow = cn->lookup(numBarelyBelow, 0.0);
   ASSERT_NE(lookupBarelyBelow.r, nullptr);
   ASSERT_NE(lookupBarelyBelow.i, nullptr);
-  const auto hashBarelyBelow = ComplexTable<>::hash(numBarelyBelow);
+  const auto hashBarelyBelow = ComplexTable::hash(numBarelyBelow);
   std::clog << "numBarelyBelow          = "
             << std::setprecision(std::numeric_limits<fp>::max_digits10)
             << numBarelyBelow << "\n";
@@ -217,11 +216,11 @@ TEST(DDComplexTest, LookupInNeighbouringBuckets) {
 
   // insert another number in the bucket below a bit farther away from the
   // border
-  const fp numBelow = numBucketBorder - 2 * ComplexTable<>::tolerance();
+  const fp numBelow = numBucketBorder - 2 * ComplexTable::tolerance();
   const auto lookupBelow = cn->lookup(numBelow, 0.0);
   ASSERT_NE(lookupBelow.r, nullptr);
   ASSERT_NE(lookupBelow.i, nullptr);
-  const auto hashBelow = ComplexTable<>::hash(numBelow);
+  const auto hashBelow = ComplexTable::hash(numBelow);
   std::clog << "numBelow          = "
             << std::setprecision(std::numeric_limits<fp>::max_digits10)
             << numBelow << "\n";
@@ -233,17 +232,17 @@ TEST(DDComplexTest, LookupInNeighbouringBuckets) {
   // but is close enough to a number in the bucket below
   const fp num4 = numBucketBorder;
   const auto c = cn->lookup(num4, 0.0);
-  const auto key4 = ComplexTable<>::hash(num4 - ComplexTable<>::tolerance());
+  const auto key4 = ComplexTable::hash(num4 - ComplexTable::tolerance());
   EXPECT_EQ(hashBarelyBelow, key4);
-  EXPECT_NEAR(c.r->value, numBarelyBelow, ComplexTable<>::tolerance());
+  EXPECT_NEAR(c.r->value, numBarelyBelow, ComplexTable::tolerance());
 
   // insert a number in the higher bucket
   const fp numNextBorder =
-      numBucketBorder + 1.0 / (nbucket - 1) + ComplexTable<>::tolerance();
+      numBucketBorder + 1.0 / (nbucket - 1) + ComplexTable::tolerance();
   const auto lookupNextBorder = cn->lookup(numNextBorder, 0.0);
   ASSERT_NE(lookupNextBorder.r, nullptr);
   ASSERT_NE(lookupNextBorder.i, nullptr);
-  const auto hashNextBorder = ComplexTable<>::hash(numNextBorder);
+  const auto hashNextBorder = ComplexTable::hash(numNextBorder);
   std::clog << "numNextBorder          = "
             << std::setprecision(std::numeric_limits<fp>::max_digits10)
             << numNextBorder << "\n";
@@ -253,16 +252,16 @@ TEST(DDComplexTest, LookupInNeighbouringBuckets) {
 
   // search for a number in the lower bucket that is ultimately close enough to
   // a number in the upper bucket
-  const fp num6 = numNextBorder - ComplexTable<>::tolerance() / 10;
+  const fp num6 = numNextBorder - ComplexTable::tolerance() / 10;
   const auto d = cn->lookup(num6, 0.0);
-  const auto key6 = ComplexTable<>::hash(num6 + ComplexTable<>::tolerance());
+  const auto key6 = ComplexTable::hash(num6 + ComplexTable::tolerance());
   EXPECT_EQ(hashNextBorder, key6);
-  EXPECT_NEAR(d.r->value, numNextBorder, ComplexTable<>::tolerance());
+  EXPECT_NEAR(d.r->value, numNextBorder, ComplexTable::tolerance());
 }
 
 TEST(DDComplexTest, ComplexValueEquals) {
   const ComplexValue a{1.0, 0.0};
-  const ComplexValue aTol{1.0 + ComplexTable<>::tolerance() / 10, 0.0};
+  const ComplexValue aTol{1.0 + ComplexTable::tolerance() / 10, 0.0};
   const ComplexValue b{0.0, 1.0};
   EXPECT_TRUE(a.approximatelyEquals(aTol));
   EXPECT_FALSE(a.approximatelyEquals(b));
@@ -487,7 +486,7 @@ TEST(DDComplexTest, ComplexTableAllocation) {
   auto cn = std::make_unique<ComplexNumbers>();
   auto allocs = cn->complexTable.getAllocations();
   std::cout << allocs << "\n";
-  std::vector<ComplexTable<>::Entry*> nums{allocs};
+  std::vector<ComplexTable::Entry*> nums{allocs};
   // get all the numbers that are pre-allocated
   for (auto i = 0U; i < allocs; ++i) {
     nums[i] = cn->complexTable.getEntry();
@@ -567,13 +566,13 @@ TEST(DDComplexTest, DoubleHitInFindOrInsert) {
 
   // insert a second number that is farther away than the tolerance, but closer
   // than twice the tolerance
-  const fp num2 = num1 + 2.1 * dd::ComplexTable<>::tolerance();
+  const fp num2 = num1 + 2.1 * dd::ComplexTable::tolerance();
   auto* tnum2 = cn->complexTable.lookup(num2);
   EXPECT_EQ(tnum2->value, num2);
 
   // insert a third number that is close to both previously inserted numbers,
   // but closer to the second
-  const fp num3 = num1 + 2.2 * dd::ComplexTable<>::tolerance();
+  const fp num3 = num1 + 2.2 * dd::ComplexTable::tolerance();
   auto* tnum3 = cn->complexTable.lookup(num3);
   EXPECT_EQ(tnum3->value, num2);
 }
@@ -590,19 +589,19 @@ TEST(DDComplexTest, DoubleHitAcrossBuckets) {
 
   // insert a second number that is farther away than the tolerance towards the
   // lower bucket, but closer than twice the tolerance
-  const fp num2 = num1 - 1.5 * dd::ComplexTable<>::tolerance();
+  const fp num2 = num1 - 1.5 * dd::ComplexTable::tolerance();
   auto* tnum2 = cn->complexTable.lookup(num2);
   EXPECT_EQ(tnum2->value, num2);
 
   // insert a third number that is close to both previously inserted numbers,
   // but closer to the second
-  const fp num3 = num1 - 0.9 * dd::ComplexTable<>::tolerance();
+  const fp num3 = num1 - 0.9 * dd::ComplexTable::tolerance();
   auto* tnum3 = cn->complexTable.lookup(num3);
   EXPECT_EQ(tnum3->value, num2);
 
   // insert a third number that is close to both previously inserted numbers,
   // but closer to the first
-  const fp num4 = num1 - 0.6 * dd::ComplexTable<>::tolerance();
+  const fp num4 = num1 - 0.6 * dd::ComplexTable::tolerance();
   auto* tnum4 = cn->complexTable.lookup(num4);
   EXPECT_EQ(tnum4->value, num1);
 }

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -33,9 +33,9 @@ TEST(DDPackageTest, TrivialTest) {
   // repeat the same calculation - triggering compute table hit
   ASSERT_EQ(dd->fidelity(zeroState, oneState), 0.0);
   ASSERT_NEAR(dd->fidelity(zeroState, hState), 0.5,
-              dd::ComplexTable<>::tolerance());
+              dd::ComplexTable::tolerance());
   ASSERT_NEAR(dd->fidelity(oneState, hState), 0.5,
-              dd::ComplexTable<>::tolerance());
+              dd::ComplexTable::tolerance());
 }
 
 TEST(DDPackageTest, BellState) {
@@ -379,9 +379,9 @@ TEST(DDPackageTest, SerializationErrors) {
 
   // test wrong version number
   std::stringstream ss{};
-  ss << 2 << std::endl;
+  ss << 2 << "\n";
   EXPECT_THROW(dd->deserialize<dd::vNode>(ss, false), std::runtime_error);
-  ss << 2 << std::endl;
+  ss << 2 << "\n";
   EXPECT_THROW(dd->deserialize<dd::mNode>(ss, false), std::runtime_error);
 
   ss.str("");
@@ -395,21 +395,21 @@ TEST(DDPackageTest, SerializationErrors) {
 
   // test wrong format
   ss.str("");
-  ss << "1" << std::endl;
-  ss << "not_complex" << std::endl;
+  ss << "1\n";
+  ss << "not_complex\n";
   EXPECT_THROW(dd->deserialize<dd::vNode>(ss), std::runtime_error);
-  ss << "1" << std::endl;
-  ss << "not_complex" << std::endl;
+  ss << "1\n";
+  ss << "not_complex\n";
   EXPECT_THROW(dd->deserialize<dd::mNode>(ss), std::runtime_error);
 
   ss.str("");
-  ss << "1" << std::endl;
-  ss << "1.0" << std::endl;
-  ss << "no_node_here" << std::endl;
+  ss << "1\n";
+  ss << "1.0\n";
+  ss << "no_node_here\n";
   EXPECT_THROW(dd->deserialize<dd::vNode>(ss), std::runtime_error);
-  ss << "1" << std::endl;
-  ss << "1.0" << std::endl;
-  ss << "no_node_here" << std::endl;
+  ss << "1\n";
+  ss << "1.0\n";
+  ss << "no_node_here\n";
   EXPECT_THROW(dd->deserialize<dd::mNode>(ss), std::runtime_error);
 }
 
@@ -672,8 +672,7 @@ TEST(DDPackageTest, PackageReset) {
   const auto& table = unique[0];
   auto ihash = decltype(dd->mUniqueTable)::hash(iGate.p);
   const auto* node = table[ihash];
-  std::cout << ihash << ": " << reinterpret_cast<uintptr_t>(iGate.p)
-            << std::endl;
+  std::cout << ihash << ": " << reinterpret_cast<uintptr_t>(iGate.p) << "\n";
   // node should be the first in this unique table bucket
   EXPECT_EQ(node, iGate.p);
   dd->reset();
@@ -717,7 +716,7 @@ TEST(DDPackageTest, UniqueTableAllocation) {
   auto dd = std::make_unique<dd::Package<>>(1);
 
   auto allocs = dd->vUniqueTable.getAllocations();
-  std::cout << allocs << std::endl;
+  std::cout << allocs << "\n";
   std::vector<dd::vNode*> nodes{allocs};
   // get all the nodes that are pre-allocated
   for (auto i = 0U; i < allocs; ++i) {
@@ -802,7 +801,7 @@ TEST(DDPackageTest, KroneckerProduct) {
 
 TEST(DDPackageTest, NearZeroNormalize) {
   auto dd = std::make_unique<dd::Package<>>(2);
-  const dd::fp nearZero = dd::ComplexTable<>::tolerance() / 10;
+  const dd::fp nearZero = dd::ComplexTable::tolerance() / 10;
   dd::vEdge ve{};
   ve.p = dd->vUniqueTable.getNode();
   ve.p->v = 1;
@@ -1076,7 +1075,7 @@ TEST(DDPackageTest, BasicNumericStabilityTest) {
   using limits = std::numeric_limits<dd::fp>;
 
   auto dd = std::make_unique<dd::Package<>>(1);
-  auto tol = dd::ComplexTable<>::tolerance();
+  auto tol = dd::ComplexTable::tolerance();
   dd::ComplexNumbers::setTolerance(limits::epsilon());
   auto state = dd->makeZeroState(1);
   auto h = dd->makeGateDD(dd::Hmat, 1, 0);
@@ -1089,8 +1088,7 @@ TEST(DDPackageTest, BasicNumericStabilityTest) {
       result.p->e[0].w.toString(false, limits::max_digits10);
   const auto rightWeight =
       result.p->e[1].w.toString(false, limits::max_digits10);
-  std::cout << topWeight << " | " << leftWeight << " | " << rightWeight
-            << std::endl;
+  std::cout << topWeight << " | " << leftWeight << " | " << rightWeight << "\n";
   EXPECT_EQ(topWeight, "1");
   std::ostringstream oss{};
   oss << std::setprecision(limits::max_digits10) << dd::SQRT2_2;
@@ -1108,7 +1106,7 @@ TEST(DDPackageTest, NormalizationNumericStabilityTest) {
     const auto lambda = dd::PI / static_cast<dd::fp>(1ULL << x);
     std::cout << std::setprecision(17) << "x: " << x << " | lambda: " << lambda
               << " | cos(lambda): " << std::cos(lambda)
-              << " | sin(lambda): " << std::sin(lambda) << std::endl;
+              << " | sin(lambda): " << std::sin(lambda) << "\n";
     auto p = dd->makeGateDD(dd::Phasemat(lambda), 1, 0);
     auto pdag = dd->makeGateDD(dd::Phasemat(-lambda), 1, 0);
     auto result = dd->multiply(p, pdag);
@@ -1132,7 +1130,7 @@ TEST(DDPackageTest, FidelityOfMeasurementOutcomes) {
   probs[0] = 0.5;
   probs[7] = 0.5;
   auto fidelity = dd->fidelityOfMeasurementOutcomes(ghzState, probs);
-  EXPECT_NEAR(fidelity, 1.0, dd::ComplexTable<>::tolerance());
+  EXPECT_NEAR(fidelity, 1.0, dd::ComplexTable::tolerance());
 }
 
 TEST(DDPackageTest, CloseToIdentity) {
@@ -1226,7 +1224,7 @@ TEST(DDPackageTest, dNodeMultiply) {
     for (const auto& cValue : stateVector) {
       std::cout << "r:" << cValue.real() << " i:" << cValue.imag();
     }
-    std::cout << std::endl;
+    std::cout << "\n";
   }
 
   for (std::size_t i = 0; i < (1 << nrQubits); i++) {
@@ -1245,7 +1243,7 @@ TEST(DDPackageTest, dNodeMultiply) {
   const auto probVector = dd->getProbVectorFromDensityMatrix(state, 0.001);
   const double tolerance = 1e-10;
   for (const auto& prob : probVector) {
-    std::cout << prob.first << ": " << prob.second << std::endl;
+    std::cout << prob.first << ": " << prob.second << "\n";
     EXPECT_NEAR(prob.second, 0.125, tolerance);
   }
 }
@@ -1286,7 +1284,7 @@ TEST(DDPackageTest, dNodeMultiply2) {
   auto probVector = dd->getProbVectorFromDensityMatrix(state, 0.001);
   const double tolerance = 1e-10;
   for (const auto& prob : probVector) {
-    std::cout << prob.first << ": " << prob.second << std::endl;
+    std::cout << prob.first << ": " << prob.second << "\n";
     EXPECT_NEAR(prob.second, 0.125, tolerance);
   }
 }
@@ -1432,7 +1430,7 @@ TEST(DDPackageTest, complexRefCount) {
 
 TEST(DDPackageTest, exactlyZeroComparison) {
   auto dd = std::make_unique<dd::Package<>>(1);
-  auto notZero = dd->cn.lookup(0, 2 * dd::ComplexTable<>::tolerance());
+  auto notZero = dd->cn.lookup(0, 2 * dd::ComplexTable::tolerance());
   auto zero = dd->cn.lookup(0, 0);
   EXPECT_TRUE(!notZero.exactlyZero());
   EXPECT_TRUE(zero.exactlyZero());
@@ -1440,7 +1438,7 @@ TEST(DDPackageTest, exactlyZeroComparison) {
 
 TEST(DDPackageTest, exactlyOneComparison) {
   auto dd = std::make_unique<dd::Package<>>(1);
-  auto notOne = dd->cn.lookup(1 + 2 * dd::ComplexTable<>::tolerance(), 0);
+  auto notOne = dd->cn.lookup(1 + 2 * dd::ComplexTable::tolerance(), 0);
   auto one = dd->cn.lookup(1, 0);
   EXPECT_TRUE(!notOne.exactlyOne());
   EXPECT_TRUE(one.exactlyOne());
@@ -1730,7 +1728,7 @@ TEST(DDPackageTest, RZZGateDDConstruction) {
 
   auto rzzTwoPi = dd->makeRZZDD(2, 0, 1, 2 * dd::PI);
   EXPECT_EQ(rzzTwoPi.p, identity.p);
-  EXPECT_EQ(dd::ComplexTable<>::Entry::val(rzzTwoPi.w.r), -1.);
+  EXPECT_EQ(dd::ComplexTable::Entry::val(rzzTwoPi.w.r), -1.);
 
   auto rzzPi = dd->makeRZZDD(2, 0, 1, dd::PI);
   auto zz = dd->makeGateDD(dd::Zmat, 2, dd::Controls{}, 0);


### PR DESCRIPTION
## Description

The code used to handle complex numbers in the DD package (ComplexTable, ComplexCache, etc.) previously contained quite some templates to configure the respective data structures. However, the added flexibility to configure those data structures was never exposed to the outside (e.g., in the `DDPackageConfig`). As such, they were always default initialized anyway.

This PR removes all template parameters from the respective classes.
- Parameters that need to be statically defined (e.g., number of buckets for the complex table), are defined as `static constexpr` members of that class.
- Parameters that do not need to be defined statically are added to the constructor of the respective class and `static constexpr` members are used to provide the same defaults as before.

Moving away from templates also means that the respective code need not be header-only any more. Consequently, this PR moves all the functionality from the header files to respective `.cpp` source files. On the one hand, this creates a nicer separation of concerns between the headers (the interface) and the source files (the implementation). On the other hand, this creates more compilation units and, hence, should speed up overall compile times as well as reduce the code that has to be re-compiled upon code changes. 
I would suspect this will mostly help MSVC under Windows and might cause CI runners to run out of heap space less often.

Last, but certainly not least, this PR starts an effort for better documentation throughout this repository.
Every class and every method is no appropriately documented. This should also allow to generate nice API documentation using doxygen.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
