### PR TITLE
Add invert functionality for quantum operations

### DIFF
--- a/include/operations/ClassicControlledOperation.hpp
+++ b/include/operations/ClassicControlledOperation.hpp
@@ -112,5 +112,7 @@ public:
     of << " == " << expectedValue << ") ";
     op->dumpOpenQASM(of, qreg, creg);
   }
+
+  void invert() override { op->invert(); }
 };
 } // namespace qc

--- a/include/operations/CompoundOperation.hpp
+++ b/include/operations/CompoundOperation.hpp
@@ -225,5 +225,12 @@ public:
     }
     return usedQubits;
   }
+
+  void invert() override {
+    for (auto& op : ops) {
+      op->invert();
+    }
+    std::reverse(ops.begin(), ops.end());
+  }
 };
 } // namespace qc

--- a/include/operations/NonUnitaryOperation.hpp
+++ b/include/operations/NonUnitaryOperation.hpp
@@ -79,5 +79,9 @@ public:
 
   void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
                     const RegisterNames& creg) const override;
+
+  void invert() override {
+    throw QFRException("Inverting a non-unitary operation is not supported.");
+  }
 };
 } // namespace qc

--- a/include/operations/Operation.hpp
+++ b/include/operations/Operation.hpp
@@ -83,6 +83,12 @@ public:
     return usedQubits;
   }
 
+  [[nodiscard]] std::unique_ptr<Operation> getInverted() const {
+    auto op = clone();
+    op->invert();
+    return op;
+  }
+
   // Setter
   virtual void setNqubits(const std::size_t nq) { nqubits = nq; }
 
@@ -177,5 +183,7 @@ public:
 
   virtual void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
                             const RegisterNames& creg) const = 0;
+
+  virtual void invert() = 0;
 };
 } // namespace qc

--- a/include/operations/StandardOperation.hpp
+++ b/include/operations/StandardOperation.hpp
@@ -106,6 +106,8 @@ public:
 
   void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
                     const RegisterNames& creg) const override;
+
+  void invert() override;
 };
 
 } // namespace qc

--- a/include/operations/SymbolicOperation.hpp
+++ b/include/operations/SymbolicOperation.hpp
@@ -59,6 +59,10 @@ protected:
   getInstantiation(const SymbolOrNumber& symOrNum,
                    const VariableAssignment& assignment);
 
+  void negateSymbolicParameter(std::size_t index);
+
+  void addToSymbolicParameter(std::size_t index, fp value);
+
 public:
   SymbolicOperation() = default;
 
@@ -140,5 +144,7 @@ public:
   // Instantiates this Operation
   // Afterwards casting to StandardOperation can be done if assignment is total
   void instantiate(const VariableAssignment& assignment);
+
+  void invert() override;
 };
 } // namespace qc

--- a/src/operations/StandardOperation.cpp
+++ b/src/operations/StandardOperation.cpp
@@ -467,4 +467,95 @@ void StandardOperation::dumpOpenQASMTeleportation(
   of << "teleport " << qreg[targets[0]].second << ", "
      << qreg[targets[1]].second << ", " << qreg[targets[2]].second << ";\n";
 }
+
+void StandardOperation::invert() {
+  switch (type) {
+  // self-inverting gates
+  case I:
+  case X:
+  case Y:
+  case Z:
+  case H:
+  case SWAP:
+  case ECR:
+  case Barrier:
+    break;
+  // gates where we just update parameters
+  case GPhase:
+  case Phase:
+  case RX:
+  case RY:
+  case RZ:
+  case RXX:
+  case RYY:
+  case RZZ:
+  case RZX:
+    parameter[0] = -parameter[0];
+    break;
+  case U2:
+    std::swap(parameter[0], parameter[1]);
+    parameter[0] = -parameter[0] + PI;
+    parameter[1] = -parameter[1] - PI;
+    break;
+  case U3:
+    parameter[0] = -parameter[0];
+    parameter[1] = -parameter[1];
+    parameter[2] = -parameter[2];
+    std::swap(parameter[1], parameter[2]);
+    break;
+  case XXminusYY:
+  case XXplusYY:
+    parameter[0] = -parameter[0];
+    break;
+  case DCX:
+    std::swap(targets[0], targets[1]);
+    break;
+  // gates where we have specialized inverted operation types
+  case S:
+    type = Sdag;
+    break;
+  case Sdag:
+    type = S;
+    break;
+  case T:
+    type = Tdag;
+    break;
+  case Tdag:
+    type = T;
+    break;
+  case V:
+    type = Vdag;
+    break;
+  case Vdag:
+    type = V;
+    break;
+  case SX:
+    type = SXdag;
+    break;
+  case SXdag:
+    type = SX;
+    break;
+  case Peres:
+    type = Peresdag;
+    break;
+  case Peresdag:
+    type = Peres;
+    break;
+  // Tracking issue for iSwap: https://github.com/cda-tum/mqt-core/issues/423
+  case iSWAP:
+  case None:
+  case Compound:
+  case Measure:
+  case Reset:
+  case Teleportation:
+  case ClassicControlled:
+  case ATrue:
+  case AFalse:
+  case MultiATrue:
+  case MultiAFalse:
+  case OpCount:
+    throw QFRException("Inverting gate" + toString(type) +
+                       " is not supported.");
+  }
+}
 } // namespace qc

--- a/src/operations/SymbolicOperation.cpp
+++ b/src/operations/SymbolicOperation.cpp
@@ -332,4 +332,64 @@ void SymbolicOperation::instantiate(const VariableAssignment& assignment) {
   }
   checkUgate();
 }
+
+void SymbolicOperation::negateSymbolicParameter(const std::size_t index) {
+  if (isSymbolicParameter(index)) {
+    // NOLINTBEGIN(bugprone-unchecked-optional-access) - we check for this
+    symbolicParameter.at(index) = -symbolicParameter.at(index).value();
+    // NOLINTEND(bugprone-unchecked-optional-access)
+  } else {
+    parameter.at(index) = -parameter.at(index);
+  }
+}
+
+void SymbolicOperation::addToSymbolicParameter(const std::size_t index,
+                                               const fp value) {
+  if (isSymbolicParameter(index)) {
+    // NOLINTBEGIN(bugprone-unchecked-optional-access) - we check for this
+    symbolicParameter.at(index) = symbolicParameter.at(index).value() + value;
+    // NOLINTEND(bugprone-unchecked-optional-access)
+  } else {
+    parameter.at(index) += value;
+  }
+}
+
+void SymbolicOperation::invert() {
+  switch (type) {
+  case GPhase:
+  case Phase:
+  case RX:
+  case RY:
+  case RZ:
+  case RXX:
+  case RYY:
+  case RZZ:
+  case RZX:
+    negateSymbolicParameter(0);
+    break;
+  case U2:
+    negateSymbolicParameter(0);
+    negateSymbolicParameter(1);
+
+    addToSymbolicParameter(0, -PI);
+    addToSymbolicParameter(1, PI);
+    std::swap(parameter[0], parameter[1]);
+    std::swap(symbolicParameter[0], symbolicParameter[1]);
+    break;
+  case U3:
+    negateSymbolicParameter(0);
+    negateSymbolicParameter(1);
+    negateSymbolicParameter(2);
+
+    std::swap(parameter[1], parameter[2]);
+    std::swap(symbolicParameter[1], symbolicParameter[2]);
+    break;
+  case XXminusYY:
+  case XXplusYY:
+    negateSymbolicParameter(0);
+    break;
+  default:
+    StandardOperation::invert();
+  }
+}
 } // namespace qc


### PR DESCRIPTION
## Description

Add an `invert` function to `Operation`. This mirrors the functionality of the [OpenQASM 3.0 `inv` modifier](https://openqasm.com/language/gates.html#inverse-modifier).

For Compound gates, this calls `invert` on each nested operation and reverses the order of the operations.
For Standard gates, this checks which type of gate is being inverted and handles each case.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
