### PR TITLE
🩹 Remove Barrier check from actsOn method

### DIFF
--- a/include/operations/Operation.hpp
+++ b/include/operations/Operation.hpp
@@ -126,10 +126,6 @@ public:
   }
 
   [[nodiscard]] inline virtual bool actsOn(const Qubit i) const {
-    if (type == Barrier) {
-      return false;
-    }
-
     for (const auto& t : targets) {
       if (t == i) {
         return true;

--- a/test/dd/test_dd_functionality.cpp
+++ b/test/dd/test_dd_functionality.cpp
@@ -213,9 +213,6 @@ TEST_F(DDFunctionality, nonUnitary) {
   EXPECT_EQ(getInverseDD(&barrier, dd), dd->makeIdent(nqubits));
   EXPECT_EQ(getDD(&barrier, dd, dummyMap), dd->makeIdent(nqubits));
   EXPECT_EQ(getInverseDD(&barrier, dd, dummyMap), dd->makeIdent(nqubits));
-  for (Qubit i = 0; i < nqubits; ++i) {
-    EXPECT_FALSE(barrier.actsOn(i));
-  }
 }
 
 TEST_F(DDFunctionality, CircuitEquivalence) {

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1463,6 +1463,23 @@ TEST_F(QFRFunctionality, trivialOperationReordering) {
   EXPECT_EQ(target2, 0);
 }
 
+TEST_F(QFRFunctionality, OperationReorderingBarrier) {
+  QuantumComputation qc(2);
+  qc.h(0);
+  qc.barrier({0, 1});
+  qc.h(1);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::reorderOperations(qc);
+  std::cout << qc << "\n";
+  auto it = qc.begin();
+  const auto target = (*it)->getTargets().at(0);
+  EXPECT_EQ(target, 0);
+  ++it;
+  ++it;
+  const auto target2 = (*it)->getTargets().at(0);
+  EXPECT_EQ(target2, 1);
+}
+
 TEST_F(QFRFunctionality, FlattenRandomClifford) {
   qc::RandomCliffordCircuit rcs(2U, 3U, 0U);
   std::cout << rcs << "\n";


### PR DESCRIPTION
## Description

Having `Barrier` operations report that they do not act on any qubits caused some problems upstream. This PR fixes the underlying issue and adds a test to prevent such errors in the future.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
