### PR TITLE
🐛 Fix broken `manylinux` wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,9 @@ archs = "auto64"
 test-command = "python -c \"from mqt import core\""
 build-frontend = "build"
 
+[tool.cibuildwheel.linux]
+environment = { DEPLOY = "ON" }
+
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
 


### PR DESCRIPTION
## Description

Due to the way Linux wheels are built by cibuildwheel (in a manylinux docker container), environment varaiables are not passed down to the container. As a result the `CI` environment variable is not defined in the docker container, which is used to flip on the `DEPLOY` CMake setting automatically.
This has lead to manylinux wheels being built with `-march=native` that might produce errors like
```console
Illegal instruction (core dumped)
```
when trying to import the respective packages.

This PR fixes this by making sure that `DEPLOY="ON"` within cibuildwheel.

> **Note**
> This also has to be updated in the top-level projects that rely on mqt-core and its publishing workflow.
> An alternative would have been to simply modify the reusable workflow files, but that would leave local cibuildwheel runs broken.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
