### PR TITLE
♻️ Switch `pybind11` from submodule to `find_package`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,11 +3,6 @@
         url = https://github.com/nlohmann/json.git
         branch = develop
         shallow = true
-[submodule "extern/pybind11"]
-        path = extern/pybind11
-        url = https://github.com/pybind/pybind11.git
-        branch = master
-        shallow = true
 [submodule "extern/pybind11_json"]
         path = extern/pybind11_json
         url = https://github.com/pybind/pybind11_json.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,7 @@ repos:
           - nanobind>=1.5.0
           - scikit-build-core[pyproject]>=0.4.8
           - setuptools-scm>=7
+          - pybind11>=2.11
 
   # Run code formatting with Black
   - repo: https://github.com/psf/black-pre-commit-mirror

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,6 @@ if(NOT TARGET project_options)
 endif()
 
 check_submodule_present(json)
-check_submodule_present(pybind11)
 check_submodule_present(pybind11_json)
 check_submodule_present(boost/config)
 check_submodule_present(boost/multiprecision)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,15 @@ if(BUILD_MQT_CORE_BINDINGS)
   set(BINDINGS
       ON
       CACHE BOOL "Enable settings related to Python bindings" FORCE)
+  # cmake-lint: disable=C0103
+  set(Python_FIND_VIRTUALENV
+      FIRST
+      CACHE STRING "Give precedence to virtualenvs when searching for Python")
+  # top-level call to find Python
+  find_package(
+    Python 3.8 REQUIRED
+    COMPONENTS Interpreter Development.Module
+    OPTIONAL_COMPONENTS Development.SABIModule)
 endif()
 
 if(NOT TARGET project_warnings)

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ def lint(session: nox.Session) -> None:
 @nox.session(reuse_venv=True)
 def pylint(session: nox.Session) -> None:
     """Run PyLint."""
-    session.install("nanobind", "scikit-build-core[pyproject]", "setuptools_scm")
+    session.install("nanobind", "scikit-build-core[pyproject]", "setuptools_scm", "pybind11")
     session.install("--no-build-isolation", "-ve.[dev]", "pylint")
     session.run("pylint", "mqt.core", *session.posargs)
 
@@ -38,7 +38,7 @@ def tests(session: nox.Session) -> None:
     if "--cov" in posargs:
         posargs.append("--cov-config=pyproject.toml")
 
-    session.install("nanobind", "scikit-build-core[pyproject]", "setuptools_scm")
+    session.install("nanobind", "scikit-build-core[pyproject]", "setuptools_scm", "pybind11")
     session.install("--no-build-isolation", install_arg)
     session.run("pytest", *posargs, env=env)
 
@@ -47,7 +47,7 @@ def tests(session: nox.Session) -> None:
 def docs(session: nox.Session) -> None:
     """Build the docs."""
     session.install("sphinx-autobuild")
-    session.install("nanobind", "scikit-build-core[pyproject]", "setuptools_scm")
+    session.install("nanobind", "scikit-build-core[pyproject]", "setuptools_scm", "pybind11")
     session.install("--no-build-isolation", "-ve.[docs]")
 
     session.run("sphinx-autobuild", "docs", "docs/_build/html", "--open-browser")

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ import nox
 
 nox.options.sessions = ["lint", "pylint", "tests"]
 
-PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
+PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 if os.environ.get("CI", None):
     nox.options.error_on_missing_interpreters = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.4.8", "nanobind>=1.5.0", "setuptools-scm>=7"]
+requires = ["scikit-build-core>=0.4.8", "nanobind>=1.5.0", "setuptools-scm>=7", "pybind11>=2.11"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,7 +94,7 @@ add_subdirectory(ecc)
 # should switch to nanobind. After that, the pybind submodules will be removed.
 if(NOT TARGET ${PROJECT_NAME}-python)
   # add pybind11 library
-  add_subdirectory("${PROJECT_SOURCE_DIR}/extern/pybind11" "extern/pybind11" EXCLUDE_FROM_ALL)
+  find_package(pybind11 CONFIG REQUIRED)
 
   if(NOT TARGET pybind11_json)
     # add pybind11_json library

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,7 +92,16 @@ add_subdirectory(ecc)
 
 # ** Note ** The following target will soon be removed from the project. All top-level projects
 # should switch to nanobind. After that, the pybind submodules will be removed.
-if(NOT TARGET ${PROJECT_NAME}-python)
+if(BINDINGS AND NOT TARGET ${PROJECT_NAME}-python)
+  if(NOT SKBUILD)
+    # Manually detect the installed pybind11 package and import it into CMake.
+    execute_process(
+      COMMAND "${Python_EXECUTABLE}" -m pybind11 --cmakedir
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      OUTPUT_VARIABLE pybind11_DIR)
+    list(APPEND CMAKE_PREFIX_PATH "${pybind11_DIR}")
+  endif()
+
   # add pybind11 library
   find_package(pybind11 CONFIG REQUIRED)
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -28,8 +28,8 @@ if(NOT SKBUILD)
   execute_process(
     COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
     OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE NB_DIR)
-  list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
+    OUTPUT_VARIABLE nanobind_DIR)
+  list(APPEND CMAKE_PREFIX_PATH "${nanobind_DIR}")
 endif()
 
 # Import nanobind through CMake's find_package mechanism

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -23,12 +23,6 @@ if(NOT SKBUILD)
   after editing C++ files.")
 endif()
 
-# Try to import all Python components potentially needed by nanobind
-find_package(
-  Python 3.8 REQUIRED
-  COMPONENTS Interpreter Development.Module
-  OPTIONAL_COMPONENTS Development.SABIModule)
-
 if(NOT SKBUILD)
   # Manually detect the installed nanobind package and import it into CMake.
   execute_process(

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT SKBUILD)
   in your environment once and use the following command that avoids
   a costly creation of a new virtual environment at every compilation:
   =====================================================================
-   $ pip install nanobind scikit-build-core[pyproject] setuptools_scm
+   $ pip install nanobind 'scikit-build-core[pyproject]' setuptools_scm pybind11
    $ pip install --no-build-isolation -ve .
   =====================================================================
   You may optionally add -Ceditable.rebuild=true to auto-rebuild when


### PR DESCRIPTION
## Description

This PR replaces the `pybind11` submodule with a more convenient version to obtain and maintain pybind11. Namely, to just obtain it via `pip` similar to how `nanobind` is obtained.
In the long run, `pybind11` will most likely be completely replaced by nanobind.
This PR makes a first step in that direction and removes the submodule.
This should, e.g., reduce the sdist sizes for all of our projects and also means one dependabot PR per month less.
Top-level projects will have to adapt their build-time dependencies and add `pybind11`.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
