### PR TITLE
♻️ [WIP] Remove redundant memory manager for complex numbers

### DIFF
--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -104,12 +104,6 @@ public:
    * separately. Hence, it suffices for the manager to only manage real numbers.
    */
   MemoryManager<RealNumber> cMemoryManager{};
-  /**
-   * @brief The cache manager for complex numbers
-   * @note Similar to the memory manager, the cache only maintains real entries,
-   * but typically gives them out in pairs to form complex numbers.
-   */
-  MemoryManager<RealNumber> cCacheManager{};
 
   /**
    * @brief Get the memory manager for a given type
@@ -139,7 +133,6 @@ public:
     mMemoryManager.reset(resizeToTotal);
     dMemoryManager.reset(resizeToTotal);
     cMemoryManager.reset(resizeToTotal);
-    cCacheManager.reset(resizeToTotal);
   }
 
   /// The unique table used for vector nodes
@@ -155,7 +148,7 @@ public:
    * @see RealNumberUniqueTable
    */
   RealNumberUniqueTable cUniqueTable{cMemoryManager};
-  ComplexNumbers cn{cUniqueTable, cCacheManager};
+  ComplexNumbers cn{cUniqueTable, cMemoryManager};
 
   /**
    * @brief Get the unique table for a given type

--- a/src/dd/ComplexNumbers.cpp
+++ b/src/dd/ComplexNumbers.cpp
@@ -245,7 +245,7 @@ void ComplexNumbers::returnToCache(const Complex& c) noexcept {
 }
 
 std::size_t ComplexNumbers::cacheCount() const noexcept {
-  return cacheManager->getUsedCount();
+  return cacheManager->getUsedCount() - realCount();
 }
 
 std::size_t ComplexNumbers::realCount() const noexcept {

--- a/src/dd/MemoryManager.cpp
+++ b/src/dd/MemoryManager.cpp
@@ -20,29 +20,7 @@ template <typename T> T* MemoryManager<T>::get() {
 }
 
 template <typename T> std::pair<T*, T*> MemoryManager<T>::getPair() {
-  if (entryAvailableForReuse()) {
-    auto* r = available;
-    assert(r->next != nullptr && "At least two entries must be available");
-    auto* i = available->next;
-    available = i->next;
-    usedCount += 2U;
-    peakUsedCount = std::max(peakUsedCount, usedCount);
-    availableForReuseCount -= 2U;
-    return {r, i};
-  }
-
-  if (!entryAvailableInChunk()) {
-    allocateNewChunk();
-  }
-
-  auto* r = &(*chunkIt);
-  ++chunkIt;
-  assert(chunkIt != chunkEndIt && "At least two entries must be available");
-  auto* i = &(*chunkIt);
-  ++chunkIt;
-  usedCount += 2U;
-  peakUsedCount = std::max(peakUsedCount, usedCount);
-  return {r, i};
+  return {get(), get()};
 }
 
 template <typename T> T* MemoryManager<T>::getTemporary() {
@@ -58,9 +36,7 @@ template <typename T> T* MemoryManager<T>::getTemporary() {
 }
 
 template <typename T> std::pair<T*, T*> MemoryManager<T>::getTemporaryPair() {
-  if (entryAvailableForReuse()) {
-    assert(available->next != nullptr &&
-           "At least two entries must be available");
+  if (entryAvailableForReuse() && available->next != nullptr) {
     return {available, available->next};
   }
 

--- a/test/dd/test_complex.cpp
+++ b/test/dd/test_complex.cpp
@@ -12,9 +12,8 @@ using CN = ComplexNumbers;
 class CNTest : public testing::Test {
 protected:
   MemoryManager<RealNumber> mm{};
-  MemoryManager<RealNumber> cm{};
   RealNumberUniqueTable ut{mm};
-  ComplexNumbers cn{ut, cm};
+  ComplexNumbers cn{ut, mm};
 };
 
 TEST_F(CNTest, TrivialTest) {
@@ -506,7 +505,7 @@ TEST_F(CNTest, ComplexTableAllocation) {
 }
 
 TEST_F(CNTest, ComplexCacheAllocation) {
-  auto allocs = cm.getAllocationCount();
+  auto allocs = mm.getAllocationCount();
   std::cout << allocs << "\n";
   std::vector<Complex> cnums{allocs};
   // get all the cached complex numbers that are pre-allocated
@@ -518,13 +517,13 @@ TEST_F(CNTest, ComplexCacheAllocation) {
   const auto cnum = cn.getCached();
   ASSERT_NE(cnum.r, nullptr);
   ASSERT_NE(cnum.i, nullptr);
-  EXPECT_EQ(cm.getAllocationCount(),
+  EXPECT_EQ(mm.getAllocationCount(),
             (1. + MemoryManager<RealNumber>::GROWTH_FACTOR) *
                 static_cast<fp>(allocs));
 
   // clearing the cache should reduce the allocated size to the original size
-  cm.reset();
-  EXPECT_EQ(cm.getAllocationCount(), allocs);
+  mm.reset();
+  EXPECT_EQ(mm.getAllocationCount(), allocs);
 
   // get all the cached complex numbers again
   for (auto i = 0U; i < allocs; i += 2) {
@@ -535,14 +534,14 @@ TEST_F(CNTest, ComplexCacheAllocation) {
   const auto tmp = cn.getTemporary();
   ASSERT_NE(tmp.r, nullptr);
   ASSERT_NE(tmp.i, nullptr);
-  EXPECT_EQ(cm.getAllocationCount(),
+  EXPECT_EQ(mm.getAllocationCount(),
             (1. + MemoryManager<RealNumber>::GROWTH_FACTOR) *
                 static_cast<fp>(allocs));
 
   // clearing the unique table should reduce the allocated size to the original
   // size
-  cm.reset();
-  EXPECT_EQ(cm.getAllocationCount(), allocs);
+  mm.reset();
+  EXPECT_EQ(mm.getAllocationCount(), allocs);
 }
 
 TEST_F(CNTest, DoubleHitInFindOrInsert) {

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -1048,7 +1048,6 @@ TEST(DDPackageTest, NormalizationNumericStabilityTest) {
     auto result = dd->multiply(p, pdag);
     EXPECT_TRUE(result.p->isIdentity());
     dd->cUniqueTable.clear();
-    dd->cCacheManager.reset();
     dd->cMemoryManager.reset();
   }
 }


### PR DESCRIPTION
## Description

This is a draft PR that tries to evaluate whether unifying the memory managers for numbers in the DD package increases the performance of the package. See #375 for more details.
This required rather few changes overall to get working. However, as of now, it seems that it leads to worse performance. Preliminary tests on my workstation show runtimes of roughly 31s vs. 37s for the `mqt-core-test-dd` target on `main` vs. this branch. I am fairly sure this can be improved if one carefully benchmarks/profiles the code.

#375 also hints at a possible performance improvement when looking up cached numbers where returning the number and allocating a new number could be skipped completely. This is not implemented yet and I do not have the time for it at the moment. If someone is up for it, please go ahead 😎 

Closes #375

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
