### PR TITLE
Fix makeDDFromMatrix Issue in Asymmetrical Matrices

### DIFF
--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1167,9 +1167,9 @@ private:
       assert(colEnd - colStart == 2);
       const auto w0 = cn.getCached(matrix[rowStart][colStart]);
       const auto e0 = mEdge{mNode::getTerminal(), w0};
-      const auto w1 = cn.getCached(matrix[rowStart + 1][colStart]);
+      const auto w1 = cn.getCached(matrix[rowStart][colStart + 1]);
       const auto e1 = mEdge{mNode::getTerminal(), w1};
-      const auto w2 = cn.getCached(matrix[rowStart][colStart + 1]);
+      const auto w2 = cn.getCached(matrix[rowStart + 1][colStart]);
       const auto e2 = mEdge{mNode::getTerminal(), w2};
       const auto w3 = cn.getCached(matrix[rowStart + 1][colStart + 1]);
       const auto e3 = mEdge{mNode::getTerminal(), w3};

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -1479,11 +1479,10 @@ TEST(DDPackageTest, DDFromTwoQubitMatrix) {
 }
 
 TEST(DDPackageTest, DDFromTwoQubitAsymmetricalMatrix) {
-  const auto inputMatrix =
-    dd::CMat {{dd::SQRT2_2, dd::SQRT2_2, 0, 0},
-              {-dd::SQRT2_2, dd::SQRT2_2, 0, 0},
-              {0, 0, dd::SQRT2_2, -dd::SQRT2_2},
-              {0, 0, dd::SQRT2_2, dd::SQRT2_2}};
+  const auto inputMatrix = dd::CMat{{dd::SQRT2_2, dd::SQRT2_2, 0, 0},
+                                    {-dd::SQRT2_2, dd::SQRT2_2, 0, 0},
+                                    {0, 0, dd::SQRT2_2, -dd::SQRT2_2},
+                                    {0, 0, dd::SQRT2_2, dd::SQRT2_2}};
 
   const auto nrQubits = 2U;
   const auto dd = std::make_unique<dd::Package<>>(nrQubits);

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -1478,6 +1478,21 @@ TEST(DDPackageTest, DDFromTwoQubitMatrix) {
   EXPECT_EQ(inputMatrix, outputMatrix);
 }
 
+TEST(DDPackageTest, DDFromTwoQubitAsymmetricalMatrix) {
+  const auto inputMatrix =
+    dd::CMat {{dd::SQRT2_2, dd::SQRT2_2, 0, 0},
+              {-dd::SQRT2_2, dd::SQRT2_2, 0, 0},
+              {0, 0, dd::SQRT2_2, -dd::SQRT2_2},
+              {0, 0, dd::SQRT2_2, dd::SQRT2_2}};
+
+  const auto nrQubits = 2U;
+  const auto dd = std::make_unique<dd::Package<>>(nrQubits);
+  const auto matDD = dd->makeDDFromMatrix(inputMatrix);
+  const auto outputMatrix = dd->getMatrix(matDD);
+
+  EXPECT_EQ(inputMatrix, outputMatrix);
+}
+
 TEST(DDPackageTest, DDFromThreeQubitMatrix) {
   const auto inputMatrix =
       dd::CMat{{1, 0, 0, 0, 0, 0, 0, 0}, {0, 1, 0, 0, 0, 0, 0, 0},


### PR DESCRIPTION
## Description

The function ```makeDDFromMatrix``` incorrectly swaps the pointers for the second and third nodes in level 1 (2x2) input submatrices. This leads to a mismatch between the input and reconstructed matrices if the input matrix is not symmetrical. All the existing tests of this function don't contain a matrix where this problem would be visible. This PR contains two commits: The first one adds a new test to reproduce and show the problem, and the second one is the actual fix.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
