### PR TITLE
📦 Enable target support from scikit-build-core

### DIFF
--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -91,6 +91,7 @@ jobs:
             src/**
             test/python/**
             noxfile.py
+            pyproject.toml
             .github/codecov.yml
             .github/workflows/reusable-python-linter.yml
             .github/workflows/reusable-python-tests.yml
@@ -114,6 +115,7 @@ jobs:
             include/**
             src/**
             test/**
+            pyproject.toml
             .github/codeql-config.yml
             .github/workflows/reusable-code-ql-cpp.yml
             .github/workflows/reusable-code-ql-python.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,9 +74,9 @@ repos:
       - id: check-sdist
         args: [--inject-junk]
         additional_dependencies:
-          - nanobind
-          - scikit-build-core[pyproject]
-          - setuptools-scm
+          - nanobind>=1.5.0
+          - scikit-build-core[pyproject]>=0.4.8
+          - setuptools-scm>=7
 
   # Run code formatting with Black
   - repo: https://github.com/psf/black-pre-commit-mirror

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ ci:
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.4.0"
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -37,14 +37,14 @@ repos:
 
   # Handling unwanted unicode characters
   - repo: https://github.com/sirosen/texthooks
-    rev: "0.5.0"
+    rev: 0.5.0
     hooks:
       - id: fix-ligatures
       - id: fix-smartquotes
 
   # Check for common mistakes
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: "v1.10.0"
+    rev: v1.10.0
     hooks:
       - id: rst-backticks
       - id: rst-directive-colons
@@ -69,7 +69,7 @@ repos:
 
   # Checking sdist validity
   - repo: https://github.com/henryiii/check-sdist
-    rev: "v0.1.2"
+    rev: v0.1.2
     hooks:
       - id: check-sdist
         args: [--inject-junk]
@@ -93,7 +93,7 @@ repos:
 
   # Clang-format the C++ part of the code base automatically
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: "v16.0.6"
+    rev: v16.0.6
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
@@ -109,14 +109,14 @@ repos:
 
   # Format configuration files with prettier
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.1"
+    rev: v3.0.1
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
 
   # Check for spelling
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.2.5"
+    rev: v2.2.5
     hooks:
       - id: codespell
         args: ["-L", "wille,linz", "--skip", "*.ipynb"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.4.5", "nanobind>=1.4.0", "setuptools-scm>=7"]
+requires = ["scikit-build-core>=0.4.8", "nanobind>=1.4.0", "setuptools-scm>=7"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -58,7 +58,10 @@ Discussions = "https://github.com/cda-tum/mqt-core/discussions"
 
 [tool.scikit-build]
 # Protect the configuration against future changes in scikit-build-core
-minimum-version = "0.4"
+minimum-version = "0.4.8"
+
+# Set the target to build
+cmake.targets = ["_core"]
 
 # Set required CMake and Ninja versions
 cmake.minimum-version = "3.19"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.4.8", "nanobind>=1.4.0", "setuptools-scm>=7"]
+requires = ["scikit-build-core>=0.4.8", "nanobind>=1.5.0", "setuptools-scm>=7"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
## Description

This PR enables the newly introduced target support of scikit-build-core. This should significantly speed-up the build process as it only builds the relevant CMake target and skips everything else.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
