### PR TITLE
Add `addControl`, `clearControls`, `removeControl` functions on Operation

### DIFF
--- a/include/operations/ClassicControlledOperation.hpp
+++ b/include/operations/ClassicControlledOperation.hpp
@@ -80,6 +80,10 @@ public:
 
   void removeControl(const Control c) override { op->removeControl(c); }
 
+  Controls::iterator removeControl(const Controls::iterator it) override {
+    return op->removeControl(it);
+  }
+
   [[nodiscard]] bool equals(const Operation& operation,
                             const Permutation& perm1,
                             const Permutation& perm2) const override {

--- a/include/operations/ClassicControlledOperation.hpp
+++ b/include/operations/ClassicControlledOperation.hpp
@@ -63,7 +63,7 @@ public:
   Controls& getControls() override { return op->getControls(); }
 
   [[nodiscard]] std::size_t getNcontrols() const override {
-    return controls.size();
+    return op->getNcontrols();
   }
 
   [[nodiscard]] bool isUnitary() const override { return false; }
@@ -73,6 +73,12 @@ public:
   }
 
   [[nodiscard]] bool actsOn(Qubit i) const override { return op->actsOn(i); }
+
+  void addControls(const Controls& c) override { op->addControls(c); }
+
+  void clearControls() override { op->clearControls(); }
+
+  void removeControls(const Controls& c) override { op->removeControls(c); }
 
   [[nodiscard]] bool equals(const Operation& operation,
                             const Permutation& perm1,

--- a/include/operations/ClassicControlledOperation.hpp
+++ b/include/operations/ClassicControlledOperation.hpp
@@ -74,11 +74,11 @@ public:
 
   [[nodiscard]] bool actsOn(Qubit i) const override { return op->actsOn(i); }
 
-  void addControls(const Controls& c) override { op->addControls(c); }
+  void addControl(const Control c) override { op->addControl(c); }
 
   void clearControls() override { op->clearControls(); }
 
-  void removeControls(const Controls& c) override { op->removeControls(c); }
+  void removeControl(const Control c) override { op->removeControl(c); }
 
   [[nodiscard]] bool equals(const Operation& operation,
                             const Permutation& perm1,

--- a/include/operations/CompoundOperation.hpp
+++ b/include/operations/CompoundOperation.hpp
@@ -54,33 +54,31 @@ public:
     });
   }
 
-  void addControls(const Controls& c) override {
-    for (auto ctrl : c) {
-      controls.insert(ctrl);
-    }
+  void addControl(const Control c) override {
+    controls.insert(c);
     // we can just add the controls to each operation, as the operations will
     // check if they already act on the control qubits.
     for (auto& op : ops) {
-      op->addControls(c);
+      op->addControl(c);
     }
   }
 
   void clearControls() override {
     // we remove just our controls from nested operations
+    // We need to copy controls here as we will modify the set while iterating
     removeControls(Controls{controls});
   }
 
-  void removeControls(const Controls& c) override {
+  void removeControl(const Control c) override {
     // first we iterate over our controls and check if we are actually allowed
     // to remove them
-    for (const auto& ctrl : c) {
-      if (controls.erase(ctrl) == 0) {
-        throw QFRException("Cannot remove control from compound operation.");
-      }
+    if (controls.erase(c) == 0) {
+      throw QFRException("Cannot remove control from compound operation as it "
+                         "is not a control.");
     }
 
     for (auto& op : ops) {
-      op->removeControls(c);
+      op->removeControl(c);
     }
   }
 

--- a/include/operations/CompoundOperation.hpp
+++ b/include/operations/CompoundOperation.hpp
@@ -54,6 +54,36 @@ public:
     });
   }
 
+  void addControls(const Controls& c) override {
+    for (auto ctrl : c) {
+      controls.insert(ctrl);
+    }
+    // we can just add the controls to each operation, as the operations will
+    // check if they already act on the control qubits.
+    for (auto& op : ops) {
+      op->addControls(c);
+    }
+  }
+
+  void clearControls() override {
+    // we remove just our controls from nested operations
+    removeControls(Controls{controls});
+  }
+
+  void removeControls(const Controls& c) override {
+    // first we iterate over our controls and check if we are actually allowed
+    // to remove them
+    for (const auto& ctrl : c) {
+      if (controls.erase(ctrl) == 0) {
+        throw QFRException("Cannot remove control from compound operation.");
+      }
+    }
+
+    for (auto& op : ops) {
+      op->removeControls(c);
+    }
+  }
+
   [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
                             const Permutation& perm2) const override {
     if (const auto* comp = dynamic_cast<const CompoundOperation*>(&op)) {

--- a/include/operations/CompoundOperation.hpp
+++ b/include/operations/CompoundOperation.hpp
@@ -65,8 +65,7 @@ public:
 
   void clearControls() override {
     // we remove just our controls from nested operations
-    // We need to copy controls here as we will modify the set while iterating
-    removeControls(Controls{controls});
+    removeControls(controls);
   }
 
   void removeControl(const Control c) override {
@@ -80,6 +79,14 @@ public:
     for (auto& op : ops) {
       op->removeControl(c);
     }
+  }
+
+  Controls::iterator removeControl(const Controls::iterator it) override {
+    for (auto& op : ops) {
+      op->removeControl(*it);
+    }
+
+    return controls.erase(it);
   }
 
   [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -40,6 +40,12 @@ public:
   std::vector<Bit>& getClassics() { return classics; }
   [[nodiscard]] size_t getNclassics() const { return classics.size(); }
 
+  Controls& getControls() const override {
+    throw QFRException("Cannot get controls from non-unitary operation.");
+  }
+
+  void addDepthContribution(std::vector<std::size_t>& depths) const override;
+
   void addControl(const Control /*c*/) override {
     throw QFRException("Cannot add control to non-unitary operation.");
   }

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -48,7 +48,6 @@ public:
     throw QFRException("Cannot clear controls from non-unitary operation.");
   }
 
-
   void removeControls(const Controls& /*c*/) override {
     throw QFRException("Cannot remove controls from non-unitary operation.");
   }

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -40,7 +40,7 @@ public:
   std::vector<Bit>& getClassics() { return classics; }
   [[nodiscard]] size_t getNclassics() const { return classics.size(); }
 
-  Controls& getControls() const override {
+  [[nodiscard]] Controls& getControls() const override {
     throw QFRException("Cannot get controls from non-unitary operation.");
   }
 

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -58,6 +58,10 @@ public:
     throw QFRException("Cannot remove controls from non-unitary operation.");
   }
 
+  Controls::iterator removeControl(const Controls::iterator /*it*/) override {
+    throw QFRException("Cannot remove controls from non-unitary operation.");
+  }
+
   [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
                             const Permutation& perm2) const override;
   [[nodiscard]] bool equals(const Operation& operation) const override {

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -40,6 +40,11 @@ public:
   std::vector<Bit>& getClassics() { return classics; }
   [[nodiscard]] size_t getNclassics() const { return classics.size(); }
 
+  [[nodiscard]] std::set<Qubit> getUsedQubits() const override {
+    const auto& opTargets = getTargets();
+    return {opTargets.begin(), opTargets.end()};
+  }
+
   [[nodiscard]] Controls& getControls() const override {
     throw QFRException("Cannot get controls from non-unitary operation.");
   }

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -40,6 +40,19 @@ public:
   std::vector<Bit>& getClassics() { return classics; }
   [[nodiscard]] size_t getNclassics() const { return classics.size(); }
 
+  void addControls(const Controls& /*c*/) override {
+    throw QFRException("Cannot add controls to non-unitary operation.");
+  }
+
+  void clearControls() override {
+    throw QFRException("Cannot clear controls from non-unitary operation.");
+  }
+
+
+  void removeControls(const Controls& /*c*/) override {
+    throw QFRException("Cannot remove controls from non-unitary operation.");
+  }
+
   [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
                             const Permutation& perm2) const override;
   [[nodiscard]] bool equals(const Operation& operation) const override {

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -40,15 +40,15 @@ public:
   std::vector<Bit>& getClassics() { return classics; }
   [[nodiscard]] size_t getNclassics() const { return classics.size(); }
 
-  void addControls(const Controls& /*c*/) override {
-    throw QFRException("Cannot add controls to non-unitary operation.");
+  void addControl(const Control /*c*/) override {
+    throw QFRException("Cannot add control to non-unitary operation.");
   }
 
   void clearControls() override {
     throw QFRException("Cannot clear controls from non-unitary operation.");
   }
 
-  void removeControls(const Controls& /*c*/) override {
+  void removeControl(const Control /*c*/) override {
     throw QFRException("Cannot remove controls from non-unitary operation.");
   }
 

--- a/include/operations/Operation.hpp
+++ b/include/operations/Operation.hpp
@@ -88,7 +88,20 @@ public:
 
   virtual void setTargets(const Targets& t) { targets = t; }
 
-  virtual void setControls(const Controls& c) { controls = c; }
+  virtual void setControls(const Controls& c) {
+    clearControls();
+    addControls(c);
+  }
+
+  virtual void addControl(const Control c) { addControls({c}); }
+
+  virtual void addControls(const Controls& c) = 0;
+
+  virtual void clearControls() = 0;
+
+  virtual void removeControl(const Control c) { removeControls({c}); }
+
+  virtual void removeControls(const Controls& c) = 0;
 
   virtual void setName();
 

--- a/include/operations/Operation.hpp
+++ b/include/operations/Operation.hpp
@@ -93,7 +93,7 @@ public:
     addControls(c);
   }
 
-  virtual void addControl(const Control c) = 0;
+  virtual void addControl(Control c) = 0;
 
   void addControls(const Controls& c) {
     for (const auto& control : c) {
@@ -103,11 +103,13 @@ public:
 
   virtual void clearControls() = 0;
 
-  virtual void removeControl(const Control c) = 0;
+  virtual void removeControl(Control c) = 0;
+
+  virtual Controls::iterator removeControl(Controls::iterator it) = 0;
 
   void removeControls(const Controls& c) {
-    for (const auto& control : c) {
-      removeControl(control);
+    for (auto it = c.begin(); it != c.end();) {
+      it = removeControl(it);
     }
   }
 

--- a/include/operations/Operation.hpp
+++ b/include/operations/Operation.hpp
@@ -93,15 +93,23 @@ public:
     addControls(c);
   }
 
-  virtual void addControl(const Control c) { addControls({c}); }
+  virtual void addControl(const Control c) = 0;
 
-  virtual void addControls(const Controls& c) = 0;
+  void addControls(const Controls& c) {
+    for (const auto& control : c) {
+      addControl(control);
+    }
+  }
 
   virtual void clearControls() = 0;
 
-  virtual void removeControl(const Control c) { removeControls({c}); }
+  virtual void removeControl(const Control c) = 0;
 
-  virtual void removeControls(const Controls& c) = 0;
+  void removeControls(const Controls& c) {
+    for (const auto& control : c) {
+      removeControl(control);
+    }
+  }
 
   virtual void setName();
 

--- a/include/operations/StandardOperation.hpp
+++ b/include/operations/StandardOperation.hpp
@@ -72,6 +72,26 @@ public:
 
   [[nodiscard]] bool isStandardOperation() const override { return true; }
 
+  void addControls(const Controls& c) override {
+    for (auto ctrl : c) {
+      if (actsOn(ctrl.qubit)) {
+        throw QFRException(
+            "Cannot add control to operation as it already acts on "
+            "the control qubit.");
+      }
+
+      controls.insert(ctrl);
+    }
+  }
+
+  void clearControls() override { controls.clear(); }
+
+  void removeControls(const Controls& c) override {
+    for (auto ctrl : c) {
+      controls.erase(ctrl);
+    }
+  }
+
   [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
                             const Permutation& perm2) const override {
     return Operation::equals(op, perm1, perm2);

--- a/include/operations/StandardOperation.hpp
+++ b/include/operations/StandardOperation.hpp
@@ -72,23 +72,22 @@ public:
 
   [[nodiscard]] bool isStandardOperation() const override { return true; }
 
-  void addControls(const Controls& c) override {
-    for (auto ctrl : c) {
-      if (actsOn(ctrl.qubit)) {
-        throw QFRException(
-            "Cannot add control to operation as it already acts on "
-            "the control qubit.");
-      }
-
-      controls.insert(ctrl);
+  void addControl(const Control c) override {
+    if (actsOn(c.qubit)) {
+      throw QFRException(
+          "Cannot add control to operation as it already acts on "
+          "the control qubit.");
     }
+
+    controls.emplace(c);
   }
 
   void clearControls() override { controls.clear(); }
 
-  void removeControls(const Controls& c) override {
-    for (auto ctrl : c) {
-      controls.erase(ctrl);
+  void removeControl(const Control c) override {
+    if (controls.erase(c) == 0) {
+      throw QFRException("Cannot remove control from operation as it is not a "
+                         "control.");
     }
   }
 

--- a/include/operations/StandardOperation.hpp
+++ b/include/operations/StandardOperation.hpp
@@ -74,9 +74,9 @@ public:
 
   void addControl(const Control c) override {
     if (actsOn(c.qubit)) {
-      throw QFRException(
-          "Cannot add control to operation as it already acts on "
-          "the control qubit.");
+      throw QFRException("Cannot add control on qubit " +
+                         std::to_string(c.qubit) +
+                         " to operation it already acts on the qubit.");
     }
 
     controls.emplace(c);
@@ -86,8 +86,9 @@ public:
 
   void removeControl(const Control c) override {
     if (controls.erase(c) == 0) {
-      throw QFRException("Cannot remove control from operation as it is not a "
-                         "control.");
+      throw QFRException("Cannot remove control on qubit " +
+                         std::to_string(c.qubit) +
+                         " from operation as it is not a control.");
     }
   }
 

--- a/include/operations/StandardOperation.hpp
+++ b/include/operations/StandardOperation.hpp
@@ -91,6 +91,10 @@ public:
     }
   }
 
+  Controls::iterator removeControl(const Controls::iterator it) override {
+    return controls.erase(it);
+  }
+
   [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
                             const Permutation& perm2) const override {
     return Operation::equals(op, perm1, perm2);

--- a/include/operations/SymbolicOperation.hpp
+++ b/include/operations/SymbolicOperation.hpp
@@ -125,6 +125,26 @@ public:
                        [](const auto& sym) { return !sym.has_value(); });
   }
 
+  void addControls(const Controls& c) override {
+    for (auto ctrl : c) {
+      if (actsOn(ctrl.qubit)) {
+        throw QFRException(
+            "Cannot add control to operation as it already acts on "
+            "the control qubit.");
+      }
+
+      controls.insert(ctrl);
+    }
+  }
+
+  void clearControls() override { controls.clear(); }
+
+  void removeControls(const Controls& c) override {
+    for (auto ctrl : c) {
+      controls.erase(ctrl);
+    }
+  }
+
   [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
                             const Permutation& perm2) const override;
   [[nodiscard]] inline bool equals(const Operation& op) const override {

--- a/include/operations/SymbolicOperation.hpp
+++ b/include/operations/SymbolicOperation.hpp
@@ -125,26 +125,6 @@ public:
                        [](const auto& sym) { return !sym.has_value(); });
   }
 
-  void addControls(const Controls& c) override {
-    for (auto ctrl : c) {
-      if (actsOn(ctrl.qubit)) {
-        throw QFRException(
-            "Cannot add control to operation as it already acts on "
-            "the control qubit.");
-      }
-
-      controls.insert(ctrl);
-    }
-  }
-
-  void clearControls() override { controls.clear(); }
-
-  void removeControls(const Controls& c) override {
-    for (auto ctrl : c) {
-      controls.erase(ctrl);
-    }
-  }
-
   [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
                             const Permutation& perm2) const override;
   [[nodiscard]] inline bool equals(const Operation& op) const override {

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -95,9 +95,9 @@ void CircuitOptimizer::swapReconstruction(QuantumComputation& qc) {
       dag.at(control).pop_back();
       dag.at(target).pop_back();
       (*opC)->setGate(I);
-      (*opC)->setControls({});
+      (*opC)->clearControls();
       it->setGate(I);
-      it->setControls({});
+      it->clearControls();
     } else if (control == opCtarget && target == opCcontrol) {
       dag.at(control).pop_back();
       dag.at(target).pop_back();
@@ -109,7 +109,7 @@ void CircuitOptimizer::swapReconstruction(QuantumComputation& qc) {
       } else {
         (*opC)->setTargets({target, control});
       }
-      (*opC)->setControls({});
+      (*opC)->clearControls();
       addToDag(dag, opC);
 
       it->setTargets({control});
@@ -1257,9 +1257,9 @@ void CircuitOptimizer::cancelCNOTs(QuantumComputation& qc) {
         dag.at(q0).pop_back();
         dag.at(q1).pop_back();
         op0->setGate(I);
-        op0->setControls({});
+        op0->clearControls();
         it->setGate(I);
-        it->setControls({});
+        it->clearControls();
       } else {
         // two CNOTs with alternating controls and targets
         // check whether there is a third one which would make this a SWAP gate
@@ -1297,16 +1297,16 @@ void CircuitOptimizer::cancelCNOTs(QuantumComputation& qc) {
         if (q0 == prevPrevQ0 && q1 == prevPrevQ1) {
           // SWAP gate identified
           prevPrevOp0->setGate(SWAP);
-          prevPrevOp0->setControls({});
+          prevPrevOp0->clearControls();
           if (prevQ0 > prevQ1) {
             prevPrevOp0->setTargets({prevQ1, prevQ0});
           } else {
             prevPrevOp0->setTargets({prevQ0, prevQ1});
           }
           op0->setGate(I);
-          op0->setControls({});
+          op0->clearControls();
           it->setGate(I);
-          it->setControls({});
+          it->clearControls();
           dag.at(q0).pop_back();
           dag.at(q1).pop_back();
         } else {
@@ -1323,9 +1323,9 @@ void CircuitOptimizer::cancelCNOTs(QuantumComputation& qc) {
         dag.at(q0).pop_back();
         dag.at(q1).pop_back();
         op0->setGate(I);
-        op0->setControls({});
+        op0->clearControls();
         it->setGate(I);
-        it->setControls({});
+        it->clearControls();
       } else {
         addToDag(dag, &it);
       }
@@ -1335,21 +1335,21 @@ void CircuitOptimizer::cancelCNOTs(QuantumComputation& qc) {
     if (isCNOT && prevOpIsSWAP) {
       // SWAP followed by a CNOT is equivalent to two CNOTs
       op0->setGate(X);
-      op0->setControls({Control{q1}});
       op0->setTargets({q0});
-      it->setControls({Control{q0}});
+      op0->setControls({Control{q1}});
       it->setTargets({q1});
+      it->setControls({Control{q0}});
       addToDag(dag, &it);
       continue;
     }
 
     if (isSWAP && prevOpIsCNOT) {
       // CNOT followed by a SWAP is equivalent to two CNOTs
-      op0->setControls({Control{prevQ0}});
       op0->setTargets({prevQ1});
+      op0->setControls({Control{prevQ0}});
       it->setGate(X);
-      it->setControls({Control{prevQ1}});
       it->setTargets({prevQ0});
+      it->setControls({Control{prevQ1}});
       addToDag(dag, &it);
       continue;
     }

--- a/src/operations/NonUnitaryOperation.cpp
+++ b/src/operations/NonUnitaryOperation.cpp
@@ -191,4 +191,20 @@ void NonUnitaryOperation::printReset(std::ostream& os,
     }
   }
 }
+
+void NonUnitaryOperation::addDepthContribution(
+    std::vector<std::size_t>& depths) const {
+  if (type == Barrier) {
+    return;
+  }
+
+  std::size_t maxDepth = 0;
+  for (const auto& target : getTargets()) {
+    maxDepth = std::max(maxDepth, depths[target]);
+  }
+  maxDepth += 1;
+  for (const auto& target : getTargets()) {
+    depths[target] = maxDepth;
+  }
+}
 } // namespace qc

--- a/src/operations/NonUnitaryOperation.cpp
+++ b/src/operations/NonUnitaryOperation.cpp
@@ -194,17 +194,8 @@ void NonUnitaryOperation::printReset(std::ostream& os,
 
 void NonUnitaryOperation::addDepthContribution(
     std::vector<std::size_t>& depths) const {
-  if (type == Barrier) {
-    return;
-  }
-
-  std::size_t maxDepth = 0;
   for (const auto& target : getTargets()) {
-    maxDepth = std::max(maxDepth, depths[target]);
-  }
-  maxDepth += 1;
-  for (const auto& target : getTargets()) {
-    depths[target] = maxDepth;
+    depths[target] += 1;
   }
 }
 } // namespace qc

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1989,6 +1989,15 @@ TEST_F(QFRFunctionality, addControlClassicControlledOperation) {
   EXPECT_EQ(op.getNcontrols(), 0);
 }
 
+TEST_F(QFRFunctionality, addControlNonUnitaryOperation) {
+  auto op = NonUnitaryOperation(1U, 0U, Measure);
+
+  EXPECT_THROW(static_cast<void>(op.getControls()), QFRException);
+  EXPECT_THROW(op.addControl(1_pc), QFRException);
+  EXPECT_THROW(op.removeControl(1_pc), QFRException);
+  EXPECT_THROW(op.clearControls(), QFRException);
+}
+
 TEST_F(QFRFunctionality, addControlCompundOperation) {
   auto op = CompoundOperation(4);
 

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1939,34 +1939,30 @@ TEST_F(QFRFunctionality, dumpAndImportTeleportation) {
 }
 
 TEST_F(QFRFunctionality, addControlStandardOperation) {
-  auto op = StandardOperation(2, Targets{0}, OpType::X);
-
-  op.addControl(Control{1, Control::Type::Pos});
-  op.addControl(Control{2, Control::Type::Pos});
-
+  auto op = StandardOperation(3, 0, OpType::X);
+  op.addControl(1_pc);
+  op.addControl(2_pc);
   ASSERT_EQ(op.getNcontrols(), 2);
-  auto expectedControls =
-      Controls{Control{1, Control::Type::Pos}, Control{2, Control::Type::Pos}};
+  const auto expectedControls = Controls{1_pc, 2_pc};
   EXPECT_EQ(op.getControls(), expectedControls);
-  op.removeControl(Control{1, Control::Type::Pos});
-  auto expectedControlsAfterRemove = Controls{Control{2, Control::Type::Pos}};
+  op.removeControl(1_pc);
+  const auto expectedControlsAfterRemove = Controls{2_pc};
   EXPECT_EQ(op.getControls(), expectedControlsAfterRemove);
   op.clearControls();
   EXPECT_EQ(op.getNcontrols(), 0);
 }
 
 TEST_F(QFRFunctionality, addControlSymbolicOperation) {
-  auto op = SymbolicOperation(2, Targets{0}, OpType::X);
+  auto op = SymbolicOperation(3, 0, OpType::X);
 
-  op.addControl(Control{1, Control::Type::Pos});
-  op.addControl(Control{2, Control::Type::Pos});
+  op.addControl(1_pc);
+  op.addControl(2_pc);
 
   ASSERT_EQ(op.getNcontrols(), 2);
-  auto expectedControls =
-      Controls{Control{1, Control::Type::Pos}, Control{2, Control::Type::Pos}};
+  auto expectedControls = Controls{1_pc, 2_pc};
   EXPECT_EQ(op.getControls(), expectedControls);
-  op.removeControl(Control{1, Control::Type::Pos});
-  auto expectedControlsAfterRemove = Controls{Control{2, Control::Type::Pos}};
+  op.removeControl(1_pc);
+  auto expectedControlsAfterRemove = Controls{2_pc};
   EXPECT_EQ(op.getControls(), expectedControlsAfterRemove);
   op.clearControls();
   EXPECT_EQ(op.getNcontrols(), 0);
@@ -1979,15 +1975,14 @@ TEST_F(QFRFunctionality, addControlClassicControlledOperation) {
   const auto expectedValue = 0U;
   auto op = ClassicControlledOperation(xp, controlRegister, expectedValue);
 
-  op.addControl(Control{1, Control::Type::Pos});
-  op.addControl(Control{2, Control::Type::Pos});
+  op.addControl(1_pc);
+  op.addControl(2_pc);
 
   ASSERT_EQ(op.getNcontrols(), 2);
-  auto expectedControls =
-      Controls{Control{1, Control::Type::Pos}, Control{2, Control::Type::Pos}};
+  auto expectedControls = Controls{1_pc, 2_pc};
   EXPECT_EQ(op.getControls(), expectedControls);
-  op.removeControl(Control{1, Control::Type::Pos});
-  auto expectedControlsAfterRemove = Controls{Control{2, Control::Type::Pos}};
+  op.removeControl(1_pc);
+  auto expectedControlsAfterRemove = Controls{2_pc};
   EXPECT_EQ(op.getControls(), expectedControlsAfterRemove);
   op.clearControls();
   EXPECT_EQ(op.getNcontrols(), 0);
@@ -1996,8 +1991,8 @@ TEST_F(QFRFunctionality, addControlClassicControlledOperation) {
 TEST_F(QFRFunctionality, addControlCompundOperation) {
   auto op = CompoundOperation(4);
 
-  auto control0 = Control{0, Control::Type::Pos};
-  auto control1 = Control{1, Control::Type::Pos};
+  auto control0 = 0_pc;
+  auto control1 = 1_pc;
 
   auto xOp = std::make_unique<StandardOperation>(4, Targets{1}, OpType::X);
   auto cxOp = std::make_unique<StandardOperation>(4, Targets{3}, OpType::X);
@@ -2020,7 +2015,7 @@ TEST_F(QFRFunctionality, addControlCompundOperation) {
 }
 
 TEST_F(QFRFunctionality, addControlTwice) {
-  Control const control{0, Control::Type::Pos};
+  auto control = 0_pc;
 
   std::unique_ptr<Operation> op =
       std::make_unique<StandardOperation>(2, Targets{1}, OpType::X);
@@ -2038,7 +2033,7 @@ TEST_F(QFRFunctionality, addControlTwice) {
 
 TEST_F(QFRFunctionality, addTargetAsControl) {
   // Adding a control that is already a target
-  Control const control{1, Control::Type::Pos};
+  auto control = 1_pc;
 
   std::unique_ptr<Operation> op =
       std::make_unique<StandardOperation>(2, Targets{1}, OpType::X);
@@ -2055,7 +2050,7 @@ TEST_F(QFRFunctionality, addTargetAsControl) {
 TEST_F(QFRFunctionality, addControlCompundOperationInvalid) {
   auto op = CompoundOperation(4);
 
-  auto control1 = Control{1, Control::Type::Pos};
+  auto control1 = 1_pc;
 
   auto xOp = std::make_unique<StandardOperation>(4, Targets{1}, OpType::X);
   auto cxOp = std::make_unique<StandardOperation>(4, Targets{3}, OpType::X);

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1953,7 +1953,7 @@ TEST_F(QFRFunctionality, addControlStandardOperation) {
   ASSERT_THROW(op.removeControl(1_pc), QFRException);
 
   op.addControl(1_pc);
-  const auto &controls = op.getControls();
+  const auto& controls = op.getControls();
   EXPECT_EQ(op.removeControl(controls.begin()), controls.end());
 }
 
@@ -1973,7 +1973,7 @@ TEST_F(QFRFunctionality, addControlSymbolicOperation) {
   EXPECT_EQ(op.getNcontrols(), 0);
 
   op.addControl(1_pc);
-  const auto &controls = op.getControls();
+  const auto& controls = op.getControls();
   EXPECT_EQ(op.removeControl(controls.begin()), controls.end());
 }
 
@@ -1996,7 +1996,7 @@ TEST_F(QFRFunctionality, addControlClassicControlledOperation) {
   op.clearControls();
   EXPECT_EQ(op.getNcontrols(), 0);
   op.addControl(1_pc);
-  const auto &controls = op.getControls();
+  const auto& controls = op.getControls();
   EXPECT_EQ(op.removeControl(controls.begin()), controls.end());
 }
 

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1951,6 +1951,10 @@ TEST_F(QFRFunctionality, addControlStandardOperation) {
   op.clearControls();
   EXPECT_EQ(op.getNcontrols(), 0);
   ASSERT_THROW(op.removeControl(1_pc), QFRException);
+
+  op.addControl(1_pc);
+  const auto &controls = op.getControls();
+  EXPECT_EQ(op.removeControl(controls.begin()), controls.end());
 }
 
 TEST_F(QFRFunctionality, addControlSymbolicOperation) {
@@ -1967,6 +1971,10 @@ TEST_F(QFRFunctionality, addControlSymbolicOperation) {
   EXPECT_EQ(op.getControls(), expectedControlsAfterRemove);
   op.clearControls();
   EXPECT_EQ(op.getNcontrols(), 0);
+
+  op.addControl(1_pc);
+  const auto &controls = op.getControls();
+  EXPECT_EQ(op.removeControl(controls.begin()), controls.end());
 }
 
 TEST_F(QFRFunctionality, addControlClassicControlledOperation) {
@@ -1987,6 +1995,9 @@ TEST_F(QFRFunctionality, addControlClassicControlledOperation) {
   EXPECT_EQ(op.getControls(), expectedControlsAfterRemove);
   op.clearControls();
   EXPECT_EQ(op.getNcontrols(), 0);
+  op.addControl(1_pc);
+  const auto &controls = op.getControls();
+  EXPECT_EQ(op.removeControl(controls.begin()), controls.end());
 }
 
 TEST_F(QFRFunctionality, addControlNonUnitaryOperation) {
@@ -1996,6 +2007,9 @@ TEST_F(QFRFunctionality, addControlNonUnitaryOperation) {
   EXPECT_THROW(op.addControl(1_pc), QFRException);
   EXPECT_THROW(op.removeControl(1_pc), QFRException);
   EXPECT_THROW(op.clearControls(), QFRException);
+  // we pass an invalid iterator to removeControl, which is fine, since the
+  // function call should unconditionally trap
+  EXPECT_THROW(op.removeControl(Controls::const_iterator{}), QFRException);
 }
 
 TEST_F(QFRFunctionality, addControlCompundOperation) {

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1950,6 +1950,7 @@ TEST_F(QFRFunctionality, addControlStandardOperation) {
   EXPECT_EQ(op.getControls(), expectedControlsAfterRemove);
   op.clearControls();
   EXPECT_EQ(op.getNcontrols(), 0);
+  ASSERT_THROW(op.removeControl(1_pc), QFRException);
 }
 
 TEST_F(QFRFunctionality, addControlSymbolicOperation) {


### PR DESCRIPTION
## Description

This PR replaces the `setControls` function on `Operation` with `addControls` and `clearControls`.
Calling `clearControls` on `CompoundOperation`s will throw an Exception, since doing so is not possible at the moment (we don't know if a control was pushed down from a `CompoundOperation` or was there from the beginning.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
