### PR TITLE
🐛 Fix Compute Table Performance

### DIFF
--- a/include/dd/ComputeTable.hpp
+++ b/include/dd/ComputeTable.hpp
@@ -82,8 +82,13 @@ public:
     }
   }
 
+  [[nodiscard]] std::size_t getHits() const { return hits; }
+  [[nodiscard]] std::size_t getLookups() const { return lookups; }
   [[nodiscard]] fp hitRatio() const {
-    return static_cast<fp>(hits) / static_cast<fp>(lookups);
+    if (lookups == 0U) {
+      return 1.;
+    }
+    return static_cast<fp>(getHits()) / static_cast<fp>(getLookups());
   }
 
   std::ostream& printStatistics(std::ostream& os = std::cout) {

--- a/include/dd/UnaryComputeTable.hpp
+++ b/include/dd/UnaryComputeTable.hpp
@@ -60,8 +60,13 @@ public:
     lookups = 0;
   }
 
+  [[nodiscard]] std::size_t getHits() const { return hits; }
+  [[nodiscard]] std::size_t getLookups() const { return lookups; }
   [[nodiscard]] fp hitRatio() const {
-    return static_cast<fp>(hits) / static_cast<fp>(lookups);
+    if (lookups == 0U) {
+      return 1.;
+    }
+    return static_cast<fp>(getHits()) / static_cast<fp>(getLookups());
   }
 
   std::ostream& printStatistics(std::ostream& os = std::cout) {

--- a/include/dd/UnaryComputeTable.hpp
+++ b/include/dd/UnaryComputeTable.hpp
@@ -38,27 +38,22 @@ public:
     ++count;
   }
 
-  ResultType lookup(const OperandType& operand) {
-    ResultType result{};
+  ResultType* lookup(const OperandType& operand) {
+    ResultType* result = nullptr;
     lookups++;
     const auto key = hash(operand);
     auto& entry = table[key];
-    if (entry.result.p == nullptr) {
-      return result;
-    }
     if (entry.operand != operand) {
       return result;
     }
 
     hits++;
-    return entry.result;
+    return &entry.result;
   }
 
   void clear() {
     if (count > 0) {
-      for (auto& entry : table) {
-        entry.result.p = nullptr;
-      }
+      std::fill(table.begin(), table.end(), Entry{});
       count = 0;
     }
     hits = 0;

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -1241,29 +1241,32 @@ TEST(DDPackageTest, dNodeMulCache1) {
 
   const auto xCopy = dd::dEdge{state.p, dd::Complex::one};
   const auto yCopy = dd::dEdge{densityMatrix0.p, dd::Complex::one};
-  const auto cachedResult = computeTable.lookup(xCopy, yCopy, false);
-  ASSERT_NE(cachedResult.p, nullptr);
+  const auto* cachedResult = computeTable.lookup(xCopy, yCopy, false);
+  ASSERT_NE(cachedResult, nullptr);
+  ASSERT_NE(cachedResult->p, nullptr);
   state = dd->multiply(state, densityMatrix0, 0, false);
   ASSERT_NE(state.p, nullptr);
-  ASSERT_EQ(state.p, cachedResult.p);
+  ASSERT_EQ(state.p, cachedResult->p);
 
   const auto densityMatrix1 = dd::densityFromMatrixEdge(operation);
   const auto xCopy1 = dd::dEdge{densityMatrix1.p, dd::Complex::one};
   const auto yCopy1 = dd::dEdge{state.p, dd::Complex::one};
-  const auto cachedResult1 = computeTable.lookup(xCopy1, yCopy1, true);
-  ASSERT_NE(cachedResult1.p, nullptr);
+  const auto* cachedResult1 = computeTable.lookup(xCopy1, yCopy1, true);
+  ASSERT_NE(cachedResult1, nullptr);
+  ASSERT_NE(cachedResult1->p, nullptr);
   state = dd->multiply(densityMatrix1, state, 0, true);
   ASSERT_NE(state.p, nullptr);
-  ASSERT_EQ(state.p, cachedResult1.p);
+  ASSERT_EQ(state.p, cachedResult1->p);
 
   // try a repeated lookup
-  const auto cachedResult2 = computeTable.lookup(xCopy1, yCopy1, true);
-  ASSERT_NE(cachedResult2.p, nullptr);
-  ASSERT_EQ(cachedResult2.p, cachedResult1.p);
+  const auto* cachedResult2 = computeTable.lookup(xCopy1, yCopy1, true);
+  ASSERT_NE(cachedResult2, nullptr);
+  ASSERT_NE(cachedResult2->p, nullptr);
+  ASSERT_EQ(cachedResult2->p, cachedResult1->p);
 
   computeTable.clear();
-  const auto cachedResult3 = computeTable.lookup(xCopy1, yCopy1, true);
-  ASSERT_EQ(cachedResult3.p, nullptr);
+  const auto* cachedResult3 = computeTable.lookup(xCopy1, yCopy1, true);
+  ASSERT_EQ(cachedResult3, nullptr);
 }
 
 TEST(DDPackageTest, dNoiseCache) {


### PR DESCRIPTION
## Description

This PR fixes a regression in the compute table performance after #381.
Since terminals are no longer represented by separate entities the assumption that `e.p == nullptr` implies a lookup miss is no longer true. This PR adapts the corresponding places in the code to handle the changes properly.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
