### PR TITLE
🐛 Fix `Barrier` handling in remove final measurements optimisation

### DIFF
--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -499,7 +499,6 @@ bool CircuitOptimizer::removeFinalMeasurement(DAG& dag,
     } else {
       // set operation to identity so that it can be collected by the
       // removeIdentities pass
-      op->setTargets(op->getTargets()); // work-around to properly set targets
       op->setGate(qc::I);
     }
     return onlyMeasurements;
@@ -530,7 +529,7 @@ void CircuitOptimizer::removeFinalMeasurementsRecursive(
       }
     }
     auto* op = (*it)->get();
-    if (op->getType() == Measure) {
+    if (op->getType() == Measure || op->getType() == Barrier) {
       const bool onlyMeasurement =
           removeFinalMeasurement(dag, dagIterators, idx, it, op);
       if (onlyMeasurement) {
@@ -541,15 +540,6 @@ void CircuitOptimizer::removeFinalMeasurementsRecursive(
           ++(dagIterators.at(target));
         }
       }
-    } else if (op->getType() == Barrier) {
-      for (const auto& target : op->getTargets()) {
-        if (dagIterators.at(target) == dag.at(target).rend()) {
-          break;
-        }
-        ++(dagIterators.at(target));
-      }
-      // Barriers at the end of the circuit can be removed
-      op->setGate(OpType::I);
     } else if (op->isCompoundOperation() && op->isNonUnitaryOperation()) {
       // iterate over all gates of compound operation and upon success increase
       // all corresponding iterators

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -652,6 +652,20 @@ TEST_F(QFRFunctionality, removeFinalMeasurementsWithOperationsInFront) {
   ASSERT_EQ(qc.getNindividualOps(), 6);
 }
 
+TEST_F(QFRFunctionality, removeFinalMeasurementsWithBarrier) {
+  const std::size_t nqubits = 2;
+  QuantumComputation qc(nqubits);
+  qc.barrier({0, 1});
+  qc.measure(0, 0);
+  qc.measure(1, 1);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  CircuitOptimizer::removeFinalMeasurements(qc);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  EXPECT_TRUE(qc.empty());
+}
+
 TEST_F(QFRFunctionality, gateShortCutsAndCloning) {
   // This test checks if the gate shortcuts are working correctly
   // and if the cloning of gates is working correctly.


### PR DESCRIPTION
## Description

Fixes a newly introduced bug in the remove final measurements optimisation that surfaced in QCEC due to the way how Barrier gates are handled since there promotion from a NonUnitaryOperation to a StandardOperation.
`Barriers` are now treated similarly to measurements and a test is added to prevent future regressions.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
