### PR TITLE
🔧 Disable `NullDereference` clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ FormatStyle: file
 Checks: |
   clang-diagnostic-*,
   clang-analyzer-*,
+  -clang-analyzer-core.NullDereference,
   boost-*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,

--- a/include/dd/UniqueTable.hpp
+++ b/include/dd/UniqueTable.hpp
@@ -134,12 +134,9 @@ public:
    */
   [[nodiscard]] bool incRef(Node* p) noexcept {
     const auto inc = ::dd::incRef(p);
-    if (inc) {
-      assert(p != nullptr);
-      if (p->ref == 1U) {
-        stats.trackActiveEntry();
-        ++active[p->v];
-      }
+    if (inc && p->ref == 1U) {
+      stats.trackActiveEntry();
+      ++active[p->v];
     }
     return inc;
   }
@@ -156,12 +153,9 @@ public:
    */
   [[nodiscard]] bool decRef(Node* p) noexcept {
     const auto dec = ::dd::decRef(p);
-    if (dec) {
-      assert(p != nullptr);
-      if (p->ref == 0U) {
-        --stats.activeEntryCount;
-        --active[p->v];
-      }
+    if (dec && p->ref == 0U) {
+      --stats.activeEntryCount;
+      --active[p->v];
     }
     return dec;
   }


### PR DESCRIPTION
## Description

This PR disables the `NullDereference` clang-tidy check since it led to many false positives.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
