### PR TITLE
♻️ Refactor `NonUnitaryOperation` class to simplify target handling

### DIFF
--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -6,14 +6,8 @@ namespace qc {
 
 class NonUnitaryOperation final : public Operation {
 protected:
-  std::vector<Qubit>
-      qubits{}; // vector for the qubits to measure (necessary since std::set
-                // does not preserve the order of inserted elements)
   std::vector<Bit> classics{}; // vector for the classical bits to measure into
 
-  std::ostream& printNonUnitary(std::ostream& os, const std::vector<Qubit>& q,
-                                const std::vector<Bit>& c = {},
-                                const Permutation& permutation = {}) const;
   void printMeasurement(std::ostream& os, const std::vector<Qubit>& q,
                         const std::vector<Bit>& c,
                         const Permutation& permutation) const;
@@ -27,8 +21,7 @@ public:
   NonUnitaryOperation(std::size_t nq, Qubit qubit, Bit cbit);
 
   // General constructor
-  NonUnitaryOperation(std::size_t nq, const std::vector<Qubit>& qubitRegister,
-                      OpType op = Reset);
+  NonUnitaryOperation(std::size_t nq, Targets qubits, OpType op = Reset);
 
   [[nodiscard]] std::unique_ptr<Operation> clone() const override {
     if (getType() == qc::Measure) {
@@ -43,27 +36,9 @@ public:
 
   [[nodiscard]] bool isNonUnitaryOperation() const override { return true; }
 
-  [[nodiscard]] const Targets& getTargets() const override {
-    if (type == Measure) {
-      return qubits;
-    }
-    return targets;
-  }
-  Targets& getTargets() override {
-    if (type == Measure) {
-      return qubits;
-    }
-    return targets;
-  }
-  [[nodiscard]] std::size_t getNtargets() const override {
-    return getTargets().size();
-  }
-
   [[nodiscard]] const std::vector<Bit>& getClassics() const { return classics; }
   std::vector<Bit>& getClassics() { return classics; }
   [[nodiscard]] size_t getNclassics() const { return classics.size(); }
-
-  [[nodiscard]] bool actsOn(Qubit i) const override;
 
   [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
                             const Permutation& perm2) const override;
@@ -71,22 +46,11 @@ public:
     return equals(operation, {}, {});
   }
 
-  std::ostream& print(std::ostream& os) const override {
-    const auto& qubitArgs = getTargets();
-    return printNonUnitary(os, qubitArgs, classics);
-  }
+  std::ostream& print(std::ostream& os) const override { return print(os, {}); }
   std::ostream& print(std::ostream& os,
-                      const Permutation& permutation) const override {
-    const auto& qubitArgs = getTargets();
-    return printNonUnitary(os, qubitArgs, classics, permutation);
-  }
+                      const Permutation& permutation) const override;
 
   void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
                     const RegisterNames& creg) const override;
-
-  [[nodiscard]] std::set<Qubit> getUsedQubits() const override {
-    const auto& ts = getTargets();
-    return {ts.begin(), ts.end()};
-  }
 };
 } // namespace qc


### PR DESCRIPTION
## Description

In the NonUnitaryOperation class, the previous implementation used two different vectors to manage the targets for Measure and other operations, which lead to redundancy in the code. This update unifies the handling of targets by using only one vector (named targets) for all operations. This simplification enhances the code readability and maintainability. It also removes the need of several functions like getTargets() and getUsedQubits(). Several function argument lists have also been refactored for cleaner and more consistent usage. Further, the print() function was restructured for better clarity. Overall, these changes will be beneficial for future development work.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
