### PR TITLE
🔥 Remove Snapshot and ShowProbabilities instructions from MQT Core

### DIFF
--- a/include/dd/FunctionalityConstruction.hpp
+++ b/include/dd/FunctionalityConstruction.hpp
@@ -45,8 +45,7 @@ inline void dumpTensorNetwork(std::ostream& of, const QuantumComputation& qc) {
   auto dd = std::make_unique<dd::Package<>>(qc.getNqubits());
   for (const auto& op : qc) {
     const auto type = op->getType();
-    if (op != qc.front() && (type != Measure && type != Barrier &&
-                             type != ShowProbabilities && type != Snapshot)) {
+    if (op != qc.front() && (type != Measure && type != Barrier)) {
       of << ",\n";
     }
     dumpTensor(op.get(), of, inds, gateIdx, dd);

--- a/include/dd/Operations.hpp
+++ b/include/dd/Operations.hpp
@@ -273,8 +273,7 @@ qc::MatrixDD getDD(const qc::Operation* op,
     return dd->makeIdent(nqubits);
   }
 
-  if (type == qc::ShowProbabilities || type == qc::Barrier ||
-      type == qc::Snapshot) {
+  if (type == qc::Barrier) {
     return dd->makeIdent(nqubits);
   }
 

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -17,25 +17,14 @@ protected:
   void printMeasurement(std::ostream& os, const std::vector<Qubit>& q,
                         const std::vector<Bit>& c,
                         const Permutation& permutation) const;
-  void printResetBarrierOrSnapshot(std::ostream& os,
-                                   const std::vector<Qubit>& q,
-                                   const Permutation& permutation) const;
+  void printResetOrBarrier(std::ostream& os, const std::vector<Qubit>& q,
+                           const Permutation& permutation) const;
 
 public:
   // Measurement constructor
   NonUnitaryOperation(std::size_t nq, std::vector<Qubit> qubitRegister,
                       std::vector<Bit> classicalRegister);
   NonUnitaryOperation(std::size_t nq, Qubit qubit, Bit cbit);
-
-  // Snapshot constructor
-  NonUnitaryOperation(std::size_t nq, const std::vector<Qubit>& qubitRegister,
-                      std::size_t n);
-
-  // ShowProbabilities constructor
-  explicit NonUnitaryOperation(const std::size_t nq) {
-    nqubits = nq;
-    type = ShowProbabilities;
-  }
 
   // General constructor
   NonUnitaryOperation(std::size_t nq, const std::vector<Qubit>& qubitRegister,
@@ -45,14 +34,6 @@ public:
     if (getType() == qc::Measure) {
       return std::make_unique<NonUnitaryOperation>(getNqubits(), getTargets(),
                                                    getClassics());
-    }
-    if (getType() == qc::Snapshot) {
-      return std::make_unique<NonUnitaryOperation>(
-          getNqubits(), getTargets(),
-          static_cast<std::size_t>(getParameter().at(0)));
-    }
-    if (getType() == qc::ShowProbabilities) {
-      return std::make_unique<NonUnitaryOperation>(getNqubits());
     }
     return std::make_unique<NonUnitaryOperation>(getNqubits(), getTargets(),
                                                  getType());

--- a/include/operations/OpType.hpp
+++ b/include/operations/OpType.hpp
@@ -47,8 +47,6 @@ enum OpType : std::uint8_t {
   // Non Unitary Operations
   Measure,
   Reset,
-  Snapshot,
-  ShowProbabilities,
   Barrier,
   Teleportation,
   // Classically-controlled Operation
@@ -136,10 +134,6 @@ inline std::string toString(const OpType& opType) {
     return "measure";
   case Reset:
     return "reset";
-  case Snapshot:
-    return "snapshot";
-  case ShowProbabilities:
-    return "show probabilities";
   case Barrier:
     return "barrier";
   case Teleportation:
@@ -241,8 +235,6 @@ const inline static std::unordered_map<std::string, qc::OpType>
         {"xx_plus_yy", OpType::XXplusYY},
         {"measure", OpType::Measure},
         {"reset", OpType::Reset},
-        {"snapshot", OpType::Snapshot},
-        {"show probabilities", OpType::ShowProbabilities},
         {"barrier", OpType::Barrier},
         {"teleportation", OpType::Teleportation},
         {"classic controlled", OpType::ClassicControlled},

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -387,8 +387,7 @@ void CircuitOptimizer::removeDiagonalGatesBeforeMeasureRecursive(
       }
     }
     auto* op = (*it)->get();
-    if (op->getType() == Barrier || op->getType() == Snapshot ||
-        op->getType() == ShowProbabilities) {
+    if (op->getType() == Barrier) {
       ++it;
     } else if (op->isStandardOperation()) {
       // try removing gate and upon success increase all corresponding iterators
@@ -548,8 +547,7 @@ void CircuitOptimizer::removeFinalMeasurementsRecursive(
           ++(dagIterators.at(target));
         }
       }
-    } else if (op->getType() == Barrier || op->getType() == Snapshot ||
-               op->getType() == ShowProbabilities) {
+    } else if (op->getType() == Barrier) {
       for (const auto& target : op->getTargets()) {
         if (dagIterators.at(target) == dag.at(target).rend()) {
           break;
@@ -1096,12 +1094,10 @@ void CircuitOptimizer::reorderOperations(QuantumComputation& qc) {
       // warning for classically controlled operations
       if (op->getType() == ClassicControlled) {
         std::cerr << "Caution! Reordering operations might not work if the "
-                     "circuit contains classically controlled operations"
-                  << std::endl;
+                     "circuit contains classically controlled operations\n";
       }
 
-      if (op->getType() == Barrier || op->getType() == Snapshot ||
-          op->getType() == ShowProbabilities) {
+      if (op->getType() == Barrier) {
         ++it;
         continue;
       }
@@ -1159,7 +1155,7 @@ void CircuitOptimizer::printDAG(const DAG& dag) {
       std::cout << std::hex << (*op).get() << std::dec << "("
                 << toString((*op)->getType()) << ") - ";
     }
-    std::cout << std::endl;
+    std::cout << "\n";
   }
 }
 void CircuitOptimizer::printDAG(const DAG& dag, const DAGIterators& iterators) {
@@ -1169,7 +1165,7 @@ void CircuitOptimizer::printDAG(const DAG& dag, const DAGIterators& iterators) {
       std::cout << std::hex << (**it).get() << std::dec << "("
                 << toString((**it)->getType()) << ") - ";
     }
-    std::cout << std::endl;
+    std::cout << "\n";
   }
 }
 

--- a/src/dd/Operations.cpp
+++ b/src/dd/Operations.cpp
@@ -124,11 +124,10 @@ void dumpTensor(qc::Operation* op, std::ostream& of,
       }
       dumpTensor(operation.get(), of, inds, gateIdx, dd);
     }
-  } else if (type == qc::Barrier || type == qc::ShowProbabilities ||
-             type == qc::Snapshot) {
+  } else if (type == qc::Barrier) {
     return;
   } else if (type == qc::Measure) {
-    std::clog << "Skipping measurement in tensor dump." << std::endl;
+    std::clog << "Skipping measurement in tensor dump.\n";
   } else {
     throw qc::QFRException("Dumping of tensors is currently only supported for "
                            "StandardOperations.");

--- a/src/operations/NonUnitaryOperation.cpp
+++ b/src/operations/NonUnitaryOperation.cpp
@@ -56,8 +56,6 @@ std::ostream& NonUnitaryOperation::printNonUnitary(
     printResetOrBarrier(os, q, permutation);
     break;
   default:
-    std::cerr << "Non-unitary operation with invalid type " << type
-              << " detected. Proceed with caution!\n";
     break;
   }
   return os;

--- a/src/operations/NonUnitaryOperation.cpp
+++ b/src/operations/NonUnitaryOperation.cpp
@@ -34,14 +34,6 @@ NonUnitaryOperation::NonUnitaryOperation(const std::size_t nq,
   Operation::setName();
 }
 
-// Snapshot constructor
-NonUnitaryOperation::NonUnitaryOperation(
-    const std::size_t nq, const std::vector<Qubit>& qubitRegister,
-    const std::size_t n)
-    : NonUnitaryOperation(nq, qubitRegister, Snapshot) {
-  parameter.emplace_back(static_cast<fp>(n));
-}
-
 // General constructor
 NonUnitaryOperation::NonUnitaryOperation(
     const std::size_t nq, const std::vector<Qubit>& qubitRegister, OpType op) {
@@ -61,15 +53,11 @@ std::ostream& NonUnitaryOperation::printNonUnitary(
     break;
   case Reset:
   case Barrier:
-  case Snapshot:
-    printResetBarrierOrSnapshot(os, q, permutation);
-    break;
-  case ShowProbabilities:
-    os << name;
+    printResetOrBarrier(os, q, permutation);
     break;
   default:
     std::cerr << "Non-unitary operation with invalid type " << type
-              << " detected. Proceed with caution!" << std::endl;
+              << " detected. Proceed with caution!\n";
     break;
   }
   return os;
@@ -78,59 +66,25 @@ std::ostream& NonUnitaryOperation::printNonUnitary(
 void NonUnitaryOperation::dumpOpenQASM(std::ostream& of,
                                        const RegisterNames& qreg,
                                        const RegisterNames& creg) const {
+  const auto& qubitArgs = getTargets();
+  if (isWholeQubitRegister(qreg, qubitArgs.front(), qubitArgs.back())) {
+    of << toString(type) << " " << qreg[qubitArgs.front()].first;
+    if (type == Measure) {
+      of << " -> ";
+      assert(isWholeQubitRegister(creg, classics.front(), classics.back()));
+      of << creg[classics.front()].first;
+    }
+    of << ";\n";
+    return;
+  }
   auto classicsIt = classics.cbegin();
-  switch (type) {
-  case Measure:
-    if (isWholeQubitRegister(qreg, qubits.front(), qubits.back()) &&
-        isWholeQubitRegister(qreg, classics.front(), classics.back())) {
-      of << "measure " << qreg[qubits.front()].first << " -> "
-         << creg[classics.front()].first << ";" << std::endl;
-    } else {
-      for (const auto& c : qubits) {
-        of << "measure " << qreg[c].second << " -> " << creg[*classicsIt].second
-           << ";" << std::endl;
-        ++classicsIt;
-      }
+  for (const auto& q : qubitArgs) {
+    of << toString(type) << " " << qreg[q].second;
+    if (type == Measure) {
+      of << " -> " << creg[*classicsIt].second;
+      ++classicsIt;
     }
-    break;
-  case Reset:
-    if (isWholeQubitRegister(qreg, targets.front(), targets.back())) {
-      of << "reset " << qreg[targets.front()].first << ";" << std::endl;
-    } else {
-      for (const auto& target : targets) {
-        of << "reset " << qreg[target].second << ";" << std::endl;
-      }
-    }
-    break;
-  case Snapshot:
-    if (!targets.empty()) {
-      of << "snapshot(" << parameter[0] << ") ";
-
-      for (unsigned int q = 0; q < targets.size(); ++q) {
-        if (q > 0) {
-          of << ", ";
-        }
-        of << qreg[targets[q]].second;
-      }
-      of << ";" << std::endl;
-    }
-    break;
-  case ShowProbabilities:
-    of << "show_probabilities;" << std::endl;
-    break;
-  case Barrier:
-    if (isWholeQubitRegister(qreg, targets.front(), targets.back())) {
-      of << "barrier " << qreg[targets.front()].first << ";" << std::endl;
-    } else {
-      for (const auto& target : targets) {
-        of << "barrier " << qreg[target].second << ";" << std::endl;
-      }
-    }
-    break;
-  default:
-    std::cerr << "Non-unitary operation with invalid type " << type
-              << " detected. Proceed with caution!" << std::endl;
-    break;
+    of << ";\n";
   }
 }
 
@@ -237,7 +191,7 @@ void NonUnitaryOperation::printMeasurement(
   }
 }
 
-void NonUnitaryOperation::printResetBarrierOrSnapshot(
+void NonUnitaryOperation::printResetOrBarrier(
     std::ostream& os, const std::vector<Qubit>& q,
     const Permutation& permutation) const {
   auto qubitIt = q.cbegin();
@@ -247,17 +201,13 @@ void NonUnitaryOperation::printResetBarrierOrSnapshot(
       if (qubitIt != q.cend() && *qubitIt == i) {
         if (type == Reset) {
           os << "\033[31m"
-             << "r\t"
-             << "\033[0m";
-        } else if (type == Barrier) {
-          os << "\033[32m"
-             << "b\t"
-             << "\033[0m";
+             << "r";
         } else {
-          os << "\033[33m"
-             << "s\t"
-             << "\033[0m";
+          assert(type == Barrier);
+          os << "\033[32m"
+             << "b";
         }
+        os << "\t\033[0m";
         ++qubitIt;
       } else {
         os << "|\t";
@@ -268,25 +218,18 @@ void NonUnitaryOperation::printResetBarrierOrSnapshot(
       if (qubitIt != q.cend() && *qubitIt == physical) {
         if (type == Reset) {
           os << "\033[31m"
-             << "r\t"
-             << "\033[0m";
-        } else if (type == Barrier) {
-          os << "\033[32m"
-             << "b\t"
-             << "\033[0m";
+             << "r";
         } else {
-          os << "\033[33m"
-             << "s\t"
-             << "\033[0m";
+          assert(type == Barrier);
+          os << "\033[32m"
+             << "b";
         }
+        os << "\t\033[0m";
         ++qubitIt;
       } else {
         os << "|\t";
       }
     }
-  }
-  if (type == Snapshot) {
-    os << "\tp: (" << q.size() << ") (" << parameter[0] << ")";
   }
 }
 } // namespace qc

--- a/src/parsers/QASMParser.cpp
+++ b/src/parsers/QASMParser.cpp
@@ -98,32 +98,15 @@ void qc::QuantumComputation::importOpenQASM(std::istream& is) {
       p.scan();
       p.check(Token::Kind::Lpar);
       p.check(Token::Kind::Nninteger);
-      auto n = static_cast<std::size_t>(p.t.val);
       p.check(Token::Kind::Rpar);
-
       std::vector<qc::QuantumRegister> arguments{};
       p.argList(arguments);
-
       p.check(Token::Kind::Semicolon);
-
-      for (auto& arg : arguments) {
-        if (arg.second != 1) {
-          p.error("Error in snapshot: arguments must be qubits");
-        }
-      }
-
-      Targets qubits{};
-      qubits.reserve(arguments.size());
-      for (auto& arg : arguments) {
-        qubits.emplace_back(arg.first);
-      }
-
-      emplace_back<NonUnitaryOperation>(nqubits, qubits, n);
+      // Snapshots have no meaning for MQT Core and are ignored.
     } else if (p.sym == Token::Kind::Probabilities) {
-      // show probabilities statement
-      emplace_back<NonUnitaryOperation>(nqubits);
       p.scan();
       p.check(Token::Kind::Semicolon);
+      // Show probabilities has no meaning for MQT Core and is ignored.
     } else if (p.sym == Token::Kind::Comment) {
       // comment
       p.scan();

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -777,8 +777,6 @@ TEST_F(QFRFunctionality, cloningDifferentOperations) {
   comp.h(0);
   qc.emplace_back(comp.asOperation());
   qc.classicControlled(qc::X, 0, qc.getCregs().at("c"), 1);
-  qc.emplace_back<NonUnitaryOperation>(qc.getNqubits(),
-                                       std::vector<Qubit>{0, 1}, 1);
 
   auto qcCloned = qc.clone();
   ASSERT_EQ(qc.size(), qcCloned.size());


### PR DESCRIPTION
## Description

Removed the parsing and creation of Snapshot and ShowProbabilities instructions from QASMParser and NonUnitaryOperations due to their irrelevance within MQT Core. This eliminates unnecessary error checking and streamlining the codebase. NonUnitaryOperation no longer needs to account for Snapshot and ShowProbabilities, simplifying its logic. The operations were also removed from related files and tests to maintain consistency.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
