### PR TITLE
♻️ Eliminate DD terminal nodes

### DIFF
--- a/include/dd/DDDefinitions.hpp
+++ b/include/dd/DDDefinitions.hpp
@@ -8,21 +8,25 @@
 #include <vector>
 
 namespace dd {
-// integer type used for indexing qubits
-// needs to be a signed type to encode -1 as the index for the terminal
-// std::int8_t can address up to 128 qubits as [0, ..., 127]
-using Qubit = std::int8_t;
-static_assert(std::is_signed_v<Qubit>, "Type Qubit must be signed.");
+/**
+ * @brief Integer type used for indexing qubits
+ * @details `std::uint16_t` can address up to 65536 qubits as [0, ..., 65535].
+ * @note If you need even more qubits, this can be increased to `std::uint32_t`.
+ * Beware of the increased memory footprint of matrix nodes.
+ */
+using Qubit = std::uint16_t;
 
-// integer type used for specifying numbers of qubits
-using QubitCount = std::make_unsigned_t<Qubit>;
-
-// integer type used for reference counting
-// 32bit suffice for a max ref count of around 4 billion
+/**
+ * @brief Integer type used for reference counting
+ * @details Allows a maximum reference count of roughly 4 billion.
+ */
 using RefCount = std::uint32_t;
 static_assert(std::is_unsigned_v<RefCount>, "RefCount should be unsigned.");
 
-// floating point type to use
+/**
+ * @brief Floating point type to use for computations
+ * @note Adjusting the precision might lead to unexpected results.
+ */
 using fp = double;
 static_assert(
     std::is_floating_point_v<fp>,

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -662,6 +662,12 @@ static void toDot(const Edge& e, std::ostream& os, bool colored = true,
   std::unordered_set<decltype(e.p)> nodes{};
 
   auto priocmp = [](const Edge* left, const Edge* right) {
+    if (left->p == nullptr) {
+      return true;
+    }
+    if (right->p == nullptr) {
+      return false;
+    }
     return left->p->v < right->p->v;
   };
 
@@ -936,6 +942,12 @@ template <typename Edge>
 static void exportEdgeWeights(const Edge& edge, std::ostream& stream) {
   struct Priocmp {
     bool operator()(const Edge* left, const Edge* right) {
+      if (left->p == nullptr) {
+        return true;
+      }
+      if (right->p == nullptr) {
+        return false;
+      }
       return left->p->v < right->p->v;
     }
   };

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -695,7 +695,7 @@ static void toDot(const Edge& e, std::ostream& os, bool colored = true,
       modernNode(*node, oss, formatAsPolar);
     }
 
-    // iterate over edges in reverse to guarantee correct proceossing order
+    // iterate over edges in reverse to guarantee correct processing order
     for (auto i = static_cast<std::int16_t>(node->p->e.size() - 1); i >= 0;
          --i) {
       auto& edge = node->p->e[static_cast<std::size_t>(i)];

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -663,7 +663,7 @@ static void toDot(const Edge& e, std::ostream& os, bool colored = true,
 
   auto priocmp = [](const Edge* left, const Edge* right) {
     if (left->p == nullptr) {
-      return true;
+      return right->p != nullptr;
     }
     if (right->p == nullptr) {
       return false;
@@ -943,7 +943,7 @@ static void exportEdgeWeights(const Edge& edge, std::ostream& stream) {
   struct Priocmp {
     bool operator()(const Edge* left, const Edge* right) {
       if (left->p == nullptr) {
-        return true;
+        return right->p != nullptr;
       }
       if (right->p == nullptr) {
         return false;

--- a/include/dd/Node.hpp
+++ b/include/dd/Node.hpp
@@ -55,7 +55,6 @@ struct mNode {
   [[nodiscard]] inline bool isSymmetric() const noexcept {
     return (flags & static_cast<std::uint8_t>(32U)) != 0;
   }
-
   inline void setIdentity(const bool identity) noexcept {
     if (identity) {
       flags = (flags | static_cast<std::uint8_t>(16U));

--- a/include/dd/Node.hpp
+++ b/include/dd/Node.hpp
@@ -9,30 +9,34 @@
 #include <utility>
 
 namespace dd {
-// NOLINTNEXTLINE(readability-identifier-naming)
-struct vNode {
+
+/**
+ * @brief A vector DD node
+ * @details Data Layout |24|24|8|4|2| = 62B (space for two more bytes)
+ */
+struct vNode {                        // NOLINT(readability-identifier-naming)
   std::array<Edge<vNode>, RADIX> e{}; // edges out of this node
   vNode* next{};                      // used to link nodes in unique table
   RefCount ref{};                     // reference count
-  Qubit v{}; // variable index (nonterminal) value (-1 for terminal)
-
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables
-  static vNode terminal;
+  Qubit v{};                          // variable index
 
   static constexpr bool isTerminal(const vNode* p) noexcept {
-    return p == &terminal;
+    return p == nullptr;
   }
-  static constexpr vNode* getTerminal() noexcept { return &terminal; }
+  static constexpr vNode* getTerminal() noexcept { return nullptr; }
 };
 using vEdge = Edge<vNode>;
 using vCachedEdge = CachedEdge<vNode>;
 
-// NOLINTNEXTLINE(readability-identifier-naming)
-struct mNode {
+/**
+ * @brief A matrix DD node
+ * @details Data Layout |24|24|24|24|8|4|2|1| = 111B (space for one more byte)
+ */
+struct mNode {                        // NOLINT(readability-identifier-naming)
   std::array<Edge<mNode>, NEDGE> e{}; // edges out of this node
   mNode* next{};                      // used to link nodes in unique table
   RefCount ref{};                     // reference count
-  Qubit v{}; // variable index (nonterminal) value (-1 for terminal)
+  Qubit v{};                          // variable index
   std::uint8_t flags = 0;
   // 32 = marks a node with is symmetric.
   // 16 = marks a node resembling identity
@@ -41,26 +45,18 @@ struct mNode {
   // 2 = mark first path edge (tmp flag),
   // 1 = mark path is conjugated (tmp flag))
 
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-  static mNode terminal;
-
-  static constexpr bool isTerminal(const mNode* p) noexcept {
-    return p == &terminal;
+  [[nodiscard]] static constexpr bool isTerminal(const mNode* p) noexcept {
+    return p == nullptr;
   }
-  static constexpr mNode* getTerminal() noexcept { return &terminal; }
-
-  [[nodiscard]] inline bool isIdentity() const noexcept {
-    return (flags & static_cast<std::uint8_t>(16U)) != 0;
+  [[nodiscard]] static constexpr mNode* getTerminal() noexcept {
+    return nullptr;
   }
+
   [[nodiscard]] inline bool isSymmetric() const noexcept {
     return (flags & static_cast<std::uint8_t>(32U)) != 0;
   }
-  inline void setIdentity(const bool identity) noexcept {
-    if (identity) {
-      flags = (flags | static_cast<std::uint8_t>(16U));
-    } else {
-      flags = (flags & static_cast<std::uint8_t>(~16U));
-    }
+  [[nodiscard]] static constexpr bool isSymmetric(const mNode* p) noexcept {
+    return p == nullptr || p->isSymmetric();
   }
   inline void setSymmetric(const bool symmetric) noexcept {
     if (symmetric) {
@@ -69,16 +65,33 @@ struct mNode {
       flags = (flags & static_cast<std::uint8_t>(~32U));
     }
   }
+
+  [[nodiscard]] inline bool isIdentity() const noexcept {
+    return (flags & static_cast<std::uint8_t>(16U)) != 0;
+  }
+  [[nodiscard]] static constexpr bool isIdentity(const mNode* p) noexcept {
+    return p == nullptr || p->isIdentity();
+  }
+  inline void setIdentity(const bool identity) noexcept {
+    if (identity) {
+      flags = (flags | static_cast<std::uint8_t>(16U));
+    } else {
+      flags = (flags & static_cast<std::uint8_t>(~16U));
+    }
+  }
 };
 using mEdge = Edge<mNode>;
 using mCachedEdge = CachedEdge<mNode>;
 
-// NOLINTNEXTLINE(readability-identifier-naming)
-struct dNode {
+/**
+ * @brief A density matrix DD node
+ * @details Data Layout |24|24|24|24|8|4|2|1| = 111B (space for one more byte)
+ */
+struct dNode {                        // NOLINT(readability-identifier-naming)
   std::array<Edge<dNode>, NEDGE> e{}; // edges out of this node
   dNode* next{};                      // used to link nodes in unique table
   RefCount ref{};                     // reference count
-  Qubit v{}; // variable index (nonterminal) value (-1 for terminal)
+  Qubit v{};                          // variable index
   std::uint8_t flags = 0;
   // 32 = marks a node with is symmetric.
   // 16 = marks a node resembling identity
@@ -87,13 +100,10 @@ struct dNode {
   // 2 = mark first path edge (tmp flag),
   // 1 = mark path is conjugated (tmp flag))
 
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-  static dNode terminal;
-
   static constexpr bool isTerminal(const dNode* p) noexcept {
-    return p == &terminal;
+    return p == nullptr;
   }
-  static constexpr dNode* getTerminal() noexcept { return &terminal; }
+  static constexpr dNode* getTerminal() noexcept { return nullptr; }
 
   [[nodiscard]] [[maybe_unused]] static inline bool
   tempDensityMatrixFlagsEqual(const std::uint8_t a,
@@ -191,8 +201,7 @@ static inline dEdge densityFromMatrixEdge(const mEdge& e) {
 template <typename Node>
 [[nodiscard]] static inline bool
 noRefCountingNeeded(const Node* const p) noexcept {
-  return p == nullptr || Node::isTerminal(p) ||
-         p->ref == std::numeric_limits<RefCount>::max();
+  return Node::isTerminal(p) || p->ref == std::numeric_limits<RefCount>::max();
 }
 
 /**

--- a/include/dd/NoiseFunctionality.hpp
+++ b/include/dd/NoiseFunctionality.hpp
@@ -26,7 +26,7 @@ public:
                                dd::QubitCount nq, double gateNoiseProbability,
                                double amplitudeDampingProb,
                                double multiQubitGateFactor,
-                               std::vector<dd::NoiseOperations> effects)
+                               std::vector<NoiseOperations> effects)
       : package(dd), nQubits(nq), dist(0.0, 1.0L),
         noiseProbability(gateNoiseProbability),
         noiseProbabilityMulti(gateNoiseProbability * multiQubitGateFactor),
@@ -38,17 +38,16 @@ public:
         oneMinusSqrtAmplitudeDampingProbabilityMulti(
             {std::sqrt(1 - multiQubitGateFactor * amplitudeDampingProb), 0}),
         ampDampingTrue(
-            dd::GateMatrix({dd::complex_zero, sqrtAmplitudeDampingProbability,
-                            dd::complex_zero, dd::complex_zero})),
-        ampDampingTrueMulti(dd::GateMatrix(
-            {dd::complex_zero, sqrtAmplitudeDampingProbabilityMulti,
-             dd::complex_zero, dd::complex_zero})),
-        ampDampingFalse(
-            dd::GateMatrix({dd::complex_one, dd::complex_zero, dd::complex_zero,
-                            oneMinusSqrtAmplitudeDampingProbability})),
+            GateMatrix({complex_zero, sqrtAmplitudeDampingProbability,
+                        complex_zero, complex_zero})),
+        ampDampingTrueMulti(
+            GateMatrix({complex_zero, sqrtAmplitudeDampingProbabilityMulti,
+                        complex_zero, complex_zero})),
+        ampDampingFalse(GateMatrix({complex_one, complex_zero, complex_zero,
+                                    oneMinusSqrtAmplitudeDampingProbability})),
         ampDampingFalseMulti(
-            dd::GateMatrix({dd::complex_one, dd::complex_zero, dd::complex_zero,
-                            oneMinusSqrtAmplitudeDampingProbabilityMulti})),
+            GateMatrix({complex_one, complex_zero, complex_zero,
+                        oneMinusSqrtAmplitudeDampingProbabilityMulti})),
         noiseEffects(std::move(effects)),
         identityDD(package->makeIdent(nQubits)) {
     package->incRef(identityDD);
@@ -64,16 +63,16 @@ protected:
 
   double noiseProbability;
   double noiseProbabilityMulti;
-  dd::ComplexValue sqrtAmplitudeDampingProbability;
-  dd::ComplexValue oneMinusSqrtAmplitudeDampingProbability;
-  dd::ComplexValue sqrtAmplitudeDampingProbabilityMulti;
-  dd::ComplexValue oneMinusSqrtAmplitudeDampingProbabilityMulti;
-  dd::GateMatrix ampDampingTrue{};
-  dd::GateMatrix ampDampingTrueMulti{};
-  dd::GateMatrix ampDampingFalse{};
-  dd::GateMatrix ampDampingFalseMulti{};
-  std::vector<dd::NoiseOperations> noiseEffects;
-  dd::mEdge identityDD;
+  ComplexValue sqrtAmplitudeDampingProbability;
+  ComplexValue oneMinusSqrtAmplitudeDampingProbability;
+  ComplexValue sqrtAmplitudeDampingProbabilityMulti;
+  ComplexValue oneMinusSqrtAmplitudeDampingProbabilityMulti;
+  GateMatrix ampDampingTrue{};
+  GateMatrix ampDampingTrueMulti{};
+  GateMatrix ampDampingFalse{};
+  GateMatrix ampDampingFalseMulti{};
+  std::vector<NoiseOperations> noiseEffects;
+  mEdge identityDD;
 
   [[nodiscard]] dd::QubitCount getNumberOfQubits() const { return nQubits; }
   [[nodiscard]] double getNoiseProbability(bool multiQubitNoiseFlag) const {
@@ -89,7 +88,7 @@ protected:
     return multiQubitNoiseFlag ? qc::MultiAFalse : qc::AFalse;
   }
 
-  [[nodiscard]] dd::GateMatrix
+  [[nodiscard]] GateMatrix
   getAmplitudeDampingOperationMatrix(bool multiQubitNoiseFlag,
                                      bool amplitudeDampingFlag) const {
     if (amplitudeDampingFlag) {
@@ -99,14 +98,13 @@ protected:
   }
 
 public:
-  [[nodiscard]] dd::mEdge getIdentityDD() const { return identityDD; }
-  void setNoiseEffects(std::vector<dd::NoiseOperations> newNoiseEffects) {
+  [[nodiscard]] mEdge getIdentityDD() const { return identityDD; }
+  void setNoiseEffects(std::vector<NoiseOperations> newNoiseEffects) {
     noiseEffects = std::move(newNoiseEffects);
   }
 
-  void applyNoiseOperation(const std::set<qc::Qubit>& targets,
-                           dd::mEdge operation, dd::vEdge& state,
-                           std::mt19937_64& generator) {
+  void applyNoiseOperation(const std::set<qc::Qubit>& targets, mEdge operation,
+                           vEdge& state, std::mt19937_64& generator) {
     const bool multiQubitOperation = targets.size() > 1;
 
     for (const auto& target : targets) {
@@ -115,7 +113,7 @@ public:
                                  generator, false, multiQubitOperation);
       auto tmp = package->multiply(stackedOperation, state);
 
-      if (dd::ComplexNumbers::mag2(tmp.w) < dist(generator)) {
+      if (ComplexNumbers::mag2(tmp.w) < dist(generator)) {
         // The probability of amplitude damping does not only depend on the
         // noise probability, but also the quantum state. Due to the
         // normalization constraint of decision diagrams the probability for
@@ -157,7 +155,7 @@ protected:
                                    bool amplitudeDamping,
                                    bool multiQubitOperation) {
     for (const auto& noiseType : noiseEffects) {
-      const auto effect = noiseType == dd::AmplitudeDamping
+      const auto effect = noiseType == AmplitudeDamping
                               ? getAmplitudeDampingOperationType(
                                     multiQubitOperation, amplitudeDamping)
                               : returnNoiseOperation(noiseType, dist(generator),
@@ -204,10 +202,10 @@ protected:
   }
 
   [[nodiscard]] qc::OpType
-  returnNoiseOperation(dd::NoiseOperations noiseOperation, double prob,
+  returnNoiseOperation(NoiseOperations noiseOperation, double prob,
                        bool multiQubitNoiseFlag) const {
     switch (noiseOperation) {
-    case dd::NoiseOperations::Depolarization: {
+    case NoiseOperations::Depolarization: {
       if (prob >= (getNoiseProbability(multiQubitNoiseFlag) * 0.75)) {
         // prob > prob apply qc::I, also 25 % of the time when depolarization is
         // applied nothing happens
@@ -227,13 +225,13 @@ protected:
       // apply qc::Z
       return qc::Z;
     }
-    case dd::NoiseOperations::PhaseFlip: {
+    case NoiseOperations::PhaseFlip: {
       if (prob > getNoiseProbability(multiQubitNoiseFlag)) {
         return qc::I;
       }
       return qc::Z;
     }
-    case dd::NoiseOperations::Identity: {
+    case NoiseOperations::Identity: {
       return qc::I;
     }
     default:
@@ -270,16 +268,16 @@ protected:
   double ampDampingProbSingleQubit;
   double ampDampingProbMultiQubit;
 
-  std::vector<dd::NoiseOperations> noiseEffects;
+  std::vector<NoiseOperations> noiseEffects;
   bool useDensityMatrixType;
   bool sequentiallyApplyNoise;
 
-  inline static const std::map<dd::NoiseOperations, std::size_t>
+  inline static const std::map<NoiseOperations, std::size_t>
       SEQUENTIAL_NOISE_MAP = {
-          {dd::Identity, 1},         // Identity Noise
-          {dd::PhaseFlip, 2},        // Phase-flip
-          {dd::AmplitudeDamping, 2}, // Amplitude Damping
-          {dd::Depolarization, 4},   // Depolarisation
+          {Identity, 1},         // Identity Noise
+          {PhaseFlip, 2},        // Phase-flip
+          {AmplitudeDamping, 2}, // Amplitude Damping
+          {Depolarization, 4},   // Depolarisation
   };
 
   [[nodiscard]] dd::QubitCount getNumberOfQubits() const { return nQubits; }
@@ -355,22 +353,22 @@ private:
                     })) {
       for (auto const& type : noiseEffects) {
         switch (type) {
-        case dd::AmplitudeDamping:
+        case AmplitudeDamping:
           applyAmplitudeDampingToEdges(
               newEdges, (usedQubits.size() == 1) ? ampDampingProbSingleQubit
                                                  : ampDampingProbMultiQubit);
           break;
-        case dd::PhaseFlip:
+        case PhaseFlip:
           applyPhaseFlipToEdges(newEdges, (usedQubits.size() == 1)
                                               ? noiseProbSingleQubit
                                               : noiseProbMultiQubit);
           break;
-        case dd::Depolarization:
+        case Depolarization:
           applyDepolarisationToEdges(newEdges, (usedQubits.size() == 1)
                                                    ? noiseProbSingleQubit
                                                    : noiseProbMultiQubit);
           break;
-        case dd::Identity:
+        case Identity:
           continue;
         }
       }
@@ -407,7 +405,7 @@ private:
   }
 
   void applyAmplitudeDampingToEdges(ArrayOfEdges& e, double probability) {
-    dd::Complex complexProb = package->cn.getCached(0., 0.);
+    Complex complexProb = package->cn.getCached(0., 0.);
 
     // e[0] = e[0] + p*e[3]
     if (!e[3].w.exactlyZero()) {
@@ -461,7 +459,7 @@ private:
 
   void applyDepolarisationToEdges(ArrayOfEdges& e, double probability) {
     std::array<qc::DensityMatrixDD, 2> helperEdge{};
-    dd::Complex complexProb = package->cn.getCached();
+    Complex complexProb = package->cn.getCached();
     complexProb.i->value = 0;
 
     qc::DensityMatrixDD oldE0Edge{e[0].p, package->cn.getCached(e[0].w)};
@@ -474,7 +472,7 @@ private:
         complexProb.r->value = (2 - probability) * 0.5;
         helperEdge[0].w = package->cn.mulCached(e[0].w, complexProb);
       } else {
-        helperEdge[0].w = dd::Complex::zero;
+        helperEdge[0].w = Complex::zero;
       }
 
       // helperEdge[1] = 0.5*p*e[3]
@@ -483,7 +481,7 @@ private:
         complexProb.r->value = probability * 0.5;
         helperEdge[1].w = package->cn.mulCached(e[3].w, complexProb);
       } else {
-        helperEdge[1].w = dd::Complex::zero;
+        helperEdge[1].w = Complex::zero;
       }
 
       // e[0] = helperEdge[0] + helperEdge[1]
@@ -522,7 +520,7 @@ private:
         complexProb.r->value = (2 - probability) * 0.5;
         helperEdge[0].w = package->cn.mulCached(e[3].w, complexProb);
       } else {
-        helperEdge[0].w = dd::Complex::zero;
+        helperEdge[0].w = Complex::zero;
       }
 
       // helperEdge[1] = 0.5*p*e[0]
@@ -531,7 +529,7 @@ private:
         complexProb.r->value = probability * 0.5;
         helperEdge[1].w = package->cn.mulCached(oldE0Edge.w, complexProb);
       } else {
-        helperEdge[1].w = dd::Complex::zero;
+        helperEdge[1].w = Complex::zero;
       }
 
       package->cn.returnToCache(e[3].w);
@@ -560,10 +558,10 @@ private:
         for (std::size_t m = 0; m < SEQUENTIAL_NOISE_MAP.find(type)->second;
              m++) {
           auto tmp0 = package->conjugateTranspose(idleOperation.at(m));
-          auto tmp1 = package->multiply(
-              originalEdge, dd::densityFromMatrixEdge(tmp0), 0, false);
+          auto tmp1 = package->multiply(originalEdge,
+                                        densityFromMatrixEdge(tmp0), 0, false);
           auto tmp2 =
-              package->multiply(dd::densityFromMatrixEdge(idleOperation.at(m)),
+              package->multiply(densityFromMatrixEdge(idleOperation.at(m)),
                                 tmp1, 0, useDensityMatrixType);
           if (tmp.p == nullptr) {
             tmp = tmp2;
@@ -590,43 +588,43 @@ private:
         idleNoiseGate{};
     dd::ComplexValue tmp = {};
 
-    tmp.r = std::sqrt(1 - ((3 * probability) / 4)) * dd::complex_one.r;
+    tmp.r = std::sqrt(1 - ((3 * probability) / 4)) * complex_one.r;
     //                   (1 0)
     // sqrt(1- ((3p)/4))*(0 1)
     idleNoiseGate[0][0] = idleNoiseGate[0][3] = tmp;
-    idleNoiseGate[0][1] = idleNoiseGate[0][2] = dd::complex_zero;
+    idleNoiseGate[0][1] = idleNoiseGate[0][2] = complex_zero;
 
     pointerForMatrices[0] =
         package->makeGateDD(idleNoiseGate[0], getNumberOfQubits(), target);
 
     //                      (0 1)
     // sqrt(probability/4))*(1 0)
-    tmp.r = std::sqrt(probability / 4) * dd::complex_one.r;
+    tmp.r = std::sqrt(probability / 4) * complex_one.r;
     idleNoiseGate[1][1] = idleNoiseGate[1][2] = tmp;
-    idleNoiseGate[1][0] = idleNoiseGate[1][3] = dd::complex_zero;
+    idleNoiseGate[1][0] = idleNoiseGate[1][3] = complex_zero;
 
     pointerForMatrices[1] =
         package->makeGateDD(idleNoiseGate[1], getNumberOfQubits(), target);
 
     //                      (1 0)
     // sqrt(probability/4))*(0 -1)
-    tmp.r = std::sqrt(probability / 4) * dd::complex_one.r;
+    tmp.r = std::sqrt(probability / 4) * complex_one.r;
     idleNoiseGate[2][0] = tmp;
     tmp.r = tmp.r * -1;
     idleNoiseGate[2][3] = tmp;
-    idleNoiseGate[2][1] = idleNoiseGate[2][2] = dd::complex_zero;
+    idleNoiseGate[2][1] = idleNoiseGate[2][2] = complex_zero;
 
     pointerForMatrices[3] =
         package->makeGateDD(idleNoiseGate[2], getNumberOfQubits(), target);
 
     //                      (0 -i)
     // sqrt(probability/4))*(i 0)
-    tmp.r = dd::complex_zero.r;
+    tmp.r = complex_zero.r;
     tmp.i = std::sqrt(probability / 4) * 1;
     idleNoiseGate[3][2] = tmp;
     tmp.i = tmp.i * -1;
     idleNoiseGate[3][1] = tmp;
-    idleNoiseGate[3][0] = idleNoiseGate[3][3] = dd::complex_zero;
+    idleNoiseGate[3][0] = idleNoiseGate[3][3] = complex_zero;
 
     pointerForMatrices[2] =
         package->makeGateDD(idleNoiseGate[3], getNumberOfQubits(), target);
@@ -645,9 +643,9 @@ private:
       // identity noise (for testing)
       //                  (1  0)
       //                  (0  1),
-    case dd::Identity: {
-      idleNoiseGate[0][0] = idleNoiseGate[0][3] = dd::complex_one;
-      idleNoiseGate[0][1] = idleNoiseGate[0][2] = dd::complex_zero;
+    case Identity: {
+      idleNoiseGate[0][0] = idleNoiseGate[0][3] = complex_one;
+      idleNoiseGate[0][1] = idleNoiseGate[0][2] = complex_zero;
 
       pointerForMatrices[0] =
           package->makeGateDD(idleNoiseGate[0], getNumberOfQubits(), target);
@@ -657,15 +655,15 @@ private:
       // phase flip
       //                          (1  0)                         (1  0)
       //  e0= sqrt(1-probability)*(0  1), e1=  sqrt(probability)*(0 -1)
-    case dd::PhaseFlip: {
-      tmp.r = std::sqrt(1 - probability) * dd::complex_one.r;
+    case PhaseFlip: {
+      tmp.r = std::sqrt(1 - probability) * complex_one.r;
       idleNoiseGate[0][0] = idleNoiseGate[0][3] = tmp;
-      idleNoiseGate[0][1] = idleNoiseGate[0][2] = dd::complex_zero;
-      tmp.r = std::sqrt(probability) * dd::complex_one.r;
+      idleNoiseGate[0][1] = idleNoiseGate[0][2] = complex_zero;
+      tmp.r = std::sqrt(probability) * complex_one.r;
       idleNoiseGate[1][0] = tmp;
       tmp.r *= -1;
       idleNoiseGate[1][3] = tmp;
-      idleNoiseGate[1][1] = idleNoiseGate[1][2] = dd::complex_zero;
+      idleNoiseGate[1][1] = idleNoiseGate[1][2] = complex_zero;
 
       pointerForMatrices[0] =
           package->makeGateDD(idleNoiseGate[0], getNumberOfQubits(), target);
@@ -677,15 +675,15 @@ private:
       // amplitude damping
       //      (1                  0)       (0      sqrt(probability))
       //  e0= (0 sqrt(1-probability), e1=  (0                      0)
-    case dd::AmplitudeDamping: {
-      tmp.r = std::sqrt(1 - probability) * dd::complex_one.r;
-      idleNoiseGate[0][0] = dd::complex_one;
-      idleNoiseGate[0][1] = idleNoiseGate[0][2] = dd::complex_zero;
+    case AmplitudeDamping: {
+      tmp.r = std::sqrt(1 - probability) * complex_one.r;
+      idleNoiseGate[0][0] = complex_one;
+      idleNoiseGate[0][1] = idleNoiseGate[0][2] = complex_zero;
       idleNoiseGate[0][3] = tmp;
 
-      tmp.r = std::sqrt(probability) * dd::complex_one.r;
+      tmp.r = std::sqrt(probability) * complex_one.r;
       idleNoiseGate[1][0] = idleNoiseGate[1][3] = idleNoiseGate[1][2] =
-          dd::complex_zero;
+          complex_zero;
       idleNoiseGate[1][1] = tmp;
 
       pointerForMatrices[0] =
@@ -695,7 +693,7 @@ private:
       break;
     }
       // depolarization
-    case dd::Depolarization:
+    case Depolarization:
       generateDepolarizationGate(pointerForMatrices, target, probability);
       break;
     default:
@@ -703,9 +701,9 @@ private:
     }
   }
 
-  double getNoiseProbability(const dd::NoiseOperations type,
+  double getNoiseProbability(const NoiseOperations type,
                              const std::set<qc::Qubit>& targets) {
-    if (type == dd::AmplitudeDamping) {
+    if (type == AmplitudeDamping) {
       return (targets.size() == 1) ? ampDampingProbSingleQubit
                                    : ampDampingProbMultiQubit;
     }

--- a/include/dd/Operations.hpp
+++ b/include/dd/Operations.hpp
@@ -13,7 +13,7 @@ namespace dd {
 // single-target Operations
 template <class Config>
 qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op,
-                                    std::unique_ptr<dd::Package<Config>>& dd,
+                                    std::unique_ptr<Package<Config>>& dd,
                                     const qc::Controls& controls,
                                     dd::Qubit target, bool inverse) {
   GateMatrix gm;
@@ -25,64 +25,63 @@ qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op,
 
   switch (type) {
   case qc::I:
-    gm = dd::Imat;
+    gm = Imat;
     break;
   case qc::H:
-    gm = dd::Hmat;
+    gm = Hmat;
     break;
-  case qc::X: {
-    gm = dd::Xmat;
+  case qc::X:
+    gm = Xmat;
     break;
-  }
   case qc::Y:
-    gm = dd::Ymat;
+    gm = Ymat;
     break;
   case qc::Z:
-    gm = dd::Zmat;
+    gm = Zmat;
     break;
   case qc::S:
-    gm = inverse ? dd::Sdagmat : dd::Smat;
+    gm = inverse ? Sdagmat : Smat;
     break;
   case qc::Sdag:
-    gm = inverse ? dd::Smat : dd::Sdagmat;
+    gm = inverse ? Smat : Sdagmat;
     break;
   case qc::T:
-    gm = inverse ? dd::Tdagmat : dd::Tmat;
+    gm = inverse ? Tdagmat : Tmat;
     break;
   case qc::Tdag:
-    gm = inverse ? dd::Tmat : dd::Tdagmat;
+    gm = inverse ? Tmat : Tdagmat;
     break;
   case qc::V:
-    gm = inverse ? dd::Vdagmat : dd::Vmat;
+    gm = inverse ? Vdagmat : Vmat;
     break;
   case qc::Vdag:
-    gm = inverse ? dd::Vmat : dd::Vdagmat;
+    gm = inverse ? Vmat : Vdagmat;
     break;
   case qc::U3:
-    gm = inverse ? dd::U3mat(-parameter[1U], -parameter[2U], -parameter[0U])
-                 : dd::U3mat(parameter[2U], parameter[1U], parameter[0U]);
+    gm = inverse ? U3mat(-parameter[1U], -parameter[2U], -parameter[0U])
+                 : U3mat(parameter[2U], parameter[1U], parameter[0U]);
     break;
   case qc::U2:
-    gm = inverse ? dd::U2mat(-parameter[0U] + dd::PI, -parameter[1U] - dd::PI)
-                 : dd::U2mat(parameter[1U], parameter[0U]);
+    gm = inverse ? U2mat(-parameter[0U] + PI, -parameter[1U] - PI)
+                 : U2mat(parameter[1U], parameter[0U]);
     break;
   case qc::Phase:
-    gm = inverse ? dd::Phasemat(-parameter[0U]) : dd::Phasemat(parameter[0U]);
+    gm = inverse ? Phasemat(-parameter[0U]) : Phasemat(parameter[0U]);
     break;
   case qc::SX:
-    gm = inverse ? dd::SXdagmat : dd::SXmat;
+    gm = inverse ? SXdagmat : SXmat;
     break;
   case qc::SXdag:
-    gm = inverse ? dd::SXmat : dd::SXdagmat;
+    gm = inverse ? SXmat : SXdagmat;
     break;
   case qc::RX:
-    gm = inverse ? dd::RXmat(-parameter[0U]) : dd::RXmat(parameter[0U]);
+    gm = inverse ? RXmat(-parameter[0U]) : RXmat(parameter[0U]);
     break;
   case qc::RY:
-    gm = inverse ? dd::RYmat(-parameter[0U]) : dd::RYmat(parameter[0U]);
+    gm = inverse ? RYmat(-parameter[0U]) : RYmat(parameter[0U]);
     break;
   case qc::RZ:
-    gm = inverse ? dd::RZmat(-parameter[0U]) : dd::RZmat(parameter[0U]);
+    gm = inverse ? RZmat(-parameter[0U]) : RZmat(parameter[0U]);
     break;
   default:
     std::ostringstream oss{};
@@ -116,36 +115,36 @@ qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op,
     bool definitionFound = true;
     switch (type) {
     case qc::SWAP:
-      gm = dd::SWAPmat;
+      gm = SWAPmat;
       break;
     case qc::iSWAP:
-      gm = inverse ? dd::iSWAPinvmat : dd::iSWAPmat;
+      gm = inverse ? iSWAPinvmat : iSWAPmat;
       break;
     case qc::DCX:
-      gm = dd::DCXmat;
+      gm = DCXmat;
       break;
     case qc::ECR:
-      gm = dd::ECRmat;
+      gm = ECRmat;
       break;
     case qc::RXX:
-      gm = inverse ? dd::RXXmat(-parameter[0U]) : dd::RXXmat(parameter[0U]);
+      gm = inverse ? RXXmat(-parameter[0U]) : RXXmat(parameter[0U]);
       break;
     case qc::RYY:
-      gm = inverse ? dd::RYYmat(-parameter[0U]) : dd::RYYmat(parameter[0U]);
+      gm = inverse ? RYYmat(-parameter[0U]) : RYYmat(parameter[0U]);
       break;
     case qc::RZZ:
-      gm = inverse ? dd::RZZmat(-parameter[0U]) : dd::RZZmat(parameter[0U]);
+      gm = inverse ? RZZmat(-parameter[0U]) : RZZmat(parameter[0U]);
       break;
     case qc::RZX:
-      gm = inverse ? dd::RZXmat(-parameter[0U]) : dd::RZXmat(parameter[0U]);
+      gm = inverse ? RZXmat(-parameter[0U]) : RZXmat(parameter[0U]);
       break;
     case qc::XXminusYY:
-      gm = inverse ? dd::XXMinusYYmat(-parameter[0U], parameter[1U])
-                   : dd::XXMinusYYmat(parameter[0U], parameter[1U]);
+      gm = inverse ? XXMinusYYmat(-parameter[0U], parameter[1U])
+                   : XXMinusYYmat(parameter[0U], parameter[1U]);
       break;
     case qc::XXplusYY:
-      gm = inverse ? dd::XXPlusYYmat(-parameter[0U], parameter[1U])
-                   : dd::XXPlusYYmat(parameter[0U], parameter[1U]);
+      gm = inverse ? XXPlusYYmat(-parameter[0U], parameter[1U])
+                   : XXPlusYYmat(parameter[0U], parameter[1U]);
       break;
     default:
       definitionFound = false;
@@ -243,22 +242,22 @@ qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op,
 
 template <class Config>
 qc::MatrixDD getDD(const qc::Operation* op,
-                   std::unique_ptr<dd::Package<Config>>& dd,
-                   qc::Permutation& permutation, bool inverse = false) {
+                   std::unique_ptr<Package<Config>>& dd,
+                   qc::Permutation& permutation, const bool inverse = false) {
   const auto type = op->getType();
   const auto nqubits = op->getNqubits();
 
   // check whether the operation can be handled by the underlying DD package
-  if (nqubits > dd::Package<Config>::MAX_POSSIBLE_QUBITS) {
+  if (nqubits > Package<Config>::MAX_POSSIBLE_QUBITS) {
     throw qc::QFRException(
         "Requested too many qubits to be handled by the DD package. Qubit "
         "datatype only allows up to " +
-        std::to_string(dd::Package<Config>::MAX_POSSIBLE_QUBITS) +
+        std::to_string(Package<Config>::MAX_POSSIBLE_QUBITS) +
         " qubits, while " + std::to_string(nqubits) +
         " were requested. If you want to use more than " +
-        std::to_string(dd::Package<Config>::MAX_POSSIBLE_QUBITS) +
+        std::to_string(Package<Config>::MAX_POSSIBLE_QUBITS) +
         " qubits, you have to recompile the package with a wider Qubit type in "
-        "`export/dd_package/include/dd/Definitions.hpp!`");
+        "`include/dd/DDDefinitions.hpp!`");
   }
 
   // if a permutation is provided and the current operation is a SWAP, this
@@ -266,8 +265,8 @@ qc::MatrixDD getDD(const qc::Operation* op,
   if (!permutation.empty() && type == qc::SWAP && !op->isControlled()) {
     const auto& targets = op->getTargets();
 
-    const auto target0 = targets.at(0U);
-    const auto target1 = targets.at(1U);
+    const auto target0 = targets[0U];
+    const auto target1 = targets[1U];
     // update permutation
     std::swap(permutation.at(target0), permutation.at(target1));
     return dd->makeIdent(static_cast<dd::QubitCount>(nqubits));
@@ -333,21 +332,21 @@ qc::MatrixDD getDD(const qc::Operation* op,
 
 template <class Config>
 qc::MatrixDD getDD(const qc::Operation* op,
-                   std::unique_ptr<dd::Package<Config>>& dd,
-                   bool inverse = false) {
+                   std::unique_ptr<Package<Config>>& dd,
+                   const bool inverse = false) {
   qc::Permutation perm{};
   return getDD(op, dd, perm, inverse);
 }
 
 template <class Config>
 qc::MatrixDD getInverseDD(const qc::Operation* op,
-                          std::unique_ptr<dd::Package<Config>>& dd) {
+                          std::unique_ptr<Package<Config>>& dd) {
   return getDD(op, dd, true);
 }
 
 template <class Config>
 qc::MatrixDD getInverseDD(const qc::Operation* op,
-                          std::unique_ptr<dd::Package<Config>>& dd,
+                          std::unique_ptr<Package<Config>>& dd,
                           qc::Permutation& permutation) {
   return getDD(op, dd, permutation, true);
 }
@@ -355,15 +354,15 @@ qc::MatrixDD getInverseDD(const qc::Operation* op,
 template <class Config>
 void dumpTensor(qc::Operation* op, std::ostream& of,
                 std::vector<std::size_t>& inds, std::size_t& gateIdx,
-                std::unique_ptr<dd::Package<Config>>& dd);
+                std::unique_ptr<Package<Config>>& dd);
 
 // apply swaps 'on' DD in order to change 'from' to 'to'
 // where |from| >= |to|
 template <class DDType, class Config>
 void changePermutation(DDType& on, qc::Permutation& from,
                        const qc::Permutation& to,
-                       std::unique_ptr<dd::Package<Config>>& dd,
-                       bool regular = true) {
+                       std::unique_ptr<Package<Config>>& dd,
+                       const bool regular = true) {
   assert(from.size() >= to.size());
 
   // iterate over (k,v) pairs of second permutation

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1782,6 +1782,14 @@ public:
   RightOperand
   multiply(const LeftOperand& x, const RightOperand& y, const Qubit start = 0,
            [[maybe_unused]] const bool generateDensityMatrix = false) {
+    static_assert(std::disjunction_v<std::is_same<LeftOperand, mEdge>,
+                                     std::is_same<LeftOperand, dEdge>>,
+                  "Left operand must be a matrix or density matrix");
+    static_assert(std::disjunction_v<std::is_same<RightOperand, vEdge>,
+                                     std::is_same<RightOperand, mEdge>,
+                                     std::is_same<RightOperand, dEdge>>,
+                  "Right operand must be a vector, matrix or density matrix");
+
     [[maybe_unused]] const auto before = cn.cacheCount();
 
     Qubit var{};

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -200,9 +200,12 @@ public:
     cn.incRef(e.w);
     const auto& p = e.p;
     const auto inc = getUniqueTable<Node>().incRef(p);
-    if (inc && p->ref == 1U) {
-      for (const auto& child : p->e) {
-        incRef(child);
+    if (inc) {
+      assert(p != nullptr);
+      if (p->ref == 1U) {
+        for (const auto& child : p->e) {
+          incRef(child);
+        }
       }
     }
   }
@@ -221,9 +224,12 @@ public:
     cn.decRef(e.w);
     const auto& p = e.p;
     const auto dec = getUniqueTable<Node>().decRef(p);
-    if (dec && p->ref == 0U) {
-      for (const auto& child : p->e) {
-        decRef(child);
+    if (dec) {
+      assert(p != nullptr);
+      if (p->ref == 0U) {
+        for (const auto& child : p->e) {
+          decRef(child);
+        }
       }
     }
   }
@@ -1811,9 +1817,11 @@ public:
       dEdge::revertDmChangesToEdges(xCopy, yCopy);
     } else {
       if (!x.isTerminal()) {
+        assert(x.p != nullptr);
         var = x.p->v;
       }
       if (!y.isTerminal() && (y.p->v) > var) {
+        assert(y.p != nullptr);
         var = y.p->v;
       }
       e = multiply2(x, y, var, start);

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -836,7 +836,8 @@ public:
     auto e = makeDDNode(z, em0);
 
     // process lines above the larger target (by creating identity structures)
-    for (++z; z < n + start; ++z) {
+    const auto end = static_cast<Qubit>(n + start);
+    for (++z; z < end; ++z) {
       e = makeDDNode(z, std::array{e, mEdge::zero, mEdge::zero, e});
     }
 
@@ -2609,7 +2610,7 @@ private:
     f = makeDDNode(f.p->v, edges);
 
     // something to reduce for this qubit
-    if (f.p->v >= 0 && ancillary[f.p->v]) {
+    if (ancillary[f.p->v]) {
       if (regular) {
         if (f.p->e[1].w != Complex::zero || f.p->e[3].w != Complex::zero) {
           f = makeDDNode(f.p->v, std::array{f.p->e[0], mEdge::zero, f.p->e[2],
@@ -2655,7 +2656,7 @@ private:
     f = makeDDNode(f.p->v, edges);
 
     // something to reduce for this qubit
-    if (f.p->v >= 0 && garbage[f.p->v]) {
+    if (garbage[f.p->v]) {
       if (f.p->e[1].w != Complex::zero) {
         vEdge g{};
         if (f.p->e[0].w == Complex::zero && f.p->e[1].w != Complex::zero) {
@@ -2708,7 +2709,7 @@ private:
     f = makeDDNode(f.p->v, edges);
 
     // something to reduce for this qubit
-    if (f.p->v >= 0 && garbage[f.p->v]) {
+    if (garbage[f.p->v]) {
       if (regular) {
         if (f.p->e[2].w != Complex::zero || f.p->e[3].w != Complex::zero) {
           mEdge g{};

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -200,12 +200,9 @@ public:
     cn.incRef(e.w);
     const auto& p = e.p;
     const auto inc = getUniqueTable<Node>().incRef(p);
-    if (inc) {
-      assert(p != nullptr);
-      if (p->ref == 1U) {
-        for (const auto& child : p->e) {
-          incRef(child);
-        }
+    if (inc && p->ref == 1U) {
+      for (const auto& child : p->e) {
+        incRef(child);
       }
     }
   }

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -221,12 +221,9 @@ public:
     cn.decRef(e.w);
     const auto& p = e.p;
     const auto dec = getUniqueTable<Node>().decRef(p);
-    if (dec) {
-      assert(p != nullptr);
-      if (p->ref == 0U) {
-        for (const auto& child : p->e) {
-          decRef(child);
-        }
+    if (dec && p->ref == 0U) {
+      for (const auto& child : p->e) {
+        decRef(child);
       }
     }
   }

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -50,10 +50,8 @@ template <class Config> class Package {
   ///
 public:
   static constexpr std::size_t MAX_POSSIBLE_QUBITS =
-      static_cast<std::make_unsigned_t<Qubit>>(
-          std::numeric_limits<Qubit>::max()) +
-      1U;
-  static constexpr std::size_t DEFAULT_QUBITS = 128;
+      static_cast<std::size_t>(std::numeric_limits<Qubit>::max()) + 1U;
+  static constexpr std::size_t DEFAULT_QUBITS = 32U;
   explicit Package(std::size_t nq = DEFAULT_QUBITS) : nqubits(nq) {
     resize(nq);
   };
@@ -145,14 +143,11 @@ public:
   }
 
   /// The unique table used for vector nodes
-  UniqueTable<vNode, Config::UT_VEC_NBUCKET> vUniqueTable{nqubits,
-                                                          vMemoryManager};
+  UniqueTable<vNode, Config::UT_VEC_NBUCKET> vUniqueTable{0U, vMemoryManager};
   /// The unique table used for matrix nodes
-  UniqueTable<mNode, Config::UT_MAT_NBUCKET> mUniqueTable{nqubits,
-                                                          mMemoryManager};
+  UniqueTable<mNode, Config::UT_MAT_NBUCKET> mUniqueTable{0U, mMemoryManager};
   /// The unique table used for density matrix nodes
-  UniqueTable<dNode, Config::UT_DM_NBUCKET> dUniqueTable{nqubits,
-                                                         dMemoryManager};
+  UniqueTable<dNode, Config::UT_DM_NBUCKET> dUniqueTable{0U, dMemoryManager};
   /**
    * @brief The unique table used for complex numbers
    * @note The table actually only stores real numbers in the interval [0, 1],
@@ -392,7 +387,7 @@ public:
     return r;
   }
 
-  dEdge makeZeroDensityOperator(QubitCount n) {
+  dEdge makeZeroDensityOperator(const std::size_t n) {
     auto f = dEdge::one;
     for (std::size_t p = 0; p < n; p++) {
       f = makeDDNode(static_cast<Qubit>(p),
@@ -402,7 +397,7 @@ public:
   }
 
   // generate |0...0> with n qubits
-  vEdge makeZeroState(QubitCount n, std::size_t start = 0) {
+  vEdge makeZeroState(const std::size_t n, const std::size_t start = 0) {
     if (n + start > nqubits) {
       throw std::runtime_error{
           "Requested state with " + std::to_string(n + start) +
@@ -417,8 +412,8 @@ public:
     return f;
   }
   // generate computational basis state |i> with n qubits
-  vEdge makeBasisState(QubitCount n, const std::vector<bool>& state,
-                       std::size_t start = 0) {
+  vEdge makeBasisState(const std::size_t n, const std::vector<bool>& state,
+                       const std::size_t start = 0) {
     if (n + start > nqubits) {
       throw std::runtime_error{
           "Requested state with " + std::to_string(n + start) +
@@ -437,8 +432,9 @@ public:
     return f;
   }
   // generate general basis state with n qubits
-  vEdge makeBasisState(QubitCount n, const std::vector<BasisStates>& state,
-                       std::size_t start = 0) {
+  vEdge makeBasisState(const std::size_t n,
+                       const std::vector<BasisStates>& state,
+                       const std::size_t start = 0) {
     if (n + start > nqubits) {
       throw std::runtime_error{
           "Requested state with " + std::to_string(n + start) +
@@ -656,18 +652,19 @@ public:
   }
 
   // build matrix representation for a single gate on an n-qubit circuit
-  mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat, QubitCount n,
-                   Qubit target, std::size_t start = 0) {
+  mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat,
+                   const std::size_t n, const qc::Qubit target,
+                   const std::size_t start = 0) {
     return makeGateDD(mat, n, qc::Controls{}, target, start);
   }
-  mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat, QubitCount n,
-                   const qc::Control& control, Qubit target,
-                   std::size_t start = 0) {
+  mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat,
+                   const std::size_t n, const qc::Control& control,
+                   const qc::Qubit target, const std::size_t start = 0) {
     return makeGateDD(mat, n, qc::Controls{control}, target, start);
   }
-  mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat, QubitCount n,
-                   const qc::Controls& controls, Qubit target,
-                   std::size_t start = 0) {
+  mEdge makeGateDD(const std::array<ComplexValue, NEDGE>& mat,
+                   const std::size_t n, const qc::Controls& controls,
+                   const qc::Qubit target, const std::size_t start = 0) {
     if (n + start > nqubits) {
       throw std::runtime_error{
           "Requested gate with " + std::to_string(n + start) +
@@ -688,33 +685,40 @@ public:
 
     // process lines below target
     auto z = static_cast<Qubit>(start);
-    for (; z < target; z++) {
-      for (auto i1 = 0U; i1 < RADIX; i1++) {
-        for (auto i2 = 0U; i2 < RADIX; i2++) {
+    for (; z < static_cast<Qubit>(target); ++z) {
+      for (auto i1 = 0U; i1 < RADIX; ++i1) {
+        for (auto i2 = 0U; i2 < RADIX; ++i2) {
           auto i = i1 * RADIX + i2;
-          if (it != controls.end() && it->qubit == static_cast<qc::Qubit>(z)) {
+          if (it != controls.end() && it->qubit == z) {
+            auto edges =
+                std::array{mEdge::zero, mEdge::zero, mEdge::zero, mEdge::zero};
             if (it->type == qc::Control::Type::Neg) { // neg. control
-              em[i] = makeDDNode(
-                  z,
-                  std::array{em[i], mEdge::zero, mEdge::zero,
-                             (i1 == i2) ? makeIdent(static_cast<Qubit>(start),
-                                                    static_cast<Qubit>(z - 1))
-                                        : mEdge::zero});
+              edges[0] = em[i];
+              if (i1 == i2) {
+                if (z == 0U) {
+                  edges[3] = mEdge::one;
+                } else {
+                  edges[3] = makeIdent(start, z - 1U);
+                }
+              }
             } else { // pos. control
-              em[i] = makeDDNode(
-                  z,
-                  std::array{(i1 == i2) ? makeIdent(static_cast<Qubit>(start),
-                                                    static_cast<Qubit>(z - 1))
-                                        : mEdge::zero,
-                             mEdge::zero, mEdge::zero, em[i]});
+              edges[3] = em[i];
+              if (i1 == i2) {
+                if (z == 0U) {
+                  edges[0] = mEdge::one;
+                } else {
+                  edges[0] = makeIdent(start, z - 1U);
+                }
+              }
             }
+            em[i] = makeDDNode(z, edges);
           } else { // not connected
             em[i] = makeDDNode(
                 z, std::array{em[i], mEdge::zero, mEdge::zero, em[i]});
           }
         }
       }
-      if (it != controls.end() && it->qubit == static_cast<qc::Qubit>(z)) {
+      if (it != controls.end() && it->qubit == z) {
         ++it;
       }
     }
@@ -728,12 +732,10 @@ public:
       if (it != controls.end() && it->qubit == static_cast<qc::Qubit>(q)) {
         if (it->type == qc::Control::Type::Neg) { // neg. control
           e = makeDDNode(q, std::array{e, mEdge::zero, mEdge::zero,
-                                       makeIdent(static_cast<Qubit>(start),
-                                                 static_cast<Qubit>(q - 1))});
+                                       makeIdent(start, q - 1U)});
         } else { // pos. control
-          e = makeDDNode(q, std::array{makeIdent(static_cast<Qubit>(start),
-                                                 static_cast<Qubit>(q - 1)),
-                                       mEdge::zero, mEdge::zero, e});
+          e = makeDDNode(q, std::array{makeIdent(start, q - 1U), mEdge::zero,
+                                       mEdge::zero, e});
         }
         ++it;
       } else { // not connected
@@ -756,7 +758,7 @@ public:
   **/
   mEdge makeTwoQubitGateDD(
       const std::array<std::array<ComplexValue, NEDGE>, NEDGE>& mat,
-      const QubitCount n, const Qubit target0, const Qubit target1,
+      const std::size_t n, const qc::Qubit target0, const qc::Qubit target1,
       const std::size_t start = 0) {
     // sanity check
     if (n + start > nqubits) {
@@ -834,82 +836,82 @@ public:
     auto e = makeDDNode(z, em0);
 
     // process lines above the larger target (by creating identity structures)
-    for (++z; z < static_cast<Qubit>(n + start); ++z) {
+    for (++z; z < n + start; ++z) {
       e = makeDDNode(z, std::array{e, mEdge::zero, mEdge::zero, e});
     }
 
     return e;
   }
 
-  mEdge makeSWAPDD(const QubitCount n, const Qubit target0, const Qubit target1,
-                   const std::size_t start = 0) {
+  mEdge makeSWAPDD(const std::size_t n, const qc::Qubit target0,
+                   const qc::Qubit target1, const std::size_t start = 0) {
     return makeTwoQubitGateDD(SWAPmat, n, target0, target1, start);
   }
-  mEdge makeSWAPDD(const QubitCount n, const qc::Controls& controls,
-                   const Qubit target0, const Qubit target1,
+  mEdge makeSWAPDD(const std::size_t n, const qc::Controls& controls,
+                   const qc::Qubit target0, const qc::Qubit target1,
                    const std::size_t start = 0) {
     auto c = controls;
-    c.insert(qc::Control{static_cast<qc::Qubit>(target0)});
+    c.insert(qc::Control{target0});
     mEdge e = makeGateDD(Xmat, n, c, target1, start);
-    c.erase(qc::Control{static_cast<qc::Qubit>(target0)});
-    c.insert(qc::Control{static_cast<qc::Qubit>(target1)});
+    c.erase(qc::Control{target0});
+    c.insert(qc::Control{target1});
     e = multiply(e, multiply(makeGateDD(Xmat, n, c, target0, start), e));
     return e;
   }
 
-  mEdge makePeresDD(const QubitCount n, const qc::Controls& controls,
-                    const Qubit target0, const Qubit target1,
+  mEdge makePeresDD(const std::size_t n, const qc::Controls& controls,
+                    const qc::Qubit target0, const qc::Qubit target1,
                     const std::size_t start = 0) {
     auto c = controls;
-    c.insert(qc::Control{static_cast<qc::Qubit>(target1)});
+    c.insert(qc::Control{target1});
     mEdge e = makeGateDD(Xmat, n, c, target0, start);
     e = multiply(makeGateDD(Xmat, n, controls, target1, start), e);
     return e;
   }
 
-  mEdge makePeresdagDD(const QubitCount n, const qc::Controls& controls,
-                       const Qubit target0, const Qubit target1,
+  mEdge makePeresdagDD(const std::size_t n, const qc::Controls& controls,
+                       const qc::Qubit target0, const qc::Qubit target1,
                        const std::size_t start = 0) {
     mEdge e = makeGateDD(Xmat, n, controls, target1, start);
     auto c = controls;
-    c.insert(qc::Control{static_cast<qc::Qubit>(target1)});
+    c.insert(qc::Control{target1});
     e = multiply(makeGateDD(Xmat, n, c, target0, start), e);
     return e;
   }
 
-  mEdge makeiSWAPDD(const QubitCount n, const Qubit target0,
-                    const Qubit target1, const std::size_t start = 0) {
+  mEdge makeiSWAPDD(const std::size_t n, const qc::Qubit target0,
+                    const qc::Qubit target1, const std::size_t start = 0) {
     return makeTwoQubitGateDD(iSWAPmat, n, target0, target1, start);
   }
-  mEdge makeiSWAPDD(const QubitCount n, const qc::Controls& controls,
-                    const Qubit target0, const Qubit target1,
+  mEdge makeiSWAPDD(const std::size_t n, const qc::Controls& controls,
+                    const qc::Qubit target0, const qc::Qubit target1,
                     const std::size_t start = 0) {
     mEdge e = makeGateDD(Smat, n, controls, target1, start);        // S q[1]
     e = multiply(e, makeGateDD(Smat, n, controls, target0, start)); // S q[0]
     e = multiply(e, makeGateDD(Hmat, n, controls, target0, start)); // H q[0]
     auto c = controls;
-    c.insert(qc::Control{static_cast<qc::Qubit>(target0)});
+    c.insert(qc::Control{target0});
     e = multiply(e, makeGateDD(Xmat, n, c, target1, start)); // CX q[0], q[1]
-    c.erase(qc::Control{static_cast<qc::Qubit>(target0)});
-    c.insert(qc::Control{static_cast<qc::Qubit>(target1)});
+    c.erase(qc::Control{target0});
+    c.insert(qc::Control{target1});
     e = multiply(e, makeGateDD(Xmat, n, c, target0, start)); // CX q[1], q[0]
     e = multiply(e, makeGateDD(Hmat, n, controls, target1, start)); // H q[1]
     return e;
   }
 
-  mEdge makeiSWAPinvDD(const QubitCount n, const Qubit target0,
-                       const Qubit target1, const std::size_t start = 0) {
+  mEdge makeiSWAPinvDD(const std::size_t n, const qc::Qubit target0,
+                       const qc::Qubit target1, const std::size_t start = 0) {
     return makeTwoQubitGateDD(iSWAPinvmat, n, target0, target1, start);
   }
-  mEdge makeiSWAPinvDD(const QubitCount n, const qc::Controls& controls,
-                       const Qubit target0, const Qubit target1,
+  mEdge makeiSWAPinvDD(const std::size_t n, const qc::Controls& controls,
+                       const qc::Qubit target0, const qc::Qubit target1,
                        const std::size_t start = 0) {
     mEdge e = makeGateDD(Hmat, n, controls, target1, start); // H q[1]
     auto c = controls;
-    c.insert(qc::Control{static_cast<qc::Qubit>(target1)});
+    c.insert(qc::Control{target1});
     e = multiply(e, makeGateDD(Xmat, n, c, target0, start)); // CX q[1], q[0]
-    c.erase(qc::Control{static_cast<qc::Qubit>(target1)});
-    c.insert(qc::Control{static_cast<qc::Qubit>(target0)});
+    c.erase(qc::Control{target1});
+    c.insert(qc::Control{target0});
     e = multiply(e, makeGateDD(Xmat, n, c, target1, start)); // CX q[0], q[1]
     e = multiply(e, makeGateDD(Hmat, n, controls, target0, start)); // H q[0]
     e = multiply(e,
@@ -919,46 +921,48 @@ public:
     return e;
   }
 
-  mEdge makeDCXDD(const QubitCount n, const Qubit target0, const Qubit target1,
-                  const std::size_t start = 0) {
+  mEdge makeDCXDD(const std::size_t n, const qc::Qubit target0,
+                  const qc::Qubit target1, const std::size_t start = 0) {
     return makeTwoQubitGateDD(DCXmat, n, target0, target1, start);
   }
-  mEdge makeDCXDD(const QubitCount n, const qc::Controls& controls,
-                  const Qubit target0, const Qubit target1,
+  mEdge makeDCXDD(const std::size_t n, const qc::Controls& controls,
+                  const qc::Qubit target0, const qc::Qubit target1,
                   const std::size_t start = 0) {
     auto c = controls;
-    c.insert(qc::Control{static_cast<qc::Qubit>(target0)});
+    c.insert(qc::Control{target0});
     mEdge e = makeGateDD(Xmat, n, c, target1, start);
-    c.erase(qc::Control{static_cast<qc::Qubit>(target0)});
-    c.insert(qc::Control{static_cast<qc::Qubit>(target1)});
+    c.erase(qc::Control{target0});
+    c.insert(qc::Control{target1});
     e = multiply(e, makeGateDD(Xmat, n, c, target0, start));
     return e;
   }
 
-  mEdge makeRZZDD(const QubitCount n, const Qubit target0, const Qubit target1,
-                  const fp theta, const std::size_t start = 0) {
+  mEdge makeRZZDD(const std::size_t n, const qc::Qubit target0,
+                  const qc::Qubit target1, const fp theta,
+                  const std::size_t start = 0) {
     return makeTwoQubitGateDD(RZZmat(theta), n, target0, target1, start);
   }
-  mEdge makeRZZDD(const QubitCount n, const qc::Controls& controls,
-                  const Qubit target0, const Qubit target1, const fp theta,
-                  const std::size_t start = 0) {
+  mEdge makeRZZDD(const std::size_t n, const qc::Controls& controls,
+                  const qc::Qubit target0, const qc::Qubit target1,
+                  const fp theta, const std::size_t start = 0) {
     auto c = controls;
-    c.insert(qc::Control{static_cast<qc::Qubit>(target0)});
+    c.insert(qc::Control{target0});
     auto e = makeGateDD(Xmat, n, c, target1, start);
-    c.erase(qc::Control{static_cast<qc::Qubit>(target0)});
+    c.erase(qc::Control{target0});
     e = multiply(e, makeGateDD(RZmat(theta), n, c, target1, start));
-    c.insert(qc::Control{static_cast<qc::Qubit>(target0)});
+    c.insert(qc::Control{target0});
     e = multiply(e, makeGateDD(Xmat, n, c, target1, start));
     return e;
   }
 
-  mEdge makeRYYDD(const QubitCount n, const Qubit target0, const Qubit target1,
-                  const fp theta, const std::size_t start = 0) {
+  mEdge makeRYYDD(const std::size_t n, const qc::Qubit target0,
+                  const qc::Qubit target1, const fp theta,
+                  const std::size_t start = 0) {
     return makeTwoQubitGateDD(RYYmat(theta), n, target0, target1, start);
   }
-  mEdge makeRYYDD(const QubitCount n, const qc::Controls& controls,
-                  const Qubit target0, const Qubit target1, const fp theta,
-                  const std::size_t start = 0) {
+  mEdge makeRYYDD(const std::size_t n, const qc::Controls& controls,
+                  const qc::Qubit target0, const qc::Qubit target1,
+                  const fp theta, const std::size_t start = 0) {
     // no controls are necessary on the RX gates since they cancel if the
     // controls are 0.
     auto e = makeGateDD(RXmat(PI_2), n, qc::Controls{}, target0, start);
@@ -971,13 +975,14 @@ public:
     return e;
   }
 
-  mEdge makeRXXDD(const QubitCount n, const Qubit target0, const Qubit target1,
-                  const fp theta, const std::size_t start = 0) {
+  mEdge makeRXXDD(const std::size_t n, const qc::Qubit target0,
+                  const qc::Qubit target1, const fp theta,
+                  const std::size_t start = 0) {
     return makeTwoQubitGateDD(RXXmat(theta), n, target0, target1, start);
   }
-  mEdge makeRXXDD(const QubitCount n, const qc::Controls& controls,
-                  const Qubit target0, const Qubit target1, const fp theta,
-                  const std::size_t start = 0) {
+  mEdge makeRXXDD(const std::size_t n, const qc::Controls& controls,
+                  const qc::Qubit target0, const qc::Qubit target1,
+                  const fp theta, const std::size_t start = 0) {
     // no controls are necessary on the H gates since they cancel if the
     // controls are 0.
     auto e = makeGateDD(Hmat, n, qc::Controls{}, target0, start);
@@ -988,13 +993,14 @@ public:
     return e;
   }
 
-  mEdge makeRZXDD(const QubitCount n, const Qubit target0, const Qubit target1,
-                  const fp theta, const std::size_t start = 0) {
+  mEdge makeRZXDD(const std::size_t n, const qc::Qubit target0,
+                  const qc::Qubit target1, const fp theta,
+                  const std::size_t start = 0) {
     return makeTwoQubitGateDD(RZXmat(theta), n, target0, target1, start);
   }
-  mEdge makeRZXDD(const QubitCount n, const qc::Controls& controls,
-                  const Qubit target0, const Qubit target1, const fp theta,
-                  const std::size_t start = 0) {
+  mEdge makeRZXDD(const std::size_t n, const qc::Controls& controls,
+                  const qc::Qubit target0, const qc::Qubit target1,
+                  const fp theta, const std::size_t start = 0) {
     // no controls are necessary on the H gates since they cancel if the
     // controls are 0.
     auto e = makeGateDD(Hmat, n, qc::Controls{}, target1, start);
@@ -1003,12 +1009,12 @@ public:
     return e;
   }
 
-  mEdge makeECRDD(const QubitCount n, const Qubit target0, const Qubit target1,
-                  const std::size_t start = 0) {
+  mEdge makeECRDD(const std::size_t n, const qc::Qubit target0,
+                  const qc::Qubit target1, const std::size_t start = 0) {
     return makeTwoQubitGateDD(ECRmat, n, target0, target1, start);
   }
-  mEdge makeECRDD(const QubitCount n, const qc::Controls& controls,
-                  const Qubit target0, const Qubit target1,
+  mEdge makeECRDD(const std::size_t n, const qc::Controls& controls,
+                  const qc::Qubit target0, const qc::Qubit target1,
                   const std::size_t start = 0) {
     auto e = makeRZXDD(n, controls, target0, target1, -PI_4, start);
     e = multiply(e, makeGateDD(Xmat, n, controls, target0, start));
@@ -1016,14 +1022,14 @@ public:
     return e;
   }
 
-  mEdge makeXXMinusYYDD(const QubitCount n, const Qubit target0,
-                        const Qubit target1, const fp theta, const fp beta = 0.,
-                        const std::size_t start = 0) {
+  mEdge makeXXMinusYYDD(const std::size_t n, const qc::Qubit target0,
+                        const qc::Qubit target1, const fp theta,
+                        const fp beta = 0., const std::size_t start = 0) {
     return makeTwoQubitGateDD(XXMinusYYmat(theta, beta), n, target0, target1,
                               start);
   }
-  mEdge makeXXMinusYYDD(const QubitCount n, const qc::Controls& controls,
-                        const Qubit target0, const Qubit target1,
+  mEdge makeXXMinusYYDD(const std::size_t n, const qc::Controls& controls,
+                        const qc::Qubit target0, const qc::Qubit target1,
                         const fp theta, const fp beta = 0.,
                         const std::size_t start = 0) {
     auto e = makeGateDD(RZmat(-beta), n, qc::Controls{}, target1, start);
@@ -1032,18 +1038,14 @@ public:
     e = multiply(e, makeGateDD(SXmat, n, qc::Controls{}, target0, start));
     e = multiply(e, makeGateDD(RZmat(PI_2), n, qc::Controls{}, target0, start));
     e = multiply(e, makeGateDD(Smat, n, qc::Controls{}, target1, start));
-    e = multiply(e, makeGateDD(Xmat, n,
-                               qc::Control{static_cast<qc::Qubit>(target0)},
-                               target1, start));
+    e = multiply(e, makeGateDD(Xmat, n, qc::Control{target0}, target1, start));
     // only the following two gates need to be controlled by the controls since
     // the other gates cancel if the controls are 0.
     e = multiply(e,
                  makeGateDD(RYmat(-theta / 2.), n, controls, target0, start));
     e = multiply(e, makeGateDD(RYmat(theta / 2.), n, controls, target1, start));
 
-    e = multiply(e, makeGateDD(Xmat, n,
-                               qc::Control{static_cast<qc::Qubit>(target0)},
-                               target1, start));
+    e = multiply(e, makeGateDD(Xmat, n, qc::Control{target0}, target1, start));
     e = multiply(e, makeGateDD(Sdagmat, n, qc::Controls{}, target1, start));
     e = multiply(e,
                  makeGateDD(RZmat(-PI_2), n, qc::Controls{}, target0, start));
@@ -1053,32 +1055,29 @@ public:
     return e;
   }
 
-  mEdge makeXXPlusYYDD(const QubitCount n, const Qubit target0,
-                       const Qubit target1, const fp theta, const fp beta = 0.,
-                       const std::size_t start = 0) {
+  mEdge makeXXPlusYYDD(const std::size_t n, const qc::Qubit target0,
+                       const qc::Qubit target1, const fp theta,
+                       const fp beta = 0., const std::size_t start = 0) {
     return makeTwoQubitGateDD(XXPlusYYmat(theta, beta), n, target0, target1,
                               start);
   }
-  mEdge makeXXPlusYYDD(const QubitCount n, const qc::Controls& controls,
-                       const Qubit target0, const Qubit target1, const fp theta,
-                       const fp beta = 0., const std::size_t start = 0) {
+  mEdge makeXXPlusYYDD(const std::size_t n, const qc::Controls& controls,
+                       const qc::Qubit target0, const qc::Qubit target1,
+                       const fp theta, const fp beta = 0.,
+                       const std::size_t start = 0) {
     auto e = makeGateDD(RZmat(beta), n, qc::Controls{}, target1, start);
     e = multiply(e,
                  makeGateDD(RZmat(-PI_2), n, qc::Controls{}, target0, start));
     e = multiply(e, makeGateDD(SXmat, n, qc::Controls{}, target0, start));
     e = multiply(e, makeGateDD(RZmat(PI_2), n, qc::Controls{}, target0, start));
     e = multiply(e, makeGateDD(Smat, n, qc::Controls{}, target1, start));
-    e = multiply(e, makeGateDD(Xmat, n,
-                               qc::Control{static_cast<qc::Qubit>(target0)},
-                               target1, start));
+    e = multiply(e, makeGateDD(Xmat, n, qc::Control{target0}, target1, start));
     // only the following two gates need to be controlled by the controls since
     // the other gates cancel if the controls are 0.
     e = multiply(e, makeGateDD(RYmat(theta / 2.), n, controls, target0, start));
     e = multiply(e, makeGateDD(RYmat(theta / 2.), n, controls, target1, start));
 
-    e = multiply(e, makeGateDD(Xmat, n,
-                               qc::Control{static_cast<qc::Qubit>(target0)},
-                               target1, start));
+    e = multiply(e, makeGateDD(Xmat, n, qc::Control{target0}, target1, start));
     e = multiply(e, makeGateDD(Sdagmat, n, qc::Controls{}, target1, start));
     e = multiply(e,
                  makeGateDD(RZmat(-PI_2), n, qc::Controls{}, target0, start));
@@ -1092,7 +1091,7 @@ public:
 private:
   // check whether node represents a symmetric matrix or the identity
   void checkSpecialMatrices(mNode* p) {
-    if (p->v == -1) {
+    if (mNode::isTerminal(p)) {
       return;
     }
 
@@ -1100,7 +1099,9 @@ private:
     p->setSymmetric(false);
 
     // check if matrix is symmetric
-    if (!p->e[0].p->isSymmetric() || !p->e[3].p->isSymmetric()) {
+    const auto& e0 = p->e[0];
+    const auto& e3 = p->e[3];
+    if (!mNode::isSymmetric(e0.p) || !mNode::isSymmetric(e3.p)) {
       return;
     }
     if (transpose(p->e[1]) != p->e[2]) {
@@ -1109,9 +1110,11 @@ private:
     p->setSymmetric(true);
 
     // check if matrix resembles identity
-    if (!(p->e[0].p->isIdentity()) || !p->e[1].w.exactlyZero() ||
-        !p->e[2].w.exactlyZero() || !p->e[0].w.exactlyOne() ||
-        !p->e[3].w.exactlyOne() || !(p->e[3].p->isIdentity())) {
+    const auto& e1 = p->e[1];
+    const auto& e2 = p->e[2];
+    if (!mNode::isIdentity(e0.p) || !e1.w.exactlyZero() ||
+        !e2.w.exactlyZero() || !e0.w.exactlyOne() || !e3.w.exactlyOne() ||
+        !mNode::isIdentity(e3.p)) {
       return;
     }
     p->setIdentity(true);
@@ -1120,7 +1123,7 @@ private:
   vEdge makeStateFromVector(const CVec::const_iterator& begin,
                             const CVec::const_iterator& end,
                             const Qubit level) {
-    if (level == 0) {
+    if (level == 0U) {
       assert(std::distance(begin, end) == 2);
       const auto& zeroWeight = cn.getCached(*begin);
       const auto& oneWeight = cn.getCached(*std::next(begin));
@@ -1147,7 +1150,6 @@ private:
   @param colStart The starting column of the quadrant being processed.
   @param colEnd The ending column of the quadrant being processed.
   @return An mEdge representing the root node of the created DD.
-  @throw std::invalid_argument If level is negative.
   @details This function recursively breaks down the matrix into quadrants until
   each quadrant has only one element. At each level of recursion, four new edges
   are created, one for each quadrant of the matrix. The four resulting decision
@@ -1161,10 +1163,18 @@ private:
                          const std::size_t rowStart, const std::size_t rowEnd,
                          const std::size_t colStart, const std::size_t colEnd) {
     // base case
-    if (level == -1) {
-      assert(rowEnd - rowStart == 1);
-      assert(colEnd - colStart == 1);
-      return {mNode::getTerminal(), cn.getCached(matrix[rowStart][colStart])};
+    if (level == 0U) {
+      assert(rowEnd - rowStart == 2);
+      assert(colEnd - colStart == 2);
+      const auto w0 = cn.getCached(matrix[rowStart][colStart]);
+      const auto e0 = mEdge{mNode::getTerminal(), w0};
+      const auto w1 = cn.getCached(matrix[rowStart + 1][colStart]);
+      const auto e1 = mEdge{mNode::getTerminal(), w1};
+      const auto w2 = cn.getCached(matrix[rowStart][colStart + 1]);
+      const auto e2 = mEdge{mNode::getTerminal(), w2};
+      const auto w3 = cn.getCached(matrix[rowStart + 1][colStart + 1]);
+      const auto e3 = mEdge{mNode::getTerminal(), w3};
+      return makeDDNode<mNode>(0U, {e0, e1, e2, e3}, true);
     }
 
     // recursively call the function on all quadrants
@@ -1188,9 +1198,9 @@ public:
   // not recreated if it already exists.
   template <class Node>
   Edge<Node> makeDDNode(
-      Qubit var,
+      const Qubit var,
       const std::array<Edge<Node>, std::tuple_size_v<decltype(Node::e)>>& edges,
-      bool cached = false,
+      const bool cached = false,
       [[maybe_unused]] const bool generateDensityMatrix = false) {
     auto& memoryManager = getMemoryManager<Node>();
     Edge<Node> e{memoryManager.get(), Complex::one};
@@ -1208,17 +1218,17 @@ public:
     for ([[maybe_unused]] const auto& edge : edges) {
       // an error here indicates that cached nodes are assigned multiple times.
       // Check if garbage collect correctly resets the cache tables!
-      assert(edge.p->v == var - 1 || edge.isTerminal());
+      assert(edge.isTerminal() || edge.p->v == var - 1);
     }
 
     // normalize it
     e = normalize(e, cached);
-    assert(e.p->v == var || e.isTerminal());
+    assert(e.isTerminal() || e.p->v == var);
 
     // look it up in the unique tables
     auto& uniqueTable = getUniqueTable<Node>();
     auto l = uniqueTable.lookup(e, false);
-    assert(l.p->v == var || l.isTerminal());
+    assert(l.isTerminal() || l.p->v == var);
 
     // set specific node properties for matrices
     if constexpr (std::is_same_v<Node, mNode>) {
@@ -1230,16 +1240,18 @@ public:
   }
 
   template <class Node>
-  Edge<Node> deleteEdge(const Edge<Node>& e, dd::Qubit v, std::size_t edgeIdx) {
+  Edge<Node> deleteEdge(const Edge<Node>& e, const Qubit v,
+                        const std::size_t edgeIdx) {
     std::unordered_map<Node*, Edge<Node>> nodes{};
     return deleteEdge(e, v, edgeIdx, nodes);
   }
 
 private:
   template <class Node>
-  Edge<Node> deleteEdge(const Edge<Node>& e, dd::Qubit v, std::size_t edgeIdx,
+  Edge<Node> deleteEdge(const Edge<Node>& e, const Qubit v,
+                        const std::size_t edgeIdx,
                         std::unordered_map<Node*, Edge<Node>>& nodes) {
-    if (e.p == nullptr || e.isTerminal()) {
+    if (e.isTerminal()) {
       return e;
     }
 
@@ -1303,7 +1315,7 @@ public:
   /// Measurements from state decision diagrams
   ///
   std::string measureAll(vEdge& rootEdge, const bool collapse,
-                         std::mt19937_64& mt, fp epsilon = 0.001) {
+                         std::mt19937_64& mt, const fp epsilon = 0.001) {
     if (std::abs(ComplexNumbers::mag2(rootEdge.w) - 1.0) > epsilon) {
       if (rootEdge.w.approximatelyZero()) {
         throw std::runtime_error(
@@ -1314,14 +1326,18 @@ public:
                 << ComplexNumbers::mag2(rootEdge.w) << ", but should be 1!\n";
     }
 
+    if (rootEdge.isTerminal()) {
+      return "";
+    }
+
     vEdge cur = rootEdge;
-    const auto numberOfQubits = static_cast<QubitCount>(rootEdge.p->v + 1);
+    const auto numberOfQubits = static_cast<std::size_t>(rootEdge.p->v) + 1U;
 
     std::string result(numberOfQubits, '0');
 
     std::uniform_real_distribution<fp> dist(0.0, 1.0L);
 
-    for (Qubit i = rootEdge.p->v; i >= 0; --i) {
+    for (auto i = numberOfQubits; i > 0; --i) {
       fp p0 = ComplexNumbers::mag2(cur.p->e.at(0).w);
       const fp p1 = ComplexNumbers::mag2(cur.p->e.at(1).w);
       const fp tmp = p0 + p1;
@@ -1336,7 +1352,7 @@ public:
       if (threshold < p0) {
         cur = cur.p->e.at(0);
       } else {
-        result[static_cast<std::size_t>(cur.p->v)] = '1';
+        result[cur.p->v] = '1';
         cur = cur.p->e.at(1);
       }
     }
@@ -1347,15 +1363,15 @@ public:
       vEdge e = vEdge::one;
       std::array<vEdge, 2> edges{};
 
-      for (Qubit p = 0; p < numberOfQubits; p++) {
-        if (result[static_cast<std::size_t>(p)] == '0') {
+      for (std::size_t p = 0U; p < numberOfQubits; ++p) {
+        if (result[p] == '0') {
           edges[0] = e;
           edges[1] = vEdge::zero;
         } else {
           edges[0] = vEdge::zero;
           edges[1] = e;
         }
-        e = makeDDNode(p, edges, false);
+        e = makeDDNode(static_cast<Qubit>(p), edges, false);
       }
       incRef(e);
       rootEdge = e;
@@ -1367,15 +1383,15 @@ public:
 
 private:
   double assignProbabilities(const vEdge& edge,
-                             std::unordered_map<vNode*, fp>& probs) {
+                             std::unordered_map<const vNode*, fp>& probs) {
     auto it = probs.find(edge.p);
     if (it != probs.end()) {
       return ComplexNumbers::mag2(edge.w) * it->second;
     }
     double sum{1};
     if (!edge.isTerminal()) {
-      sum = assignProbabilities(edge.p->e.at(0), probs) +
-            assignProbabilities(edge.p->e.at(1), probs);
+      sum = assignProbabilities(edge.p->e[0], probs) +
+            assignProbabilities(edge.p->e[1], probs);
     }
 
     probs.insert({edge.p, sum});
@@ -1387,40 +1403,42 @@ public:
   std::pair<dd::fp, dd::fp>
   determineMeasurementProbabilities(const vEdge& rootEdge, const Qubit index,
                                     const bool assumeProbabilityNormalization) {
-    std::map<vNode*, fp> probsMone;
-    std::set<vNode*> visited;
-    std::queue<vNode*> q;
+    std::map<const vNode*, fp> probsMone;
+    std::set<const vNode*> visited;
+    std::queue<const vNode*> q;
 
     probsMone[rootEdge.p] = ComplexNumbers::mag2(rootEdge.w);
     visited.insert(rootEdge.p);
     q.push(rootEdge.p);
 
     while (q.front()->v != index) {
-      vNode* ptr = q.front();
+      const auto* ptr = q.front();
       q.pop();
       const fp prob = probsMone[ptr];
 
-      if (!ptr->e.at(0).w.approximatelyZero()) {
-        const fp tmp1 = prob * ComplexNumbers::mag2(ptr->e.at(0).w);
+      const auto& s0 = ptr->e[0];
+      if (!s0.w.approximatelyZero()) {
+        const fp tmp1 = prob * ComplexNumbers::mag2(s0.w);
 
-        if (visited.find(ptr->e.at(0).p) != visited.end()) {
-          probsMone[ptr->e.at(0).p] = probsMone[ptr->e.at(0).p] + tmp1;
+        if (visited.find(s0.p) != visited.end()) {
+          probsMone[s0.p] = probsMone[s0.p] + tmp1;
         } else {
-          probsMone[ptr->e.at(0).p] = tmp1;
-          visited.insert(ptr->e.at(0).p);
-          q.push(ptr->e.at(0).p);
+          probsMone[s0.p] = tmp1;
+          visited.insert(s0.p);
+          q.push(s0.p);
         }
       }
 
-      if (!ptr->e.at(1).w.approximatelyZero()) {
-        const fp tmp1 = prob * ComplexNumbers::mag2(ptr->e.at(1).w);
+      const auto& s1 = ptr->e[1];
+      if (!s1.w.approximatelyZero()) {
+        const fp tmp1 = prob * ComplexNumbers::mag2(s1.w);
 
-        if (visited.find(ptr->e.at(1).p) != visited.end()) {
-          probsMone[ptr->e.at(1).p] = probsMone[ptr->e.at(1).p] + tmp1;
+        if (visited.find(s1.p) != visited.end()) {
+          probsMone[s1.p] = probsMone[s1.p] + tmp1;
         } else {
-          probsMone[ptr->e.at(1).p] = tmp1;
-          visited.insert(ptr->e.at(1).p);
-          q.push(ptr->e.at(1).p);
+          probsMone[s1.p] = tmp1;
+          visited.insert(s1.p);
+          q.push(s1.p);
         }
       }
     }
@@ -1430,33 +1448,32 @@ public:
 
     if (assumeProbabilityNormalization) {
       while (!q.empty()) {
-        vNode* ptr = q.front();
+        const auto* ptr = q.front();
         q.pop();
-
-        if (!ptr->e.at(0).w.approximatelyZero()) {
-          pzero += probsMone[ptr] * ComplexNumbers::mag2(ptr->e.at(0).w);
+        const auto& s0 = ptr->e[0];
+        if (!s0.w.approximatelyZero()) {
+          pzero += probsMone[ptr] * ComplexNumbers::mag2(s0.w);
         }
-
-        if (!ptr->e.at(1).w.approximatelyZero()) {
-          pone += probsMone[ptr] * ComplexNumbers::mag2(ptr->e.at(1).w);
+        const auto& s1 = ptr->e[1];
+        if (!s1.w.approximatelyZero()) {
+          pone += probsMone[ptr] * ComplexNumbers::mag2(s1.w);
         }
       }
     } else {
-      std::unordered_map<vNode*, fp> probs;
+      std::unordered_map<const vNode*, fp> probs;
       assignProbabilities(rootEdge, probs);
 
       while (!q.empty()) {
-        vNode* ptr = q.front();
+        const auto* ptr = q.front();
         q.pop();
 
-        if (!ptr->e.at(0).w.approximatelyZero()) {
-          pzero += probsMone[ptr] * probs[ptr->e.at(0).p] *
-                   ComplexNumbers::mag2(ptr->e.at(0).w);
+        const auto& s0 = ptr->e[0];
+        if (!s0.w.approximatelyZero()) {
+          pzero += probsMone[ptr] * probs[s0.p] * ComplexNumbers::mag2(s0.w);
         }
-
-        if (!ptr->e.at(1).w.approximatelyZero()) {
-          pone += probsMone[ptr] * probs[ptr->e.at(1).p] *
-                  ComplexNumbers::mag2(ptr->e.at(1).w);
+        const auto& s1 = ptr->e[1];
+        if (!s1.w.approximatelyZero()) {
+          pone += probsMone[ptr] * probs[s1.p] * ComplexNumbers::mag2(s1.w);
         }
       }
     }
@@ -1522,8 +1539,7 @@ public:
     }
 
     const auto measurementGate =
-        makeGateDD(measurementMatrix,
-                   static_cast<dd::QubitCount>(rootEdge.p->v + 1), index);
+        makeGateDD(measurementMatrix, rootEdge.p->v + 1U, index);
 
     vEdge e = multiply(measurementGate, rootEdge);
 
@@ -1572,13 +1588,6 @@ public:
 
   template <class Node>
   Edge<Node> add2(const Edge<Node>& x, const Edge<Node>& y) {
-    if (x.p == nullptr) {
-      return y;
-    }
-    if (y.p == nullptr) {
-      return x;
-    }
-
     if (x.w.exactlyZero()) {
       if (y.w.exactlyZero()) {
         return Edge<Node>::zero;
@@ -1600,9 +1609,7 @@ public:
 
     auto& computeTable = getAddComputeTable<Node>();
     auto r = computeTable.lookup({x.p, x.w}, {y.p, y.w});
-    //           if (r.p != nullptr && false) { // activate for debugging
-    //           caching only
-    if (r.p != nullptr) {
+    if (!Node::isTerminal(r.p)) {
       if (r.w.approximatelyZero()) {
         return Edge<Node>::zero;
       }
@@ -1625,8 +1632,8 @@ public:
         }
       } else {
         e1 = x;
-        if (y.p->e[i].p == nullptr) {
-          e1 = {nullptr, Complex::zero};
+        if (y.p->e[i].isTerminal()) {
+          e1 = Edge<Node>::zero;
         }
       }
       Edge<Node> e2{};
@@ -1638,8 +1645,8 @@ public:
         }
       } else {
         e2 = y;
-        if (x.p->e[i].p == nullptr) {
-          e2 = {nullptr, Complex::zero};
+        if (x.p->e[i].isTerminal()) {
+          e2 = Edge<Node>::zero;
         }
       }
 
@@ -1662,11 +1669,6 @@ public:
 
     auto e = makeDDNode(w, edge, true);
 
-    //           if (r.p != nullptr && e.p != r.p){ // activate for debugging
-    //           caching only
-    //               std::cout << "Caching error detected in add" << std::endl;
-    //           }
-
     computeTable.insert({x.p, x.w}, {y.p, y.w}, {e.p, e.w});
     return e;
   }
@@ -1680,13 +1682,13 @@ public:
       conjugateMatrixTranspose{};
 
   mEdge transpose(const mEdge& a) {
-    if (a.p == nullptr || a.isTerminal() || a.p->isSymmetric()) {
+    if (a.isTerminal() || a.p->isSymmetric()) {
       return a;
     }
 
     // check in compute table
     auto r = matrixTranspose.lookup(a);
-    if (r.p != nullptr) {
+    if (!r.isTerminal()) {
       return r;
     }
 
@@ -1707,18 +1709,13 @@ public:
     return r;
   }
   mEdge conjugateTranspose(const mEdge& a) {
-    if (a.p == nullptr) {
-      return a;
-    }
     if (a.isTerminal()) { // terminal case
-      auto r = a;
-      r.w = ComplexNumbers::conj(a.w);
-      return r;
+      return {a.p, ComplexNumbers::conj(a.w)};
     }
 
     // check if in compute table
     auto r = conjugateMatrixTranspose.lookup(a);
-    if (r.p != nullptr) {
+    if (!r.isTerminal()) {
       return r;
     }
 
@@ -1762,7 +1759,7 @@ public:
   }
 
   dEdge applyOperationToDensity(dEdge& e, const mEdge& operation,
-                                bool generateDensityMatrix = false) {
+                                const bool generateDensityMatrix = false) {
     [[maybe_unused]] const auto before = cn.cacheCount();
     auto tmp0 = conjugateTranspose(operation);
     auto tmp1 = multiply(e, densityFromMatrixEdge(tmp0), 0, false);
@@ -1781,12 +1778,12 @@ public:
   }
 
   template <class LeftOperand, class RightOperand>
-  RightOperand multiply(const LeftOperand& x, const RightOperand& y,
-                        dd::Qubit start = 0,
-                        [[maybe_unused]] bool generateDensityMatrix = false) {
+  RightOperand
+  multiply(const LeftOperand& x, const RightOperand& y, const Qubit start = 0,
+           [[maybe_unused]] const bool generateDensityMatrix = false) {
     [[maybe_unused]] const auto before = cn.cacheCount();
 
-    Qubit var = -1;
+    Qubit var{};
     RightOperand e;
 
     if constexpr (std::is_same_v<LeftOperand, dEdge>) {
@@ -1795,25 +1792,19 @@ public:
       dEdge::applyDmChangesToEdges(xCopy, yCopy);
 
       if (!xCopy.isTerminal()) {
-        assert(xCopy.p != nullptr);
         var = xCopy.p->v;
       }
       if (!y.isTerminal() && yCopy.p->v > var) {
-        assert(xCopy.p != nullptr);
         var = yCopy.p->v;
       }
 
       e = multiply2(xCopy, yCopy, var, start, generateDensityMatrix);
-
       dEdge::revertDmChangesToEdges(xCopy, yCopy);
-
     } else {
       if (!x.isTerminal()) {
-        assert(x.p != nullptr);
         var = x.p->v;
       }
       if (!y.isTerminal() && (y.p->v) > var) {
-        assert(y.p != nullptr);
         var = y.p->v;
       }
       e = multiply2(x, y, var, start);
@@ -1831,24 +1822,17 @@ private:
   template <class LeftOperandNode, class RightOperandNode>
   Edge<RightOperandNode>
   multiply2(const Edge<LeftOperandNode>& x, const Edge<RightOperandNode>& y,
-            Qubit var, Qubit start = 0,
-            [[maybe_unused]] bool generateDensityMatrix = false) {
+            const Qubit var, const Qubit start = 0,
+            [[maybe_unused]] const bool generateDensityMatrix = false) {
     using LEdge = Edge<LeftOperandNode>;
     using REdge = Edge<RightOperandNode>;
     using ResultEdge = Edge<RightOperandNode>;
-
-    if (x.p == nullptr) {
-      return {nullptr, Complex::zero};
-    }
-    if (y.p == nullptr) {
-      return y;
-    }
 
     if (x.w.exactlyZero() || y.w.exactlyZero()) {
       return ResultEdge::zero;
     }
 
-    if (var == start - 1) {
+    if (x.isTerminal() && y.isTerminal()) {
       return ResultEdge::terminal(cn.mulCached(x.w, y.w));
     }
 
@@ -1858,9 +1842,7 @@ private:
     auto& computeTable =
         getMultiplicationComputeTable<LeftOperandNode, RightOperandNode>();
     auto r = computeTable.lookup(xCopy, yCopy, generateDensityMatrix);
-    //            if (r.p != nullptr && false) { // activate for debugging
-    //            caching only
-    if (r.p != nullptr) {
+    if (!RightOperandNode::isTerminal(r.p)) {
       if (r.w.approximatelyZero()) {
         return ResultEdge::zero;
       }
@@ -1875,7 +1857,6 @@ private:
     }
 
     constexpr std::size_t n = std::tuple_size_v<decltype(y.p->e)>;
-
     ResultEdge e{};
     if constexpr (std::is_same_v<RightOperandNode, mCachedEdge>) {
       // This branch is only taken for matrices
@@ -1994,12 +1975,6 @@ private:
       }
     }
     e = makeDDNode(var, edge, true, generateDensityMatrix);
-
-    //            if (r.p != nullptr && e.p != r.p) { // activate for debugging
-    //            caching
-    //                std::cout << "Caching error detected in mul" << std::endl;
-    //            }
-
     computeTable.insert(xCopy, yCopy, {e.p, e.w});
 
     if (!e.w.exactlyZero()) {
@@ -2031,7 +2006,7 @@ public:
       @return a complex number representing the scalar product of the DDs
   **/
   ComplexValue innerProduct(const vEdge& x, const vEdge& y) {
-    if (x.p == nullptr || y.p == nullptr || x.w.approximatelyZero() ||
+    if (x.isTerminal() || y.isTerminal() || x.w.approximatelyZero() ||
         y.w.approximatelyZero()) { // the 0 case
       return {0, 0};
     }
@@ -2045,7 +2020,7 @@ public:
     // Overall normalization factor needs to be conjugated
     // before input into recursive private function
     auto xCopy = vEdge{x.p, ComplexNumbers::conj(x.w)};
-    const ComplexValue ip = innerProduct(xCopy, y, static_cast<Qubit>(w + 1));
+    const ComplexValue ip = innerProduct(xCopy, y, w + 1U);
 
     [[maybe_unused]] const auto after = cn.cacheCount();
     assert(after == before);
@@ -2091,8 +2066,7 @@ public:
           fidelityOfMeasurementOutcomesRecursive(e.p->e[1], probs, rightIdx);
     }
 
-    const dd::fp fidelity = topw * (leftContribution + rightContribution);
-    return fidelity;
+    return topw * (leftContribution + rightContribution);
   }
 
 private:
@@ -2107,8 +2081,7 @@ private:
   decreases each time to traverse the DDs.
   **/
   ComplexValue innerProduct(const vEdge& x, const vEdge& y, Qubit var) {
-    if (x.p == nullptr || y.p == nullptr || x.w.approximatelyZero() ||
-        y.w.approximatelyZero()) { // the 0 case
+    if (x.w.approximatelyZero() || y.w.approximatelyZero()) { // the 0 case
       return {0.0, 0.0};
     }
 
@@ -2121,15 +2094,14 @@ private:
     auto xCopy = vEdge{x.p, Complex::one};
     auto yCopy = vEdge{y.p, Complex::one};
     auto r = vectorInnerProduct.lookup(xCopy, yCopy);
-    if (r.p != nullptr) {
+    if (!vNode::isTerminal(r.p)) {
       auto c = cn.getTemporary(r.w);
       ComplexNumbers::mul(c, c, x.w);
       ComplexNumbers::mul(c, c, y.w);
-      return {RealNumber::val(c.r), RealNumber::val(c.i)};
+      return {c.r->value, c.i->value};
     }
 
-    auto w = static_cast<Qubit>(var - 1);
-
+    auto w = static_cast<Qubit>(var - 1U);
     ComplexValue sum{0.0, 0.0};
     // Iterates through edge weights recursively until terminal
     for (auto i = 0U; i < RADIX; i++) {
@@ -2150,14 +2122,13 @@ private:
       sum.r += cv.r;
       sum.i += cv.i;
     }
-    r.p = vNode::getTerminal();
     r.w = sum;
 
     vectorInnerProduct.insert(xCopy, yCopy, r);
     auto c = cn.getTemporary(sum);
     ComplexNumbers::mul(c, c, x.w);
     ComplexNumbers::mul(c, c, y.w);
-    return {RealNumber::val(c.r), RealNumber::val(c.i)};
+    return {c.r->value, c.i->value};
   }
 
 public:
@@ -2177,7 +2148,7 @@ public:
   memory.
   **/
   fp expectationValue(const mEdge& x, const vEdge& y) {
-    assert(x.p != nullptr && y.p != nullptr);
+    assert(!x.isTerminal() && !y.isTerminal());
     if (x.p->v != y.p->v) {
       throw std::invalid_argument(
           "Observable and state must act on the same number of qubits to "
@@ -2212,7 +2183,7 @@ public:
   }
 
   template <class Edge>
-  Edge kronecker(const Edge& x, const Edge& y, bool incIdx = true) {
+  Edge kronecker(const Edge& x, const Edge& y, const bool incIdx = true) {
     if constexpr (std::is_same_v<Edge, dEdge>) {
       throw std::invalid_argument(
           "Kronecker is currently not supported for density matrices");
@@ -2226,18 +2197,16 @@ public:
 
   // extent the DD pointed to by `e` with `h` identities on top and `l`
   // identities at the bottom
-  mEdge extend(const mEdge& e, Qubit h, Qubit l = 0) {
-    auto f =
-        (l > 0) ? kronecker(e, makeIdent(static_cast<dd::QubitCount>(l))) : e;
-    auto g =
-        (h > 0) ? kronecker(makeIdent(static_cast<dd::QubitCount>(h)), f) : f;
+  mEdge extend(const mEdge& e, const Qubit h, const Qubit l = 0) {
+    auto f = (l > 0) ? kronecker(e, makeIdent(l)) : e;
+    auto g = (h > 0) ? kronecker(makeIdent(h), f) : f;
     return g;
   }
 
 private:
   template <class Node>
   Edge<Node> kronecker2(const Edge<Node>& x, const Edge<Node>& y,
-                        bool incIdx = true) {
+                        const bool incIdx = true) {
     if (x.w.approximatelyZero() || y.w.approximatelyZero()) {
       return Edge<Node>::zero;
     }
@@ -2248,7 +2217,7 @@ private:
 
     auto& computeTable = getKroneckerComputeTable<Node>();
     auto r = computeTable.lookup(x, y);
-    if (r.p != nullptr) {
+    if (!Node::isTerminal(r.p)) {
       if (r.w.approximatelyZero()) {
         return Edge<Node>::zero;
       }
@@ -2263,7 +2232,7 @@ private:
         auto e = makeDDNode(
             idx, std::array{y, Edge<Node>::zero, Edge<Node>::zero, y});
         for (auto i = 0; i < x.p->v; ++i) {
-          idx = incIdx ? static_cast<Qubit>(e.p->v + 1) : e.p->v;
+          idx = incIdx ? (e.p->v + 1) : e.p->v;
           e = makeDDNode(idx,
                          std::array{e, Edge<Node>::zero, Edge<Node>::zero, e});
         }
@@ -2279,8 +2248,8 @@ private:
       edge[i] = kronecker2(x.p->e[i], y, incIdx);
     }
 
-    auto idx = incIdx ? static_cast<Qubit>(y.p->v + x.p->v + 1) : x.p->v;
-    auto e = makeDDNode(idx, edge, true);
+    auto idx = incIdx ? (y.p->v + x.p->v + 1) : x.p->v;
+    auto e = makeDDNode(static_cast<Qubit>(idx), edge, true);
     ComplexNumbers::mul(e.w, e.w, x.w);
     computeTable.insert(x, y, {e.p, e.w});
     return e;
@@ -2298,14 +2267,14 @@ public:
     return result;
   }
   ComplexValue trace(const mEdge& a) {
-    auto eliminate = std::vector<bool>(nqubits, true);
+    const auto eliminate = std::vector<bool>(nqubits, true);
     [[maybe_unused]] const auto before = cn.cacheCount();
     const auto res = partialTrace(a, eliminate);
     [[maybe_unused]] const auto after = cn.cacheCount();
     assert(before == after);
     return {RealNumber::val(res.w.r), RealNumber::val(res.w.i)};
   }
-  bool isCloseToIdentity(const mEdge& m, dd::fp tol = 1e-10) {
+  bool isCloseToIdentity(const mEdge& m, const dd::fp tol = 1e-10) {
     std::unordered_set<decltype(m.p)> visited{};
     visited.reserve(mUniqueTable.getStats().activeEntryCount);
     return isCloseToIdentityRecursive(m, visited, tol);
@@ -2319,28 +2288,21 @@ private:
       return mEdge::zero;
     }
 
-    if (std::none_of(eliminate.begin(), eliminate.end(),
-                     [](bool v) { return v; })) {
+    if (a.isTerminal() || std::none_of(eliminate.begin(), eliminate.end(),
+                                       [](bool v) { return v; })) {
       return a;
     }
-    auto v = a.p->v;
-    // Base case
-    if (v == -1) {
-      if (a.isTerminal()) {
-        return a;
-      }
-      throw std::runtime_error("Expected terminal node in trace.");
-    }
 
-    if (eliminate[static_cast<std::size_t>(v)]) {
-      auto elims = alreadyEliminated + 1;
+    const auto v = a.p->v;
+    if (eliminate[v]) {
+      const auto elims = alreadyEliminated + 1;
       auto r = mEdge::zero;
 
-      auto t0 = trace(a.p->e[0], eliminate, elims);
+      const auto t0 = trace(a.p->e[0], eliminate, elims);
       r = add2(r, t0);
       auto r1 = r;
 
-      auto t1 = trace(a.p->e[3], eliminate, elims);
+      const auto t1 = trace(a.p->e[3], eliminate, elims);
       r = add2(r, t1);
       auto r2 = r;
 
@@ -2364,13 +2326,12 @@ private:
         [this, &eliminate, &alreadyEliminated](const mEdge& e) -> mEdge {
           return trace(e, eliminate, alreadyEliminated);
         });
-    auto adjustedV =
+    const auto adjustedV =
         static_cast<Qubit>(static_cast<std::size_t>(a.p->v) -
                            (static_cast<std::size_t>(std::count(
                                 eliminate.begin(), eliminate.end(), true)) -
                             alreadyEliminated));
     auto r = makeDDNode(adjustedV, edge);
-
     if (r.w.exactlyOne()) {
       r.w = a.w;
     } else {
@@ -2381,14 +2342,14 @@ private:
 
   bool isCloseToIdentityRecursive(const mEdge& m,
                                   std::unordered_set<decltype(m.p)>& visited,
-                                  dd::fp tol) {
+                                  const dd::fp tol) {
     // immediately return if this node has already been visited
     if (visited.find(m.p) != visited.end()) {
       return true;
     }
 
     // immediately return of this node is identical to the identity
-    if (m.p->isIdentity()) {
+    if (m.isTerminal() || m.p->isIdentity()) {
       return true;
     }
 
@@ -2446,42 +2407,42 @@ public:
   /// Identity matrices
   ///
   // create n-qubit identity DD. makeIdent(n) === makeIdent(0, n-1)
-  mEdge makeIdent(QubitCount n) {
-    return makeIdent(0, static_cast<Qubit>(n - 1));
+  mEdge makeIdent(const std::size_t n) {
+    if (n == 0U) {
+      return mEdge::one;
+    }
+    return makeIdent(0, n - 1);
   }
-  mEdge makeIdent(Qubit leastSignificantQubit, Qubit mostSignificantQubit) {
+  mEdge makeIdent(const std::size_t leastSignificantQubit,
+                  const std::size_t mostSignificantQubit) {
     if (mostSignificantQubit < leastSignificantQubit) {
       return mEdge::one;
     }
 
-    const auto& entry =
-        idTable.at(static_cast<std::size_t>(mostSignificantQubit));
+    const auto& entry = idTable.at(mostSignificantQubit);
     if (leastSignificantQubit == 0 && entry.p != nullptr) {
       return entry;
     }
 
     if (mostSignificantQubit >= 1) {
-      const auto& prevEntry =
-          idTable.at(static_cast<std::size_t>(mostSignificantQubit - 1));
-      if (prevEntry.p != nullptr) {
-        idTable.at(static_cast<std::size_t>(mostSignificantQubit)) = makeDDNode(
-            mostSignificantQubit,
+      const auto& prevEntry = idTable.at(mostSignificantQubit - 1);
+      if (!prevEntry.isTerminal()) {
+        idTable.at(mostSignificantQubit) = makeDDNode(
+            static_cast<Qubit>(mostSignificantQubit),
             std::array{prevEntry, mEdge::zero, mEdge::zero, prevEntry});
-        return idTable[static_cast<std::size_t>(mostSignificantQubit)];
+        return idTable[mostSignificantQubit];
       }
     }
 
-    auto e =
-        makeDDNode(leastSignificantQubit, std::array{mEdge::one, mEdge::zero,
-                                                     mEdge::zero, mEdge::one});
-    for (auto k = static_cast<std::size_t>(leastSignificantQubit + 1);
-         k <= static_cast<std::make_unsigned_t<Qubit>>(mostSignificantQubit);
-         k++) {
+    auto e = makeDDNode(
+        static_cast<Qubit>(leastSignificantQubit),
+        std::array{mEdge::one, mEdge::zero, mEdge::zero, mEdge::one});
+    for (auto k = leastSignificantQubit + 1; k <= mostSignificantQubit; ++k) {
       e = makeDDNode(static_cast<Qubit>(k),
                      std::array{e, mEdge::zero, mEdge::zero, e});
     }
     if (leastSignificantQubit == 0) {
-      idTable.at(static_cast<std::size_t>(mostSignificantQubit)) = e;
+      idTable.at(mostSignificantQubit) = e;
     }
     return e;
   }
@@ -2495,7 +2456,7 @@ public:
     }
   }
 
-  mEdge createInitialMatrix(dd::QubitCount n,
+  mEdge createInitialMatrix(const std::size_t n,
                             const std::vector<bool>& ancillary) {
     auto e = makeIdent(n);
     incRef(e);
@@ -2516,8 +2477,8 @@ public:
   ///
   /// Decision diagram size
   ///
-  template <class Edge> unsigned int size(const Edge& e) {
-    static constexpr unsigned int NODECOUNT_BUCKETS = 200000;
+  template <class Edge> std::size_t size(const Edge& e) {
+    static constexpr std::size_t NODECOUNT_BUCKETS = 200000U;
     static std::unordered_set<decltype(e.p)> visited{NODECOUNT_BUCKETS}; // 2e6
     visited.max_load_factor(10);
     visited.clear();
@@ -2526,13 +2487,13 @@ public:
 
 private:
   template <class Edge>
-  unsigned int nodeCount(const Edge& e,
-                         std::unordered_set<decltype(e.p)>& v) const {
+  std::size_t nodeCount(const Edge& e,
+                        std::unordered_set<decltype(e.p)>& v) const {
     v.insert(e.p);
-    unsigned int sum = 1;
+    std::size_t sum = 1U;
     if (!e.isTerminal()) {
       for (const auto& edge : e.p->e) {
-        if (edge.p != nullptr && !v.count(edge.p)) {
+        if (!v.count(edge.p)) {
           sum += nodeCount(edge, v);
         }
       }
@@ -2545,11 +2506,11 @@ private:
   ///
 public:
   mEdge reduceAncillae(mEdge& e, const std::vector<bool>& ancillary,
-                       bool regular = true) {
+                       const bool regular = true) {
     // return if no more garbage left
     if (std::none_of(ancillary.begin(), ancillary.end(),
                      [](bool v) { return v; }) ||
-        e.p == nullptr) {
+        e.isTerminal()) {
       return e;
     }
     Qubit lowerbound = 0;
@@ -2574,7 +2535,7 @@ public:
     // return if no more garbage left
     if (std::none_of(garbage.begin(), garbage.end(),
                      [](bool v) { return v; }) ||
-        e.p == nullptr) {
+        e.isTerminal()) {
       return e;
     }
     Qubit lowerbound = 0;
@@ -2593,11 +2554,11 @@ public:
     return f;
   }
   mEdge reduceGarbage(mEdge& e, const std::vector<bool>& garbage,
-                      bool regular = true) {
+                      const bool regular = true) {
     // return if no more garbage left
     if (std::none_of(garbage.begin(), garbage.end(),
                      [](bool v) { return v; }) ||
-        e.p == nullptr) {
+        e.isTerminal()) {
       return e;
     }
     Qubit lowerbound = 0;
@@ -2618,7 +2579,8 @@ public:
 
 private:
   mEdge reduceAncillaeRecursion(mEdge& e, const std::vector<bool>& ancillary,
-                                Qubit lowerbound, bool regular = true) {
+                                const Qubit lowerbound,
+                                const bool regular = true) {
     if (e.p->v < lowerbound) {
       return e;
     }
@@ -2647,7 +2609,7 @@ private:
     f = makeDDNode(f.p->v, edges);
 
     // something to reduce for this qubit
-    if (f.p->v >= 0 && ancillary[static_cast<std::size_t>(f.p->v)]) {
+    if (f.p->v >= 0 && ancillary[f.p->v]) {
       if (regular) {
         if (f.p->e[1].w != Complex::zero || f.p->e[3].w != Complex::zero) {
           f = makeDDNode(f.p->v, std::array{f.p->e[0], mEdge::zero, f.p->e[2],
@@ -2665,7 +2627,7 @@ private:
   }
 
   vEdge reduceGarbageRecursion(vEdge& e, const std::vector<bool>& garbage,
-                               Qubit lowerbound) {
+                               const Qubit lowerbound) {
     if (e.p->v < lowerbound) {
       return e;
     }
@@ -2693,7 +2655,7 @@ private:
     f = makeDDNode(f.p->v, edges);
 
     // something to reduce for this qubit
-    if (f.p->v >= 0 && garbage[static_cast<std::size_t>(f.p->v)]) {
+    if (f.p->v >= 0 && garbage[f.p->v]) {
       if (f.p->e[1].w != Complex::zero) {
         vEdge g{};
         if (f.p->e[0].w == Complex::zero && f.p->e[1].w != Complex::zero) {
@@ -2716,7 +2678,8 @@ private:
     return f;
   }
   mEdge reduceGarbageRecursion(mEdge& e, const std::vector<bool>& garbage,
-                               Qubit lowerbound, bool regular = true) {
+                               const Qubit lowerbound,
+                               const bool regular = true) {
     if (e.p->v < lowerbound) {
       return e;
     }
@@ -2745,7 +2708,7 @@ private:
     f = makeDDNode(f.p->v, edges);
 
     // something to reduce for this qubit
-    if (f.p->v >= 0 && garbage[static_cast<std::size_t>(f.p->v)]) {
+    if (f.p->v >= 0 && garbage[f.p->v]) {
       if (regular) {
         if (f.p->e[2].w != Complex::zero || f.p->e[3].w != Complex::zero) {
           mEdge g{};
@@ -2821,8 +2784,7 @@ public:
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
     do {
       ComplexNumbers::mul(c, c, r.w);
-      auto tmp = static_cast<std::size_t>(
-          elements.at(static_cast<std::size_t>(r.p->v)) - '0');
+      auto tmp = static_cast<std::size_t>(elements.at(r.p->v) - '0');
       assert(tmp <= r.p->e.size());
       r = r.p->e.at(tmp);
     } while (!r.isTerminal());
@@ -2830,14 +2792,14 @@ public:
 
     return {RealNumber::val(c.r), RealNumber::val(c.i)};
   }
-  ComplexValue getValueByPath(const vEdge& e, std::size_t i) {
+  ComplexValue getValueByPath(const vEdge& e, const std::size_t i) {
     if (e.isTerminal()) {
       return {RealNumber::val(e.w.r), RealNumber::val(e.w.i)};
     }
     return getValueByPath(e, Complex::one, i);
   }
   ComplexValue getValueByPath(const vEdge& e, const Complex& amp,
-                              std::size_t i) {
+                              const std::size_t i) {
     auto c = cn.mulCached(e.w, amp);
 
     if (e.isTerminal()) {
@@ -2856,14 +2818,15 @@ public:
     cn.returnToCache(c);
     return r;
   }
-  ComplexValue getValueByPath(const mEdge& e, std::size_t i, std::size_t j) {
+  ComplexValue getValueByPath(const mEdge& e, const std::size_t i,
+                              const std::size_t j) {
     if (e.isTerminal()) {
       return {RealNumber::val(e.w.r), RealNumber::val(e.w.i)};
     }
     return getValueByPath(e, Complex::one, i, j);
   }
-  ComplexValue getValueByPath(const mEdge& e, const Complex& amp, std::size_t i,
-                              std::size_t j) {
+  ComplexValue getValueByPath(const mEdge& e, const Complex& amp,
+                              const std::size_t i, const std::size_t j) {
     auto c = cn.mulCached(e.w, amp);
 
     if (e.isTerminal()) {
@@ -2889,7 +2852,7 @@ public:
   }
 
   std::map<std::string, dd::fp>
-  getProbVectorFromDensityMatrix(dEdge e, double measurementThreshold) {
+  getProbVectorFromDensityMatrix(dEdge e, const double measurementThreshold) {
     dEdge::alignDensityEdge(e);
     if (std::pow(2, e.p->v + 1) >=
         static_cast<double>(std::numeric_limits<std::size_t>::max())) {
@@ -2905,7 +2868,7 @@ public:
       auto resultString = intToString(m, '1', e.p->v + 1);
       dEdge cur = e;
       for (dd::Qubit i = 0; i < e.p->v + 1; ++i) {
-        if (cur.p->v == -1 || globalProbability <= measurementThreshold) {
+        if (cur.isTerminal() || globalProbability <= measurementThreshold) {
           globalProbability = 0;
           break;
         }
@@ -2930,12 +2893,13 @@ public:
     return measuredResult;
   }
 
-  [[nodiscard]] std::string intToString(std::size_t targetNumber, char value,
-                                        dd::Qubit size) const {
-    std::string path(static_cast<std::size_t>(size), '0');
-    for (auto i = 1; i <= size; i++) {
+  [[nodiscard]] std::string intToString(std::size_t targetNumber,
+                                        const char value,
+                                        const Qubit size) const {
+    std::string path(size, '0');
+    for (auto i = 1U; i <= size; ++i) {
       if ((targetNumber % 2) != 0U) {
-        path[static_cast<std::size_t>(size - i)] = value;
+        path[size - i] = value;
       }
       targetNumber = targetNumber >> 1U;
     }
@@ -2949,7 +2913,8 @@ public:
     getVector(e, Complex::one, 0, vec);
     return vec;
   }
-  void getVector(const vEdge& e, const Complex& amp, std::size_t i, CVec& vec) {
+  void getVector(const vEdge& e, const Complex& amp, const std::size_t i,
+                 CVec& vec) {
     // calculate new accumulated amplitude
     auto c = cn.mulCached(e.w, amp);
 
@@ -2976,8 +2941,9 @@ public:
     const std::size_t element = 2ULL << e.p->v;
     for (auto i = 0ULL; i < element; i++) {
       const auto amplitude = getValueByPath(e, i);
-      for (Qubit j = e.p->v; j >= 0; j--) {
-        std::cout << ((i >> j) & 1ULL);
+      const auto n = static_cast<std::size_t>(e.p->v) + 1U;
+      for (auto j = n; j > 0; --j) {
+        std::cout << ((i >> (j - 1)) & 1ULL);
       }
       constexpr auto precision = 3;
       // set fixed width to maximum of a printed number
@@ -3017,8 +2983,8 @@ public:
     getMatrix(e, Complex::one, 0, 0, mat);
     return mat;
   }
-  void getMatrix(const mEdge& e, const Complex& amp, std::size_t i,
-                 std::size_t j, CMat& mat) {
+  void getMatrix(const mEdge& e, const Complex& amp, const std::size_t i,
+                 const std::size_t j, CMat& mat) {
     // calculate new accumulated amplitude
     auto c = cn.mulCached(e.w, amp);
 
@@ -3058,8 +3024,8 @@ public:
     return mat;
   }
 
-  void getDensityMatrix(dEdge& e, const Complex& amp, std::size_t i,
-                        std::size_t j, CMat& mat) {
+  void getDensityMatrix(dEdge& e, const Complex& amp, const std::size_t i,
+                        const std::size_t j, CMat& mat) {
     // calculate new accumulated amplitude
     auto c = cn.mulCached(e.w, amp);
 
@@ -3100,7 +3066,7 @@ public:
 
   void exportAmplitudesRec(const vEdge& edge, std::ostream& oss,
                            const std::string& path, Complex& amplitude,
-                           dd::QubitCount level, bool binary = false) {
+                           const std::size_t level, const bool binary = false) {
     if (edge.isTerminal()) {
       auto amp = cn.getTemporary();
       dd::ComplexNumbers::mul(amp, amplitude, edge.w);
@@ -3120,8 +3086,8 @@ public:
     exportAmplitudesRec(edge.p->e[1], oss, path + "1", a, level - 1, binary);
     cn.returnToCache(a);
   }
-  void exportAmplitudes(const vEdge& edge, std::ostream& oss, dd::QubitCount nq,
-                        bool binary = false) {
+  void exportAmplitudes(const vEdge& edge, std::ostream& oss,
+                        const std::size_t nq, const bool binary = false) {
     if (edge.isTerminal()) {
       // TODO special treatment
       return;
@@ -3131,7 +3097,7 @@ public:
     cn.returnToCache(weight);
   }
   void exportAmplitudes(const vEdge& edge, const std::string& outputFilename,
-                        dd::QubitCount nq, bool binary = false) {
+                        const std::size_t nq, const bool binary = false) {
     std::ofstream init(outputFilename);
     std::ostringstream oss{};
 
@@ -3143,7 +3109,7 @@ public:
 
   void exportAmplitudesRec(const vEdge& edge,
                            std::vector<std::complex<dd::fp>>& amplitudes,
-                           Complex& amplitude, dd::QubitCount level,
+                           Complex& amplitude, const std::size_t level,
                            std::size_t idx) {
     if (edge.isTerminal()) {
       auto amp = cn.getTemporary();
@@ -3165,7 +3131,7 @@ public:
   }
   void exportAmplitudes(const vEdge& edge,
                         std::vector<std::complex<dd::fp>>& amplitudes,
-                        dd::QubitCount nq) {
+                        const std::size_t nq) {
     if (edge.isTerminal()) {
       // TODO special treatment
       return;
@@ -3177,7 +3143,7 @@ public:
 
   void addAmplitudesRec(const vEdge& edge,
                         std::vector<std::complex<dd::fp>>& amplitudes,
-                        ComplexValue& amplitude, dd::QubitCount level,
+                        ComplexValue& amplitude, const std::size_t level,
                         std::size_t idx) {
     const auto ar = RealNumber::val(edge.w.r);
     const auto ai = RealNumber::val(edge.w.i);
@@ -3200,7 +3166,7 @@ public:
   }
   void addAmplitudes(const vEdge& edge,
                      std::vector<std::complex<dd::fp>>& amplitudes,
-                     dd::QubitCount nq) {
+                     const std::size_t nq) {
     if (edge.isTerminal()) {
       // TODO special treatment
       return;
@@ -3297,7 +3263,7 @@ public:
 
   template <class Node, class Edge = Edge<Node>,
             std::size_t N = std::tuple_size_v<decltype(Node::e)>>
-  Edge deserialize(std::istream& is, bool readBinary = false) {
+  Edge deserialize(std::istream& is, const bool readBinary = false) {
     auto result = Edge::zero;
     ComplexValue rootweight{};
 
@@ -3409,7 +3375,7 @@ public:
   }
 
   template <class Node, class Edge = Edge<Node>>
-  Edge deserialize(const std::string& inputFilename, bool readBinary) {
+  Edge deserialize(const std::string& inputFilename, const bool readBinary) {
     auto ifs = std::ifstream(inputFilename, std::ios::binary);
 
     if (!ifs.good()) {
@@ -3423,9 +3389,9 @@ public:
 private:
   template <class Node, class Edge = Edge<Node>,
             std::size_t N = std::tuple_size_v<decltype(Node::e)>>
-  Edge deserializeNode(std::int64_t index, Qubit v,
+  Edge deserializeNode(const std::int64_t index, const Qubit v,
                        std::array<std::int64_t, N>& edgeIdx,
-                       std::array<ComplexValue, N>& edgeWeight,
+                       const std::array<ComplexValue, N>& edgeWeight,
                        std::unordered_map<std::int64_t, Node*>& nodes) {
     if (index == -1) {
       return Edge::zero;
@@ -3526,7 +3492,7 @@ private:
     }
 
     for (const auto& child : e.p->e) {
-      if (child.p->v + 1 != e.p->v && !child.isTerminal()) {
+      if (!child.isTerminal() && child.p->v + 1 != e.p->v) {
         std::clog << "\nLOCAL INCONSISTENCY FOUND: Wrong V\n";
         debugnode(e.p);
         return false;
@@ -3642,6 +3608,10 @@ public:
               << alignof(mEdge) << " bytes)"
               << "\n  mNode size: " << sizeof(mNode) << " bytes (aligned "
               << alignof(mNode) << " bytes)"
+              << "\n  dEdge size: " << sizeof(dEdge) << " bytes (aligned "
+              << alignof(dEdge) << " bytes)"
+              << "\n  dNode size: " << sizeof(dNode) << " bytes (aligned "
+              << alignof(dNode) << " bytes)"
               << "\n  CT Vector Add size: "
               << sizeof(typename decltype(vectorAdd)::Entry)
               << " bytes (aligned "
@@ -3691,10 +3661,10 @@ public:
   // print unique and compute table statistics
   void statistics() {
     std::cout << "DD statistics:\n";
-    std::cout << "[vUniqueTable] " << vUniqueTable.getStats();
-    std::cout << "[mUniqueTable] " << mUniqueTable.getStats();
-    std::cout << "[dUniqueTable] " << dUniqueTable.getStats();
-    std::cout << "[cUniqueTable] " << cUniqueTable.getStats();
+    std::cout << "[vUniqueTable] " << vUniqueTable.getStats() << "\n";
+    std::cout << "[mUniqueTable] " << mUniqueTable.getStats() << "\n";
+    std::cout << "[dUniqueTable] " << dUniqueTable.getStats() << "\n";
+    std::cout << "[cUniqueTable] " << cUniqueTable.getStats() << "\n";
     std::cout << "[CT Vector Add] ";
     vectorAdd.printStatistics();
     std::cout << "[CT Matrix Add] ";

--- a/include/dd/StochasticNoiseOperationTable.hpp
+++ b/include/dd/StochasticNoiseOperationTable.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Definitions.hpp"
 #include "dd/DDDefinitions.hpp"
 
 #include <array>
@@ -25,23 +26,23 @@ public:
     table.resize(nvars);
   }
 
-  void insert(std::uint8_t kind, Qubit target, const Edge& r) {
+  void insert(std::uint8_t kind, qc::Qubit target, const Edge& r) {
     assert(kind <
            numberOfStochasticOperations); // There are new operations in OpType.
                                           // Increase the value of
                                           // numberOfOperations accordingly
-    table.at(static_cast<std::size_t>(target)).at(kind) = r;
+    table.at(target).at(kind) = r;
     ++count;
   }
 
-  Edge lookup(std::uint8_t kind, Qubit target) {
+  Edge lookup(std::uint8_t kind, qc::Qubit target) {
     assert(kind <
            numberOfStochasticOperations); // There are new operations in OpType.
                                           // Increase the value of
                                           // numberOfOperations accordingly
     lookups++;
     Edge r{};
-    auto entry = table.at(static_cast<std::size_t>(target)).at(kind);
+    auto entry = table.at(target).at(kind);
     if (entry.p == nullptr) {
       return r;
     }

--- a/include/dd/UniqueTable.hpp
+++ b/include/dd/UniqueTable.hpp
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
+#include <type_traits>
 #include <vector>
 
 namespace dd {
@@ -22,6 +23,11 @@ namespace dd {
  * @tparam NBUCKET number of hash buckets to use (has to be a power of two)
  */
 template <class Node, std::size_t NBUCKET = 32768> class UniqueTable {
+
+  static_assert(
+      std::disjunction_v<std::is_same<Node, vNode>, std::is_same<Node, mNode>,
+                         std::is_same<Node, dNode>>,
+      "Node type must be one of vNode, mNode, dNode");
 
 public:
   /**

--- a/include/dd/UniqueTable.hpp
+++ b/include/dd/UniqueTable.hpp
@@ -156,9 +156,12 @@ public:
    */
   [[nodiscard]] bool decRef(Node* p) noexcept {
     const auto dec = ::dd::decRef(p);
-    if (dec && p->ref == 0U) {
-      --stats.activeEntryCount;
-      --active[p->v];
+    if (dec) {
+      assert(p != nullptr);
+      if (p->ref == 0U) {
+        --stats.activeEntryCount;
+        --active[p->v];
+      }
     }
     return dec;
   }

--- a/include/dd/UniqueTable.hpp
+++ b/include/dd/UniqueTable.hpp
@@ -255,7 +255,7 @@ private:
   using Table = std::array<Bucket, NBUCKET>;
 
   /// The number of variables
-  std::size_t nvars = 0;
+  std::size_t nvars = 0U;
   /**
    * @brief The actual tables (one for each variable)
    * @details Each hash table is an array of buckets. Each bucket is a linked
@@ -274,7 +274,7 @@ private:
    * @brief the number of active nodes for each variable
    * @note A node is considered active if it has a non-zero reference count.
    */
-  std::vector<std::size_t> active{std::vector<std::size_t>(nvars, 0)};
+  std::vector<std::size_t> active{std::vector<std::size_t>(nvars, 0U)};
 
   /// The initial garbage collection limit
   std::size_t initialGCLimit;

--- a/include/dd/UniqueTable.hpp
+++ b/include/dd/UniqueTable.hpp
@@ -134,9 +134,12 @@ public:
    */
   [[nodiscard]] bool incRef(Node* p) noexcept {
     const auto inc = ::dd::incRef(p);
-    if (inc && p->ref == 1U) {
-      stats.trackActiveEntry();
-      ++active[p->v];
+    if (inc) {
+      assert(p != nullptr);
+      if (p->ref == 1U) {
+        stats.trackActiveEntry();
+        ++active[p->v];
+      }
     }
     return inc;
   }

--- a/src/dd/Edge.cpp
+++ b/src/dd/Edge.cpp
@@ -99,10 +99,11 @@ hash<dd::Edge<Node>>::operator()(const dd::Edge<Node>& e) const noexcept {
   const auto h2 = std::hash<dd::Complex>{}(e.w);
   auto h3 = dd::combineHash(h1, h2);
   if constexpr (std::is_same_v<Node, dd::dNode>) {
-    assert(e.p != nullptr);
+    if (e.isTerminal()) {
+      return h3;
+    }
     assert((dd::dNode::isDensityMatrixTempFlagSet(e.p)) == false);
-    const auto h4 = std::hash<std::uint8_t>{}(static_cast<std::uint8_t>(
-        dd::dNode::getDensityMatrixTempFlags(e.p->flags)));
+    const auto h4 = dd::dNode::getDensityMatrixTempFlags(e.p->flags);
     h3 = dd::combineHash(h3, h4);
   }
   return h3;

--- a/src/dd/FunctionalityConstruction.cpp
+++ b/src/dd/FunctionalityConstruction.cpp
@@ -35,7 +35,7 @@ MatrixDD buildFunctionality(const QuantumComputation* qc,
 
 template <class Config>
 MatrixDD buildFunctionalityRecursive(const QuantumComputation* qc,
-                                     std::unique_ptr<dd::Package<Config>>& dd) {
+                                     std::unique_ptr<Package<Config>>& dd) {
   if (qc->getNqubits() == 0U) {
     return MatrixDD::one;
   }
@@ -71,7 +71,7 @@ bool buildFunctionalityRecursive(const QuantumComputation* qc,
                                  std::size_t depth, std::size_t opIdx,
                                  std::stack<MatrixDD>& s,
                                  Permutation& permutation,
-                                 std::unique_ptr<dd::Package<Config>>& dd) {
+                                 std::unique_ptr<Package<Config>>& dd) {
   // base case
   if (depth == 1U) {
     auto e = getDD(qc->at(opIdx).get(), dd, permutation);
@@ -119,7 +119,7 @@ bool buildFunctionalityRecursive(const QuantumComputation* qc,
 
 template <class Config>
 MatrixDD buildFunctionality(const qc::Grover* qc,
-                            std::unique_ptr<dd::Package<Config>>& dd) {
+                            std::unique_ptr<Package<Config>>& dd) {
   QuantumComputation groverIteration(qc->getNqubits());
   qc->oracle(groverIteration);
   qc->diffusion(groverIteration);
@@ -152,7 +152,7 @@ MatrixDD buildFunctionality(const qc::Grover* qc,
 
 template <class Config>
 MatrixDD buildFunctionalityRecursive(const qc::Grover* qc,
-                                     std::unique_ptr<dd::Package<Config>>& dd) {
+                                     std::unique_ptr<Package<Config>>& dd) {
   QuantumComputation groverIteration(qc->getNqubits());
   qc->oracle(groverIteration);
   qc->diffusion(groverIteration);
@@ -227,23 +227,24 @@ MatrixDD buildFunctionality(GoogleRandomCircuitSampling* qc,
 
 template MatrixDD
 buildFunctionality(const qc::QuantumComputation* qc,
-                   std::unique_ptr<dd::Package<dd::DDPackageConfig>>& dd);
-template MatrixDD buildFunctionalityRecursive(
-    const qc::QuantumComputation* qc,
-    std::unique_ptr<dd::Package<dd::DDPackageConfig>>& dd);
-template bool buildFunctionalityRecursive(
-    const qc::QuantumComputation* qc, const std::size_t depth,
-    const std::size_t opIdx, std::stack<MatrixDD>& s,
-    qc::Permutation& permutation,
-    std::unique_ptr<dd::Package<dd::DDPackageConfig>>& dd);
+                   std::unique_ptr<Package<DDPackageConfig>>& dd);
+template MatrixDD
+buildFunctionalityRecursive(const qc::QuantumComputation* qc,
+                            std::unique_ptr<Package<DDPackageConfig>>& dd);
+template bool
+buildFunctionalityRecursive(const qc::QuantumComputation* qc,
+                            const std::size_t depth, const std::size_t opIdx,
+                            std::stack<MatrixDD>& s,
+                            qc::Permutation& permutation,
+                            std::unique_ptr<Package<DDPackageConfig>>& dd);
 template MatrixDD
 buildFunctionality(const qc::Grover* qc,
-                   std::unique_ptr<dd::Package<dd::DDPackageConfig>>& dd);
-template MatrixDD buildFunctionalityRecursive(
-    const qc::Grover* qc,
-    std::unique_ptr<dd::Package<dd::DDPackageConfig>>& dd);
+                   std::unique_ptr<Package<DDPackageConfig>>& dd);
+template MatrixDD
+buildFunctionalityRecursive(const qc::Grover* qc,
+                            std::unique_ptr<Package<DDPackageConfig>>& dd);
 template MatrixDD
 buildFunctionality(GoogleRandomCircuitSampling* qc,
-                   std::unique_ptr<dd::Package<dd::DDPackageConfig>>& dd,
+                   std::unique_ptr<Package<DDPackageConfig>>& dd,
                    const std::optional<std::size_t> ncycles);
 } // namespace dd

--- a/src/dd/FunctionalityConstruction.cpp
+++ b/src/dd/FunctionalityConstruction.cpp
@@ -3,9 +3,9 @@
 namespace dd {
 template <class Config>
 MatrixDD buildFunctionality(const QuantumComputation* qc,
-                            std::unique_ptr<dd::Package<Config>>& dd) {
-  const auto nqubits = static_cast<dd::QubitCount>(qc->getNqubits());
-  if (nqubits == 0U) {
+                            std::unique_ptr<Package<Config>>& dd) {
+  const auto nq = qc->getNqubits();
+  if (nq == 0U) {
     return MatrixDD::one;
   }
 
@@ -14,7 +14,7 @@ MatrixDD buildFunctionality(const QuantumComputation* qc,
   }
 
   auto permutation = qc->initialLayout;
-  auto e = dd->createInitialMatrix(nqubits, qc->ancillary);
+  auto e = dd->createInitialMatrix(nq, qc->ancillary);
 
   for (const auto& op : *qc) {
     auto tmp = dd->multiply(getDD(op.get(), dd, permutation), e);
@@ -207,12 +207,12 @@ MatrixDD buildFunctionality(GoogleRandomCircuitSampling* qc,
     qc->removeCycles(qc->cycles.size() - 2U - *ncycles);
   }
 
-  const auto nqubits = static_cast<dd::QubitCount>(qc->getNqubits());
+  const auto nq = qc->getNqubits();
   Permutation permutation = qc->initialLayout;
-  auto e = dd->makeIdent(nqubits);
+  auto e = dd->makeIdent(nq);
   dd->incRef(e);
   for (const auto& cycle : qc->cycles) {
-    auto f = dd->makeIdent(nqubits);
+    auto f = dd->makeIdent(nq);
     for (const auto& op : cycle) {
       f = dd->multiply(getDD(op.get(), dd, permutation), f);
     }

--- a/src/dd/Node.cpp
+++ b/src/dd/Node.cpp
@@ -4,30 +4,6 @@
 #include "dd/RealNumber.hpp"
 
 namespace dd {
-// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,
-// cppcoreguidelines-interfaces-global-init)
-vNode vNode::terminal{
-    {{{nullptr, Complex::zero}, {nullptr, Complex::zero}}}, nullptr, 0U, -1};
-
-mNode mNode::terminal{{{{nullptr, Complex::zero},
-                        {nullptr, Complex::zero},
-                        {nullptr, Complex::zero},
-                        {nullptr, Complex::zero}}},
-                      nullptr,
-                      0U,
-                      -1,
-                      32 + 16};
-
-dNode dNode::terminal{{{{nullptr, Complex::zero},
-                        {nullptr, Complex::zero},
-                        {nullptr, Complex::zero},
-                        {nullptr, Complex::zero}}},
-                      nullptr,
-                      0,
-                      -1,
-                      0};
-// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,
-// cppcoreguidelines-interfaces-global-init)
 
 void dNode::setDensityMatrixNodeFlag(const bool densityMatrix) noexcept {
   if (densityMatrix) {
@@ -42,7 +18,7 @@ std::uint8_t dNode::alignDensityNodeNode(dNode*& p) noexcept {
   // Get an aligned node
   alignDensityNode(p);
 
-  if (p == nullptr || dNode::isTerminal(p)) {
+  if (dNode::isTerminal(p)) {
     return 0U;
   }
 
@@ -99,13 +75,16 @@ void dNode::getAlignedNodeRevertModificationsOnSubEdges(dNode* p) noexcept {
 void dNode::applyDmChangesToNode(dNode*& p) noexcept {
   if (isDensityMatrixTempFlagSet(p)) {
     const auto tmp = alignDensityNodeNode(p);
+    if (p == nullptr) {
+      return;
+    }
     assert(getDensityMatrixTempFlags(p->flags) == 0);
     p->flags = p->flags | tmp;
   }
 }
 
 void dNode::revertDmChangesToNode(dNode*& p) noexcept {
-  if (isDensityMatrixTempFlagSet(p->flags)) {
+  if (!dNode::isTerminal(p) && isDensityMatrixTempFlagSet(p->flags)) {
     getAlignedNodeRevertModificationsOnSubEdges(p);
     p->unsetTempDensityMatrixFlags();
   }

--- a/src/dd/UniqueTableStatistics.cpp
+++ b/src/dd/UniqueTableStatistics.cpp
@@ -29,20 +29,26 @@ void UniqueTableStatistics::reset() noexcept {
 }
 
 nlohmann::json UniqueTableStatistics::json() const {
-  return nlohmann::json{
-      {"table_performance",
-       {"collisions", collisions},
-       {"hits", hits},
-       {"lookups", lookups},
-       {"inserts", inserts},
-       {"hit_ratio", hitRatio()},
-       {"col_ratio", colRatio()}},
-      {"entry_statistics",
-       {"entry_count", entryCount},
-       {"peak_entry_count", peakActiveEntryCount},
-       {"active_entry_count", activeEntryCount},
-       {"peak_active_entry_count", peakActiveEntryCount}},
-      {"garbage_collection_statistics", {"calls", gcCalls}, {"runs", gcRuns}}};
+  nlohmann::json j{};
+  auto& perf = j["table_performance"];
+  perf["collisions"] = collisions;
+  perf["hits"] = hits;
+  perf["lookups"] = lookups;
+  perf["inserts"] = inserts;
+  perf["hit_ratio"] = hitRatio();
+  perf["col_ratio"] = colRatio();
+
+  auto& entry = j["entry_statistics"];
+  entry["entry_count"] = entryCount;
+  entry["peak_entry_count"] = peakEntryCount;
+  entry["active_entry_count"] = activeEntryCount;
+  entry["peak_active_entry_count"] = peakActiveEntryCount;
+
+  auto& garbage = j["garbage_collection_statistics"];
+  garbage["calls"] = gcCalls;
+  garbage["runs"] = gcRuns;
+
+  return j;
 }
 
 std::string UniqueTableStatistics::toString() const { return json().dump(2U); }

--- a/test/algorithms/eval_dynamic_circuits.cpp
+++ b/test/algorithms/eval_dynamic_circuits.cpp
@@ -41,11 +41,11 @@ protected:
     iqpeNgates = iqpe->getNindividualOps();
 
     std::cout << "Estimating lambda = " << lambda << "π up to " << precision
-              << "-bit precision." << std::endl;
+              << "-bit precision.\n";
 
     theta = lambda / 2;
 
-    std::cout << "Expected theta=" << theta << std::endl;
+    std::cout << "Expected theta=" << theta << "\n";
     std::bitset<64> binaryExpansion{};
     dd::fp expansion = theta * 2;
     std::size_t index = 0;
@@ -75,9 +75,9 @@ protected:
     expectedResultRepresentation = ss.str();
 
     std::cout << "Theta is exactly representable using " << precision
-              << " bits." << std::endl;
+              << " bits.\n";
     std::cout << "The expected output state is |"
-              << expectedResultRepresentation << ">." << std::endl;
+              << expectedResultRepresentation << ">.\n";
   }
 };
 
@@ -160,9 +160,9 @@ TEST_P(DynamicCircuitEvalExactQPE, UnitaryTransformation) {
   std::stringstream ss{};
   ss << "qpe_exact,transformation," << qpe->getNqubits() << "," << qpeNgates
      << ",2," << iqpeNgates << "," << preprocessing << "," << verification;
-  std::cout << ss.str() << std::endl;
+  std::cout << ss.str() << "\n";
   ofs.open("results_exact.csv", std::ios_base::app);
-  ofs << ss.str() << std::endl;
+  ofs << ss.str() << "\n";
 
   EXPECT_TRUE(e.p->isIdentity());
 }
@@ -207,9 +207,9 @@ TEST_P(DynamicCircuitEvalExactQPE, ProbabilityExtraction) {
   ss << "qpe_exact,extraction," << qpe->getNqubits() << "," << qpeNgates
      << ",2," << iqpeNgates << "," << simulation << "," << extraction << ","
      << comparison << "," << total;
-  std::cout << ss.str() << std::endl;
+  std::cout << ss.str() << "\n";
   ofs.open("results_exact_prob.csv", std::ios_base::app);
-  ofs << ss.str() << std::endl;
+  ofs << ss.str() << "\n";
 
   EXPECT_NEAR(fidelity, 1.0, 1e-4);
 }
@@ -246,11 +246,11 @@ protected:
     iqpeNgates = iqpe->getNindividualOps();
 
     std::cout << "Estimating lambda = " << lambda << "π up to " << precision
-              << "-bit precision." << std::endl;
+              << "-bit precision.\n";
 
     theta = lambda / 2;
 
-    std::cout << "Expected theta=" << theta << std::endl;
+    std::cout << "Expected theta=" << theta << "\n";
     std::bitset<64> binaryExpansion{};
     dd::fp expansion = theta * 2;
     std::size_t index = 0;
@@ -270,8 +270,8 @@ protected:
       }
     }
     std::stringstream ss{};
-    for (auto i = precision - 1; i >= 0; --i) {
-      if ((expectedResult & (1ULL << i)) != 0) {
+    for (auto i = precision; i > 0; --i) {
+      if ((expectedResult & (1ULL << (i - 1))) != 0) {
         ss << 1;
       } else {
         ss << 0;
@@ -281,8 +281,8 @@ protected:
 
     secondExpectedResult = expectedResult + 1;
     ss.str("");
-    for (auto i = precision - 1; i >= 0; --i) {
-      if ((secondExpectedResult & (1ULL << i)) != 0) {
+    for (auto i = precision; i > 0; --i) {
+      if ((secondExpectedResult & (1ULL << (i - 1))) != 0) {
         ss << 1;
       } else {
         ss << 0;
@@ -291,10 +291,10 @@ protected:
     secondExpectedResultRepresentation = ss.str();
 
     std::cout << "Theta is not exactly representable using " << precision
-              << " bits." << std::endl;
+              << " bits.\n";
     std::cout << "Most probable output states are |"
               << expectedResultRepresentation << "> and |"
-              << secondExpectedResultRepresentation << ">." << std::endl;
+              << secondExpectedResultRepresentation << ">.\n";
   }
 };
 
@@ -377,9 +377,9 @@ TEST_P(DynamicCircuitEvalInexactQPE, UnitaryTransformation) {
   std::stringstream ss{};
   ss << "qpe_inexact,transformation," << qpe->getNqubits() << "," << qpeNgates
      << ",2," << iqpeNgates << "," << preprocessing << "," << verification;
-  std::cout << ss.str() << std::endl;
+  std::cout << ss.str() << "\n";
   ofs.open("results_inexact.csv", std::ios_base::app);
-  ofs << ss.str() << std::endl;
+  ofs << ss.str() << "\n";
 
   EXPECT_TRUE(e.p->isIdentity());
 }
@@ -393,14 +393,14 @@ TEST_P(DynamicCircuitEvalInexactQPE, ProbabilityExtraction) {
       dd->makeZeroState(static_cast<dd::QubitCount>(iqpe->getNqubits())), probs,
       dd);
   const auto extractionEnd = std::chrono::steady_clock::now();
-  std::cout << "---- extraction done ----" << std::endl;
+  std::cout << "---- extraction done ----\n";
 
   // generate DD of QPE circuit via simulation
   auto e = simulate(
       qpe.get(),
       dd->makeZeroState(static_cast<dd::QubitCount>(qpe->getNqubits())), dd);
   const auto simulationEnd = std::chrono::steady_clock::now();
-  std::cout << "---- sim done ----" << std::endl;
+  std::cout << "---- sim done ----\n";
 
   // extend to account for 0 qubit
   auto stub = dd::ProbabilityVector{};
@@ -426,9 +426,9 @@ TEST_P(DynamicCircuitEvalInexactQPE, ProbabilityExtraction) {
   ss << "qpe_inexact,extraction," << qpe->getNqubits() << "," << qpeNgates
      << ",2," << iqpeNgates << "," << simulation << "," << extraction << ","
      << comparison << "," << total;
-  std::cout << ss.str() << std::endl;
+  std::cout << ss.str() << "\n";
   ofs.open("results_inexact_prob.csv", std::ios_base::app);
-  ofs << ss.str() << std::endl;
+  ofs << ss.str() << "\n";
 
   EXPECT_NEAR(fidelity, 1.0, 1e-4);
 }
@@ -461,7 +461,7 @@ protected:
     const auto expected =
         dynamic_cast<qc::BernsteinVazirani*>(bv.get())->expected;
     std::cout << "Hidden bitstring: " << expected << " (" << bitwidth
-              << " qubits)" << std::endl;
+              << " qubits)\n";
   }
 };
 
@@ -544,9 +544,9 @@ TEST_P(DynamicCircuitEvalBV, UnitaryTransformation) {
   std::stringstream ss{};
   ss << "bv,transformation," << bv->getNqubits() << "," << bvNgates << ",2,"
      << dbvNgates << "," << preprocessing << "," << verification;
-  std::cout << ss.str() << std::endl;
+  std::cout << ss.str() << "\n";
   ofs.open("results_bv.csv", std::ios_base::app);
-  ofs << ss.str() << std::endl;
+  ofs << ss.str() << "\n";
 
   EXPECT_TRUE(e.p->isIdentity());
 }
@@ -591,9 +591,9 @@ TEST_P(DynamicCircuitEvalBV, ProbabilityExtraction) {
   ss << "bv,extraction," << bv->getNqubits() << "," << bvNgates << ",2,"
      << dbvNgates << "," << simulation << "," << extraction << "," << comparison
      << "," << total;
-  std::cout << ss.str() << std::endl;
+  std::cout << ss.str() << "\n";
   ofs.open("results_bv_prob.csv", std::ios_base::app);
-  ofs << ss.str() << std::endl;
+  ofs << ss.str() << "\n";
 
   EXPECT_NEAR(fidelity, 1.0, 1e-4);
 }
@@ -703,9 +703,9 @@ TEST_P(DynamicCircuitEvalQFT, UnitaryTransformation) {
   std::stringstream ss{};
   ss << "qft,transformation," << qft->getNqubits() << "," << qftNgates << ",1,"
      << dqftNgates << "," << preprocessing << "," << verification;
-  std::cout << ss.str() << std::endl;
+  std::cout << ss.str() << "\n";
   ofs.open("results_qft.csv", std::ios_base::app);
-  ofs << ss.str() << std::endl;
+  ofs << ss.str() << "\n";
 
   EXPECT_TRUE(e.p->isIdentity());
 }
@@ -743,14 +743,14 @@ TEST_P(DynamicCircuitEvalQFT, ProbabilityExtraction) {
     ss << "qft,extraction," << qft->getNqubits() << "," << qftNgates << ",1,"
        << dqftNgates << "," << extraction << "," << simulation << ","
        << comparison << "," << total;
-    std::cout << ss.str() << std::endl;
+    std::cout << ss.str() << "\n";
 
   } else {
     ss << "qft,extraction," << qft->getNqubits() << "," << qftNgates << ",1,"
        << dqftNgates << ",," << simulation << ",,,";
-    std::cout << ss.str() << std::endl;
+    std::cout << ss.str() << "\n";
   }
 
   ofs.open("results_qft_prob.csv", std::ios_base::app);
-  ofs << ss.str() << std::endl;
+  ofs << ss.str() << "\n";
 }

--- a/test/algorithms/eval_dynamic_circuits.cpp
+++ b/test/algorithms/eval_dynamic_circuits.cpp
@@ -109,7 +109,7 @@ TEST_P(DynamicCircuitEvalExactQPE, UnitaryTransformation) {
   qc::CircuitOptimizer::reorderOperations(*iqpe);
   const auto finishedTransformation = std::chrono::steady_clock::now();
 
-  qc::MatrixDD e = dd->makeIdent(static_cast<dd::QubitCount>(precision + 1));
+  qc::MatrixDD e = dd->makeIdent(precision + 1);
   dd->incRef(e);
 
   auto leftIt = qpe->begin();
@@ -170,17 +170,13 @@ TEST_P(DynamicCircuitEvalExactQPE, UnitaryTransformation) {
 TEST_P(DynamicCircuitEvalExactQPE, ProbabilityExtraction) {
   // generate DD of QPE circuit via simulation
   const auto start = std::chrono::steady_clock::now();
-  auto e = simulate(
-      qpe.get(),
-      dd->makeZeroState(static_cast<dd::QubitCount>(qpe->getNqubits())), dd);
+  auto e = simulate(qpe.get(), dd->makeZeroState(qpe->getNqubits()), dd);
   const auto simulationEnd = std::chrono::steady_clock::now();
 
   // extract measurement probabilities from IQPE simulations
   dd::ProbabilityVector probs{};
-  extractProbabilityVector(
-      iqpe.get(),
-      dd->makeZeroState(static_cast<dd::QubitCount>(iqpe->getNqubits())), probs,
-      dd);
+  extractProbabilityVector(iqpe.get(), dd->makeZeroState(iqpe->getNqubits()),
+                           probs, dd);
   const auto extractionEnd = std::chrono::steady_clock::now();
 
   // extend to account for 0 qubit
@@ -217,7 +213,7 @@ TEST_P(DynamicCircuitEvalExactQPE, ProbabilityExtraction) {
 class DynamicCircuitEvalInexactQPE
     : public testing::TestWithParam<std::size_t> {
 protected:
-  dd::QubitCount precision{};
+  std::size_t precision{};
   dd::fp theta{};
   std::size_t expectedResult{};
   std::string expectedResultRepresentation{};
@@ -232,7 +228,7 @@ protected:
 
   void TearDown() override {}
   void SetUp() override {
-    precision = static_cast<dd::QubitCount>(GetParam());
+    precision = GetParam();
 
     dd = std::make_unique<dd::Package<>>(precision + 1);
 
@@ -388,17 +384,13 @@ TEST_P(DynamicCircuitEvalInexactQPE, ProbabilityExtraction) {
   const auto start = std::chrono::steady_clock::now();
   // extract measurement probabilities from IQPE simulations
   dd::ProbabilityVector probs{};
-  extractProbabilityVector(
-      iqpe.get(),
-      dd->makeZeroState(static_cast<dd::QubitCount>(iqpe->getNqubits())), probs,
-      dd);
+  extractProbabilityVector(iqpe.get(), dd->makeZeroState(iqpe->getNqubits()),
+                           probs, dd);
   const auto extractionEnd = std::chrono::steady_clock::now();
   std::cout << "---- extraction done ----\n";
 
   // generate DD of QPE circuit via simulation
-  auto e = simulate(
-      qpe.get(),
-      dd->makeZeroState(static_cast<dd::QubitCount>(qpe->getNqubits())), dd);
+  auto e = simulate(qpe.get(), dd->makeZeroState(qpe->getNqubits()), dd);
   const auto simulationEnd = std::chrono::steady_clock::now();
   std::cout << "---- sim done ----\n";
 
@@ -493,7 +485,7 @@ TEST_P(DynamicCircuitEvalBV, UnitaryTransformation) {
   qc::CircuitOptimizer::reorderOperations(*dbv);
   const auto finishedTransformation = std::chrono::steady_clock::now();
 
-  qc::MatrixDD e = dd->makeIdent(static_cast<dd::QubitCount>(bitwidth + 1));
+  qc::MatrixDD e = dd->makeIdent(bitwidth + 1);
   dd->incRef(e);
 
   auto leftIt = bv->begin();
@@ -554,17 +546,13 @@ TEST_P(DynamicCircuitEvalBV, UnitaryTransformation) {
 TEST_P(DynamicCircuitEvalBV, ProbabilityExtraction) {
   // generate DD of QPE circuit via simulation
   const auto start = std::chrono::steady_clock::now();
-  auto e = simulate(
-      bv.get(),
-      dd->makeZeroState(static_cast<dd::QubitCount>(bv->getNqubits())), dd);
+  auto e = simulate(bv.get(), dd->makeZeroState(bv->getNqubits()), dd);
   const auto simulationEnd = std::chrono::steady_clock::now();
 
   // extract measurement probabilities from IQPE simulations
   dd::ProbabilityVector probs{};
-  extractProbabilityVector(
-      dbv.get(),
-      dd->makeZeroState(static_cast<dd::QubitCount>(dbv->getNqubits())), probs,
-      dd);
+  extractProbabilityVector(dbv.get(), dd->makeZeroState(dbv->getNqubits()),
+                           probs, dd);
   const auto extractionEnd = std::chrono::steady_clock::now();
 
   // extend to account for 0 qubit
@@ -652,7 +640,7 @@ TEST_P(DynamicCircuitEvalQFT, UnitaryTransformation) {
   qc::CircuitOptimizer::reorderOperations(*dqft);
   const auto finishedTransformation = std::chrono::steady_clock::now();
 
-  qc::MatrixDD e = dd->makeIdent(static_cast<dd::QubitCount>(precision));
+  qc::MatrixDD e = dd->makeIdent(precision);
   dd->incRef(e);
 
   auto leftIt = qft->begin();
@@ -713,9 +701,7 @@ TEST_P(DynamicCircuitEvalQFT, UnitaryTransformation) {
 TEST_P(DynamicCircuitEvalQFT, ProbabilityExtraction) {
   // generate DD of QPE circuit via simulation
   const auto start = std::chrono::steady_clock::now();
-  auto e = simulate(
-      qft.get(),
-      dd->makeZeroState(static_cast<dd::QubitCount>(qft->getNqubits())), dd);
+  auto e = simulate(qft.get(), dd->makeZeroState(qft->getNqubits()), dd);
   const auto simulationEnd = std::chrono::steady_clock::now();
   const auto simulation =
       std::chrono::duration<double>(simulationEnd - start).count();
@@ -724,10 +710,8 @@ TEST_P(DynamicCircuitEvalQFT, ProbabilityExtraction) {
   // extract measurement probabilities from IQPE simulations
   if (qft->getNqubits() <= 15) {
     dd::ProbabilityVector probs{};
-    extractProbabilityVector(
-        dqft.get(),
-        dd->makeZeroState(static_cast<dd::QubitCount>(dqft->getNqubits())),
-        probs, dd);
+    extractProbabilityVector(dqft.get(), dd->makeZeroState(dqft->getNqubits()),
+                             probs, dd);
     const auto extractionEnd = std::chrono::steady_clock::now();
 
     // compare outcomes

--- a/test/algorithms/test_bernsteinvazirani.cpp
+++ b/test/algorithms/test_bernsteinvazirani.cpp
@@ -43,7 +43,7 @@ TEST_P(BernsteinVazirani, FunctionTest) {
                dd, shots);
 
   for (const auto& [state, count] : measurements) {
-    std::cout << state << ": " << count << std::endl;
+    std::cout << state << ": " << count << "\n";
   }
 
   // expect to obtain the hidden bitstring with certainty
@@ -67,7 +67,7 @@ TEST_P(BernsteinVazirani, FunctionTestDynamic) {
                dd, shots);
 
   for (const auto& [state, count] : measurements) {
-    std::cout << state << ": " << count << std::endl;
+    std::cout << state << ": " << count << "\n";
   }
 
   // expect to obtain the hidden bitstring with certainty
@@ -88,7 +88,7 @@ TEST_F(BernsteinVazirani, LargeCircuit) {
                dd, shots);
 
   for (const auto& [state, count] : measurements) {
-    std::cout << state << ": " << count << std::endl;
+    std::cout << state << ": " << count << "\n";
   }
 
   // expect to obtain the hidden bitstring with certainty
@@ -109,7 +109,7 @@ TEST_F(BernsteinVazirani, DynamicCircuit) {
                dd, shots);
 
   for (const auto& [state, count] : measurements) {
-    std::cout << state << ": " << count << std::endl;
+    std::cout << state << ": " << count << "\n";
   }
 
   // expect to obtain the hidden bitstring with certainty
@@ -152,7 +152,7 @@ TEST_P(BernsteinVazirani, DynamicEquivalenceSimulation) {
 
   // calculate fidelity between both results
   auto fidelity = dd->fidelity(e, f);
-  std::cout << "Fidelity of both circuits: " << fidelity << std::endl;
+  std::cout << "Fidelity of both circuits: " << fidelity << "\n";
 
   EXPECT_NEAR(fidelity, 1.0, 1e-4);
 }

--- a/test/algorithms/test_bernsteinvazirani.cpp
+++ b/test/algorithms/test_bernsteinvazirani.cpp
@@ -31,23 +31,21 @@ TEST_P(BernsteinVazirani, FunctionTest) {
   auto s = qc::BitString(GetParam());
 
   // construct Bernstein Vazirani circuit
-  auto qc = std::make_unique<qc::BernsteinVazirani>(s);
-  qc->printStatistics(std::cout);
+  auto qc = qc::BernsteinVazirani(s);
+  qc.printStatistics(std::cout);
 
   // simulate the circuit
-  auto dd = std::make_unique<dd::Package<>>(qc->getNqubits());
+  auto dd = std::make_unique<dd::Package<>>(qc.getNqubits());
   const std::size_t shots = 1024;
   auto measurements =
-      simulate(qc.get(),
-               dd->makeZeroState(static_cast<dd::QubitCount>(qc->getNqubits())),
-               dd, shots);
+      simulate(&qc, dd->makeZeroState(qc.getNqubits()), dd, shots);
 
   for (const auto& [state, count] : measurements) {
     std::cout << state << ": " << count << "\n";
   }
 
   // expect to obtain the hidden bitstring with certainty
-  EXPECT_EQ(measurements[qc->expected], shots);
+  EXPECT_EQ(measurements[qc.expected], shots);
 }
 
 TEST_P(BernsteinVazirani, FunctionTestDynamic) {
@@ -55,65 +53,59 @@ TEST_P(BernsteinVazirani, FunctionTestDynamic) {
   auto s = qc::BitString(GetParam());
 
   // construct Bernstein Vazirani circuit
-  auto qc = std::make_unique<qc::BernsteinVazirani>(s, true);
-  qc->printStatistics(std::cout);
+  auto qc = qc::BernsteinVazirani(s, true);
+  qc.printStatistics(std::cout);
 
   // simulate the circuit
-  auto dd = std::make_unique<dd::Package<>>(qc->getNqubits());
+  auto dd = std::make_unique<dd::Package<>>(qc.getNqubits());
   const std::size_t shots = 1024;
   auto measurements =
-      simulate(qc.get(),
-               dd->makeZeroState(static_cast<dd::QubitCount>(qc->getNqubits())),
-               dd, shots);
+      simulate(&qc, dd->makeZeroState(qc.getNqubits()), dd, shots);
 
   for (const auto& [state, count] : measurements) {
     std::cout << state << ": " << count << "\n";
   }
 
   // expect to obtain the hidden bitstring with certainty
-  EXPECT_EQ(measurements[qc->expected], shots);
+  EXPECT_EQ(measurements[qc.expected], shots);
 }
 
 TEST_F(BernsteinVazirani, LargeCircuit) {
   const std::size_t nq = 127;
-  auto qc = std::make_unique<qc::BernsteinVazirani>(nq);
-  qc->printStatistics(std::cout);
+  auto qc = qc::BernsteinVazirani(nq);
+  qc.printStatistics(std::cout);
 
   // simulate the circuit
-  auto dd = std::make_unique<dd::Package<>>(qc->getNqubits());
+  auto dd = std::make_unique<dd::Package<>>(qc.getNqubits());
   const std::size_t shots = 1024;
   auto measurements =
-      simulate(qc.get(),
-               dd->makeZeroState(static_cast<dd::QubitCount>(qc->getNqubits())),
-               dd, shots);
+      simulate(&qc, dd->makeZeroState(qc.getNqubits()), dd, shots);
 
   for (const auto& [state, count] : measurements) {
     std::cout << state << ": " << count << "\n";
   }
 
   // expect to obtain the hidden bitstring with certainty
-  EXPECT_EQ(measurements[qc->expected], shots);
+  EXPECT_EQ(measurements[qc.expected], shots);
 }
 
 TEST_F(BernsteinVazirani, DynamicCircuit) {
   const std::size_t nq = 127;
-  auto qc = std::make_unique<qc::BernsteinVazirani>(nq, true);
-  qc->printStatistics(std::cout);
+  auto qc = qc::BernsteinVazirani(nq, true);
+  qc.printStatistics(std::cout);
 
   // simulate the circuit
-  auto dd = std::make_unique<dd::Package<>>(qc->getNqubits());
+  auto dd = std::make_unique<dd::Package<>>(qc.getNqubits());
   const std::size_t shots = 1024;
   auto measurements =
-      simulate(qc.get(),
-               dd->makeZeroState(static_cast<dd::QubitCount>(qc->getNqubits())),
-               dd, shots);
+      simulate(&qc, dd->makeZeroState(qc.getNqubits()), dd, shots);
 
   for (const auto& [state, count] : measurements) {
     std::cout << state << ": " << count << "\n";
   }
 
   // expect to obtain the hidden bitstring with certainty
-  EXPECT_EQ(measurements[qc->expected], shots);
+  EXPECT_EQ(measurements[qc.expected], shots);
 }
 
 TEST_P(BernsteinVazirani, DynamicEquivalenceSimulation) {
@@ -121,34 +113,29 @@ TEST_P(BernsteinVazirani, DynamicEquivalenceSimulation) {
   auto s = qc::BitString(GetParam());
 
   // create standard BV circuit
-  auto bv = std::make_unique<qc::BernsteinVazirani>(s);
+  auto bv = qc::BernsteinVazirani(s);
 
-  auto dd = std::make_unique<dd::Package<>>(bv->getNqubits());
+  auto dd = std::make_unique<dd::Package<>>(bv.getNqubits());
 
   // remove final measurements to obtain statevector
-  qc::CircuitOptimizer::removeFinalMeasurements(*bv);
+  qc::CircuitOptimizer::removeFinalMeasurements(bv);
 
   // simulate circuit
-  auto e = simulate(
-      bv.get(),
-      dd->makeZeroState(static_cast<dd::QubitCount>(bv->getNqubits())), dd);
+  auto e = simulate(&bv, dd->makeZeroState(bv.getNqubits()), dd);
 
   // create dynamic BV circuit
-  auto dbv = std::make_unique<qc::BernsteinVazirani>(s, true);
+  auto dbv = qc::BernsteinVazirani(s, true);
 
   // transform dynamic circuits by first eliminating reset operations and
   // afterwards deferring measurements
-  qc::CircuitOptimizer::eliminateResets(*dbv);
-
-  qc::CircuitOptimizer::deferMeasurements(*dbv);
+  qc::CircuitOptimizer::eliminateResets(dbv);
+  qc::CircuitOptimizer::deferMeasurements(dbv);
 
   // remove final measurements to obtain statevector
-  qc::CircuitOptimizer::removeFinalMeasurements(*dbv);
+  qc::CircuitOptimizer::removeFinalMeasurements(dbv);
 
   // simulate circuit
-  auto f = simulate(
-      dbv.get(),
-      dd->makeZeroState(static_cast<dd::QubitCount>(dbv->getNqubits())), dd);
+  auto f = simulate(&dbv, dd->makeZeroState(dbv.getNqubits()), dd);
 
   // calculate fidelity between both results
   auto fidelity = dd->fidelity(e, f);

--- a/test/algorithms/test_entanglement.cpp
+++ b/test/algorithms/test_entanglement.cpp
@@ -4,35 +4,30 @@
 #include "gtest/gtest.h"
 #include <string>
 
-class Entanglement : public testing::TestWithParam<dd::QubitCount> {
+class Entanglement : public testing::TestWithParam<std::size_t> {
 protected:
   void TearDown() override {}
   void SetUp() override {}
 };
 
 INSTANTIATE_TEST_SUITE_P(
-    Entanglement, Entanglement,
-    testing::Range(static_cast<dd::QubitCount>(2),
-                   static_cast<dd::QubitCount>(90), 7),
+    Entanglement, Entanglement, testing::Range<std::size_t>(2U, 90U, 7U),
     [](const testing::TestParamInfo<Entanglement::ParamType>& inf) {
       // Generate names for test cases
-      const dd::QubitCount nqubits = inf.param;
+      const auto nqubits = inf.param;
       std::stringstream ss{};
-      ss << static_cast<std::size_t>(nqubits) << "_qubits";
+      ss << nqubits << "_qubits";
       return ss.str();
     });
 
 TEST_P(Entanglement, FunctionTest) {
-  const dd::QubitCount nq = GetParam();
+  const auto nq = GetParam();
 
   auto dd = std::make_unique<dd::Package<>>(nq);
-  std::unique_ptr<qc::Entanglement> qc;
-  qc::MatrixDD e{};
+  auto qc = qc::Entanglement(nq);
+  auto e = buildFunctionality(&qc, dd);
 
-  ASSERT_NO_THROW({ qc = std::make_unique<qc::Entanglement>(nq); });
-  ASSERT_NO_THROW({ e = buildFunctionality(qc.get(), dd); });
-
-  ASSERT_EQ(qc->getNops(), nq);
+  ASSERT_EQ(qc.getNops(), nq);
   const qc::VectorDD r = dd->multiply(e, dd->makeZeroState(nq));
 
   ASSERT_EQ(dd->getValueByPath(r, std::string(nq, '0')),

--- a/test/algorithms/test_grcs.cpp
+++ b/test/algorithms/test_grcs.cpp
@@ -27,7 +27,7 @@ TEST_F(GRCS, simulate) {
       qc::GoogleRandomCircuitSampling("./circuits/grcs/bris_4_40_9_v2.txt");
 
   auto dd = std::make_unique<dd::Package<>>(qcBris.getNqubits());
-  auto in = dd->makeZeroState(static_cast<dd::QubitCount>(qcBris.getNqubits()));
+  auto in = dd->makeZeroState(qcBris.getNqubits());
   const std::optional<std::size_t> ncycles = 4;
   ASSERT_NO_THROW({ simulate(&qcBris, in, dd, ncycles); });
   std::cout << qcBris << "\n";

--- a/test/algorithms/test_grcs.cpp
+++ b/test/algorithms/test_grcs.cpp
@@ -14,12 +14,12 @@ TEST_F(GRCS, import) {
   auto qcBris =
       qc::GoogleRandomCircuitSampling("./circuits/grcs/bris_4_40_9_v2.txt");
   qcBris.printStatistics(std::cout);
-  std::cout << qcBris << std::endl;
+  std::cout << qcBris << "\n";
 
   auto qcInst =
       qc::GoogleRandomCircuitSampling("./circuits/grcs/inst_4x4_80_9_v2.txt");
   qcInst.printStatistics(std::cout);
-  std::cout << qcInst << std::endl;
+  std::cout << qcInst << "\n";
 }
 
 TEST_F(GRCS, simulate) {
@@ -30,7 +30,7 @@ TEST_F(GRCS, simulate) {
   auto in = dd->makeZeroState(static_cast<dd::QubitCount>(qcBris.getNqubits()));
   const std::optional<std::size_t> ncycles = 4;
   ASSERT_NO_THROW({ simulate(&qcBris, in, dd, ncycles); });
-  std::cout << qcBris << std::endl;
+  std::cout << qcBris << "\n";
   qcBris.printStatistics(std::cout);
 }
 
@@ -40,6 +40,6 @@ TEST_F(GRCS, buildFunctionality) {
 
   auto dd = std::make_unique<dd::Package<>>(qcBris.getNqubits());
   ASSERT_NO_THROW({ buildFunctionality(&qcBris, dd, 4); });
-  std::cout << qcBris << std::endl;
+  std::cout << qcBris << "\n";
   qcBris.printStatistics(std::cout);
 }

--- a/test/algorithms/test_grover.cpp
+++ b/test/algorithms/test_grover.cpp
@@ -10,12 +10,8 @@ class Grover
     : public testing::TestWithParam<std::tuple<std::size_t, std::size_t>> {
 protected:
   void TearDown() override {
-    if (sim.p != nullptr) {
-      dd->decRef(sim);
-    }
-    if (func.p != nullptr) {
-      dd->decRef(func);
-    }
+    dd->decRef(sim);
+    dd->decRef(func);
     dd->garbageCollect(true);
 
     // number of complex table entries after clean-up should equal initial
@@ -113,7 +109,7 @@ TEST_P(Grover, Simulation) {
   ASSERT_NO_THROW({ qc = std::make_unique<qc::Grover>(nqubits, seed); });
 
   qc->printStatistics(std::cout);
-  auto in = dd->makeZeroState(static_cast<dd::QubitCount>(nqubits + 1));
+  auto in = dd->makeZeroState(nqubits + 1U);
   // there should be no error simulating the circuit
   const std::size_t shots = 1024;
   auto measurements = simulate(qc.get(), in, dd, shots);

--- a/test/algorithms/test_grover.cpp
+++ b/test/algorithms/test_grover.cpp
@@ -119,7 +119,7 @@ TEST_P(Grover, Simulation) {
   auto measurements = simulate(qc.get(), in, dd, shots);
 
   for (const auto& [state, count] : measurements) {
-    std::cout << state << ": " << count << std::endl;
+    std::cout << state << ": " << count << "\n";
   }
 
   auto correctShots = measurements[qc->expected];

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -87,7 +87,7 @@ TEST_P(QFT, Functionality) {
   // since only positive real values are stored in the complex table
   // this number has to be divided by 4
   ASSERT_EQ(dd->cn.realCount(),
-            static_cast<unsigned int>(std::ceil(std::pow(2, nqubits) / 4)));
+            static_cast<std::size_t>(std::ceil(std::pow(2, nqubits) / 4)));
 
   // top edge weight should equal sqrt(0.5)^n
   EXPECT_NEAR(dd::RealNumber::val(func.w.r),
@@ -128,7 +128,7 @@ TEST_P(QFT, FunctionalityRecursive) {
   // since only positive real values are stored in the complex table
   // this number has to be divided by 4
   ASSERT_EQ(dd->cn.realCount(),
-            static_cast<unsigned int>(std::ceil(std::pow(2, nqubits) / 4)));
+            static_cast<std::size_t>(std::ceil(std::pow(2, nqubits) / 4)));
 
   // top edge weight should equal sqrt(0.5)^n
   EXPECT_NEAR(dd::RealNumber::val(func.w.r),

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -6,15 +6,11 @@
 #include <cmath>
 #include <iostream>
 
-class QFT : public testing::TestWithParam<dd::QubitCount> {
+class QFT : public testing::TestWithParam<std::size_t> {
 protected:
   void TearDown() override {
-    if (sim.p != nullptr) {
-      dd->decRef(sim);
-    }
-    if (func.p != nullptr) {
-      dd->decRef(func);
-    }
+    dd->decRef(sim);
+    dd->decRef(func);
     dd->garbageCollect(true);
 
     // number of complex table entries after clean-up should equal initial
@@ -32,7 +28,7 @@ protected:
     initialComplexCount = dd->cn.realCount();
   }
 
-  dd::QubitCount nqubits = 0;
+  std::size_t nqubits = 0;
   std::unique_ptr<dd::Package<>> dd;
   std::unique_ptr<qc::QFT> qc;
   std::size_t initialCacheCount = 0;
@@ -52,23 +48,22 @@ protected:
 /// The accuracy of double floating points allows for a minimal CN::TOLERANCE
 /// value of 10e-15
 ///	Utilizing more qubits requires the use of fp=long double
-constexpr dd::QubitCount QFT_MAX_QUBITS = 20;
+constexpr std::size_t QFT_MAX_QUBITS = 20U;
 
-INSTANTIATE_TEST_SUITE_P(
-    QFT, QFT,
-    testing::Range(static_cast<dd::QubitCount>(0),
-                   static_cast<dd::QubitCount>(QFT_MAX_QUBITS + 1), 3),
-    [](const testing::TestParamInfo<QFT::ParamType>& inf) {
-      const auto nqubits = inf.param;
-      std::stringstream ss{};
-      ss << static_cast<std::size_t>(nqubits);
-      if (nqubits == 1) {
-        ss << "_qubit";
-      } else {
-        ss << "_qubits";
-      }
-      return ss.str();
-    });
+INSTANTIATE_TEST_SUITE_P(QFT, QFT,
+                         testing::Range<std::size_t>(0U, QFT_MAX_QUBITS + 1U,
+                                                     3U),
+                         [](const testing::TestParamInfo<QFT::ParamType>& inf) {
+                           const auto nqubits = inf.param;
+                           std::stringstream ss{};
+                           ss << nqubits;
+                           if (nqubits == 1) {
+                             ss << "_qubit";
+                           } else {
+                             ss << "_qubits";
+                           }
+                           return ss.str();
+                         });
 
 TEST_P(QFT, Functionality) {
   // there should be no error constructing the circuit
@@ -207,9 +202,7 @@ TEST_P(QFT, DynamicSimulation) {
   // simulate the circuit
   std::size_t shots = 8192U;
   auto measurements =
-      simulate(qc.get(),
-               dd->makeZeroState(static_cast<dd::QubitCount>(qc->getNqubits())),
-               dd, shots);
+      simulate(qc.get(), dd->makeZeroState(qc->getNqubits()), dd, shots);
 
   for (const auto& [state, count] : measurements) {
     std::cout << state << ": " << count << "\n";

--- a/test/algorithms/test_qpe.cpp
+++ b/test/algorithms/test_qpe.cpp
@@ -26,11 +26,11 @@ protected:
     precision = GetParam().second;
 
     std::cout << "Estimating lambda = " << lambda << "π up to " << precision
-              << "-bit precision." << std::endl;
+              << "-bit precision.\n";
 
     theta = lambda / 2;
 
-    std::cout << "Expected theta=" << theta << std::endl;
+    std::cout << "Expected theta=" << theta << "\n";
     std::bitset<64> binaryExpansion{};
     auto expansion = theta * 2;
     std::size_t index = 0;
@@ -69,9 +69,9 @@ protected:
 
     if (exactlyRepresentable) {
       std::cout << "Theta is exactly representable using " << precision
-                << " bits." << std::endl;
+                << " bits.\n";
       std::cout << "The expected output state is |"
-                << expectedResultRepresentation << ">." << std::endl;
+                << expectedResultRepresentation << ">.\n";
     } else {
       secondExpectedResult = expectedResult + 1;
       ss.str("");
@@ -85,10 +85,10 @@ protected:
       secondExpectedResultRepresentation = ss.str();
 
       std::cout << "Theta is not exactly representable using " << precision
-                << " bits." << std::endl;
+                << " bits.\n";
       std::cout << "Most probable output states are |"
                 << expectedResultRepresentation << "> and |"
-                << secondExpectedResultRepresentation << ">." << std::endl;
+                << secondExpectedResultRepresentation << ">.\n";
     }
   }
 };
@@ -129,7 +129,7 @@ TEST_P(QPE, QPETest) {
   auto amplitude = dd->getValueByPath(e, (expectedResult << 1) + 1);
   auto probability = amplitude.r * amplitude.r + amplitude.i * amplitude.i;
   std::cout << "Obtained probability for |" << expectedResultRepresentation
-            << ">: " << probability << std::endl;
+            << ">: " << probability << "\n";
 
   if (exactlyRepresentable) {
     EXPECT_NEAR(probability, 1.0, 1e-8);
@@ -143,7 +143,7 @@ TEST_P(QPE, QPETest) {
                              secondAmplitude.i * secondAmplitude.i;
     std::cout << "Obtained probability for |"
               << secondExpectedResultRepresentation
-              << ">: " << secondProbability << std::endl;
+              << ">: " << secondProbability << "\n";
 
     EXPECT_GT(probability, threshold);
     EXPECT_GT(secondProbability, threshold);
@@ -175,10 +175,10 @@ TEST_P(QPE, IQPETest) {
   const std::set<Measurement, decltype(comp)> ordered(measurements.begin(),
                                                       measurements.end(), comp);
 
-  std::cout << "Obtained measurements: " << std::endl;
+  std::cout << "Obtained measurements: \n";
   for (const auto& measurement : ordered) {
     std::cout << "\t" << measurement.first << ": " << measurement.second << " ("
-              << (measurement.second * 100) / shots << "%)" << std::endl;
+              << (measurement.second * 100) / shots << "%)\n";
   }
 
   const auto& mostLikely = *ordered.begin();
@@ -235,7 +235,7 @@ TEST_P(QPE, DynamicEquivalenceSimulation) {
 
   // calculate fidelity between both results
   auto fidelity = dd->fidelity(e, f);
-  std::cout << "Fidelity of both circuits: " << fidelity << std::endl;
+  std::cout << "Fidelity of both circuits: " << fidelity << "\n";
 
   EXPECT_NEAR(fidelity, 1.0, 1e-4);
 }
@@ -285,7 +285,7 @@ TEST_P(QPE, ProbabilityExtraction) {
   for (const auto& [state, prob] : probs) {
     std::stringstream ss{};
     qc::QuantumComputation::printBin(state, ss);
-    std::cout << ss.str() << ": " << prob << std::endl;
+    std::cout << ss.str() << ": " << prob << "\n";
   }
 
   if (exactlyRepresentable) {
@@ -311,9 +311,9 @@ TEST_P(QPE, DynamicEquivalenceSimulationProbabilityExtraction) {
       qpe.get(),
       dd->makeZeroState(static_cast<dd::QubitCount>(qpe->getNqubits())), dd);
   const auto vec = dd->getVector(e);
-  std::cout << "QPE: " << std::endl;
+  std::cout << "QPE:\n";
   for (const auto& amp : vec) {
-    std::cout << std::norm(amp) << std::endl;
+    std::cout << std::norm(amp) << "\n";
   }
 
   // create standard IQPE circuit
@@ -333,17 +333,17 @@ TEST_P(QPE, DynamicEquivalenceSimulationProbabilityExtraction) {
     stub[2 * state + 1] = prob;
   }
 
-  std::cout << "IQPE: " << std::endl;
+  std::cout << "IQPE:\n";
   for (const auto& [state, prob] : stub) {
     std::stringstream ss{};
     qc::QuantumComputation::printBin(state, ss);
-    std::cout << ss.str() << ": " << prob << std::endl;
+    std::cout << ss.str() << ": " << prob << "\n";
   }
 
   // calculate fidelity between both results
   auto fidelity = dd->fidelityOfMeasurementOutcomes(e, stub);
   std::cout << "Fidelity of both circuits' measurement outcomes: " << fidelity
-            << std::endl;
+            << "\n";
 
   EXPECT_NEAR(fidelity, 1.0, 1e-4);
 }

--- a/test/algorithms/test_random_clifford.cpp
+++ b/test/algorithms/test_random_clifford.cpp
@@ -26,7 +26,7 @@ TEST_P(RandomClifford, simulate) {
 
   auto dd = std::make_unique<dd::Package<>>(nq);
   auto qc = qc::RandomCliffordCircuit(nq, nq * nq, 12345);
-  auto in = dd->makeZeroState(static_cast<dd::QubitCount>(nq));
+  auto in = dd->makeZeroState(nq);
 
   std::cout << qc << "\n";
   ASSERT_NO_THROW({ simulate(&qc, in, dd); });

--- a/test/algorithms/test_random_clifford.cpp
+++ b/test/algorithms/test_random_clifford.cpp
@@ -12,8 +12,7 @@ protected:
 };
 
 INSTANTIATE_TEST_SUITE_P(
-    RandomClifford, RandomClifford,
-    testing::Range(static_cast<std::size_t>(1), static_cast<std::size_t>(9)),
+    RandomClifford, RandomClifford, testing::Range<std::size_t>(1U, 9U),
     [](const testing::TestParamInfo<RandomClifford::ParamType>& inf) {
       // Generate names for test cases
       const auto nqubits = inf.param;
@@ -29,7 +28,7 @@ TEST_P(RandomClifford, simulate) {
   auto qc = qc::RandomCliffordCircuit(nq, nq * nq, 12345);
   auto in = dd->makeZeroState(static_cast<dd::QubitCount>(nq));
 
-  std::cout << qc << std::endl;
+  std::cout << qc << "\n";
   ASSERT_NO_THROW({ simulate(&qc, in, dd); });
   qc.printStatistics(std::cout);
 }
@@ -39,7 +38,7 @@ TEST_P(RandomClifford, buildFunctionality) {
 
   auto dd = std::make_unique<dd::Package<>>(nq);
   auto qc = qc::RandomCliffordCircuit(nq, nq * nq, 12345);
-  std::cout << qc << std::endl;
+  std::cout << qc << "\n";
   ASSERT_NO_THROW({ buildFunctionality(&qc, dd); });
   qc.printStatistics(std::cout);
 }

--- a/test/dd/test_dd_functionality.cpp
+++ b/test/dd/test_dd_functionality.cpp
@@ -43,7 +43,7 @@ protected:
     dist = std::uniform_real_distribution<dd::fp>(0.0, 2. * dd::PI);
   }
 
-  dd::QubitCount nqubits = 4U;
+  std::size_t nqubits = 4U;
   std::size_t initialCacheCount = 0U;
   std::size_t initialComplexCount = 0U;
   qc::MatrixDD e{}, ident{};
@@ -244,8 +244,7 @@ TEST_F(DDFunctionality, changePermutation) {
      << "qreg q[2];"
      << "x q[0];\n";
   qc.import(ss, qc::Format::OpenQASM);
-  auto sim = simulate(
-      &qc, dd->makeZeroState(static_cast<dd::QubitCount>(qc.getNqubits())), dd);
+  auto sim = simulate(&qc, dd->makeZeroState(qc.getNqubits()), dd);
   EXPECT_TRUE(sim.p->e[0].isZeroTerminal());
   EXPECT_TRUE(sim.p->e[1].w.approximatelyOne());
   EXPECT_TRUE(sim.p->e[1].p->e[1].isZeroTerminal());

--- a/test/dd/test_dd_noise_functionality.cpp
+++ b/test/dd/test_dd_noise_functionality.cpp
@@ -93,8 +93,7 @@ TEST_F(DDNoiseFunctionalityTest, DetSimulateAdder4TrackAPD) {
     for (const auto applyNoiseSequentially : {false, true}) {
       auto dd = std::make_unique<DensityMatrixTestPackage>(qc.getNqubits());
 
-      auto rootEdge = dd->makeZeroDensityOperator(
-          static_cast<dd::QubitCount>(qc.getNqubits()));
+      auto rootEdge = dd->makeZeroDensityOperator(qc.getNqubits());
       dd->incRef(rootEdge);
 
       const auto noiseEffects = {dd::AmplitudeDamping, dd::PhaseFlip,
@@ -102,9 +101,8 @@ TEST_F(DDNoiseFunctionalityTest, DetSimulateAdder4TrackAPD) {
 
       auto deterministicNoiseFunctionality =
           dd::DeterministicNoiseFunctionality(
-              dd, static_cast<dd::QubitCount>(qc.getNqubits()), 0.01, 0.02,
-              0.02, 0.04, noiseEffects, useDensityMatrixType,
-              applyNoiseSequentially);
+              dd, qc.getNqubits(), 0.01, 0.02, 0.02, 0.04, noiseEffects,
+              useDensityMatrixType, applyNoiseSequentially);
 
       for (auto const& op : qc) {
         dd->applyOperationToDensity(rootEdge, dd::getDD(op.get(), dd),
@@ -140,12 +138,10 @@ TEST_F(DDNoiseFunctionalityTest, StochSimulateAdder4TrackAPD) {
                              dd::Depolarization};
 
   auto stochasticNoiseFunctionality = dd::StochasticNoiseFunctionality(
-      dd, static_cast<dd::QubitCount>(qc.getNqubits()), 0.01, 0.02, 2.,
-      noiseEffects);
+      dd, qc.getNqubits(), 0.01, 0.02, 2., noiseEffects);
 
   for (size_t i = 0U; i < stochRuns; i++) {
-    auto rootEdge =
-        dd->makeZeroState(static_cast<dd::QubitCount>(qc.getNqubits()));
+    auto rootEdge = dd->makeZeroState(qc.getNqubits());
     dd->incRef(rootEdge);
 
     for (auto const& op : qc) {
@@ -194,12 +190,10 @@ TEST_F(DDNoiseFunctionalityTest, StochSimulateAdder4IdentiyError) {
   const auto noiseEffects = {dd::Identity};
 
   auto stochasticNoiseFunctionality = dd::StochasticNoiseFunctionality(
-      dd, static_cast<dd::QubitCount>(qc.getNqubits()), 0.01, 0.02, 2.,
-      noiseEffects);
+      dd, qc.getNqubits(), 0.01, 0.02, 2., noiseEffects);
 
   for (size_t i = 0U; i < stochRuns; i++) {
-    auto rootEdge =
-        dd->makeZeroState(static_cast<dd::QubitCount>(qc.getNqubits()));
+    auto rootEdge = dd->makeZeroState(qc.getNqubits());
     dd->incRef(rootEdge);
 
     for (auto const& op : qc) {

--- a/test/unittests/test_ecc_functionality.cpp
+++ b/test/unittests/test_ecc_functionality.cpp
@@ -134,7 +134,7 @@ protected:
       auto mapper = std::make_unique<eccType>(qcOriginal, 0);
       mapper->apply();
       circuitCounter++;
-      std::cout << "Testing circuit " << circuitCounter << std::endl;
+      std::cout << "Testing circuit " << circuitCounter << "\n";
       bool const success = testErrorCorrectionCircuit(
           mapper->getOriginalCircuit(), mapper->getMappedCircuit(),
           testParameter.testNoise, mapper->getDataQubits(),
@@ -183,16 +183,14 @@ protected:
         (static_cast<double>(shots) / 100.0) * (tolerance * 100.0);
 
     auto ddOriginal = std::make_unique<dd::Package<>>(qcOriginal->getNqubits());
-    auto originalRootEdge = ddOriginal->makeZeroState(
-        static_cast<dd::QubitCount>(qcOriginal->getNqubits()));
+    auto originalRootEdge = ddOriginal->makeZeroState(qcOriginal->getNqubits());
     ddOriginal->incRef(originalRootEdge);
 
     auto measurementsOriginal =
         simulate(qcOriginal.get(), originalRootEdge, ddOriginal, shots);
 
     auto ddEcc = std::make_unique<dd::Package<>>(qcMapped->getNqubits());
-    auto eccRootEdge = ddEcc->makeZeroState(
-        static_cast<dd::QubitCount>(qcMapped->getNqubits()));
+    auto eccRootEdge = ddEcc->makeZeroState(qcMapped->getNqubits());
     ddEcc->incRef(eccRootEdge);
 
     auto measurementsProtected =
@@ -210,13 +208,13 @@ protected:
       auto difference = std::max(eccHits, hits) - std::min(eccHits, hits);
       std::cout << "Diff/tolerance " << difference << "/" << toleranceAbsolute
                 << " Original register: " << hits
-                << " ecc register: " << eccHits << std::endl;
+                << " ecc register: " << eccHits << "\n";
       if (simulateWithErrors) {
         std::cout << " Simulating an error in qubit " << target << " after "
-                  << insertErrorAfterNGates << " gates." << std::endl;
+                  << insertErrorAfterNGates << " gates.\n";
       }
       if (static_cast<double>(difference) > toleranceAbsolute) {
-        std::cout << "Error is too large!" << std::endl;
+        std::cout << "Error is too large!\n";
         return false;
       }
     }


### PR DESCRIPTION
## Description

This PR completely eliminates the static DD node terminals and replaces them by using `nullptr` instead.
For one, this eliminates some global static variables.. Yay 😃
Furthermore, DD terminal nodes are no longer associated with the index `-1`. This allows changing the qubit index to an unsigned type and unlocks double the number of qubits (while also allowing to get rid of some `static_cast`s).
Finally, analysis has shown that the DD node size does not increase when using 16 bits for the qubit index (due to alignment). Hence, the package now directly supports up to `65536` qubits 🥳.

Note that this, naturally, is a breaking change. Qubit indices are now unsigned and checks for a terminal node should now use the respective functions of the Node classes instead of relying the variable index to be `-1`.
Something to look out for: Any decreasing loops that used a Qubit index for iteration and relied on `>=0` stopping conditions have to be revised since they now just wrap around at zero.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
