### PR TITLE
🐛 Fix identity handling in DD multiplication

### DIFF
--- a/include/dd/Edge.hpp
+++ b/include/dd/Edge.hpp
@@ -32,6 +32,7 @@ template <class Node> struct Edge {
   [[nodiscard]] bool isTerminal() const;
   [[nodiscard]] bool isZeroTerminal() const;
   [[nodiscard]] bool isOneTerminal() const;
+  [[nodiscard]] bool isIdentity() const;
 
   // Functions only related to density matrices
   [[maybe_unused]] static void setDensityConjugateTrue(Edge& e);

--- a/include/dd/Node.hpp
+++ b/include/dd/Node.hpp
@@ -105,6 +105,10 @@ struct dNode {                        // NOLINT(readability-identifier-naming)
   }
   static constexpr dNode* getTerminal() noexcept { return nullptr; }
 
+  [[nodiscard]] static constexpr bool isIdentity(const dNode* p) noexcept {
+    return p == nullptr;
+  }
+
   [[nodiscard]] [[maybe_unused]] static inline bool
   tempDensityMatrixFlagsEqual(const std::uint8_t a,
                               const std::uint8_t b) noexcept {

--- a/include/dd/NoiseFunctionality.hpp
+++ b/include/dd/NoiseFunctionality.hpp
@@ -414,7 +414,12 @@ private:
       complexProb.r->value = probability;
       if (!e[0].w.exactlyZero()) {
         const auto w = package->cn.mulCached(complexProb, e[3].w);
-        const auto tmp = package->add2(e[0], {e[3].p, w});
+        const auto var =
+            static_cast<Qubit>(std::max({e[0].p != nullptr ? e[0].p->v : 0,
+                                         e[1].p != nullptr ? e[1].p->v : 0,
+                                         e[2].p != nullptr ? e[2].p->v : 0,
+                                         e[3].p != nullptr ? e[3].p->v : 0}));
+        const auto tmp = package->add2(e[0], {e[3].p, w}, var);
         package->cn.returnToCache(w);
         package->cn.returnToCache(e[0].w);
         e[0] = tmp;
@@ -464,6 +469,11 @@ private:
     Complex complexProb = package->cn.getCached();
     complexProb.i->value = 0;
 
+    const auto var = static_cast<Qubit>(std::max(
+        {e[0].p != nullptr ? e[0].p->v : 0, e[1].p != nullptr ? e[1].p->v : 0,
+         e[2].p != nullptr ? e[2].p->v : 0,
+         e[3].p != nullptr ? e[3].p->v : 0}));
+
     qc::DensityMatrixDD oldE0Edge{e[0].p, package->cn.getCached(e[0].w)};
 
     // e[0] = 0.5*((2-p)*e[0] + p*e[3])
@@ -488,7 +498,7 @@ private:
 
       // e[0] = helperEdge[0] + helperEdge[1]
       package->cn.returnToCache(e[0].w);
-      e[0] = package->add2(helperEdge[0], helperEdge[1]);
+      e[0] = package->add2(helperEdge[0], helperEdge[1], var);
       package->cn.returnToCache(helperEdge[0].w);
       package->cn.returnToCache(helperEdge[1].w);
     }
@@ -535,7 +545,7 @@ private:
       }
 
       package->cn.returnToCache(e[3].w);
-      e[3] = package->add2(helperEdge[0], helperEdge[1]);
+      e[3] = package->add2(helperEdge[0], helperEdge[1], var);
       package->cn.returnToCache(helperEdge[0].w);
       package->cn.returnToCache(helperEdge[1].w);
     }

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1576,7 +1576,17 @@ public:
   template <class Edge> Edge add(const Edge& x, const Edge& y) {
     [[maybe_unused]] const auto before = cn.cacheCount();
 
-    auto result = add2(x, y);
+    Qubit var{};
+    if (!x.isTerminal()) {
+      assert(x.p != nullptr);
+      var = x.p->v;
+    }
+    if (!y.isTerminal() && (y.p->v) > var) {
+      assert(y.p != nullptr);
+      var = y.p->v;
+    }
+
+    auto result = add2(x, y, var);
     result.w = cn.lookup(result.w, true);
 
     [[maybe_unused]] const auto after = cn.cacheCount();
@@ -1586,7 +1596,7 @@ public:
   }
 
   template <class Node>
-  Edge<Node> add2(const Edge<Node>& x, const Edge<Node>& y) {
+  Edge<Node> add2(const Edge<Node>& x, const Edge<Node>& y, const Qubit var) {
     if (x.w.exactlyZero()) {
       if (y.w.exactlyZero()) {
         return Edge<Node>::zero;
@@ -1615,15 +1625,16 @@ public:
       return {r->p, cn.getCached(r->w)};
     }
 
-    const Qubit w = (x.isTerminal() || (!y.isTerminal() && y.p->v > x.p->v))
-                        ? y.p->v
-                        : x.p->v;
-
     constexpr std::size_t n = std::tuple_size_v<decltype(x.p->e)>;
     std::array<Edge<Node>, n> edge{};
     for (std::size_t i = 0U; i < n; i++) {
+      if constexpr (std::is_same_v<Node, vNode>) {
+        assert(!x.isTerminal() && "x must not be terminal");
+        assert(!y.isTerminal() && "y must not be terminal");
+        assert(x.p->v == y.p->v && "x and y must be at the same level");
+      }
       Edge<Node> e1{};
-      if (!x.isTerminal() && x.p->v == w) {
+      if (!x.isTerminal()) {
         e1 = x.p->e[i];
 
         if (!e1.w.exactlyZero()) {
@@ -1636,7 +1647,7 @@ public:
         }
       }
       Edge<Node> e2{};
-      if (!y.isTerminal() && y.p->v == w) {
+      if (!y.isTerminal()) {
         e2 = y.p->e[i];
 
         if (!e2.w.exactlyZero()) {
@@ -1651,22 +1662,22 @@ public:
 
       if constexpr (std::is_same_v<Node, dNode>) {
         dEdge::applyDmChangesToEdges(e1, e2);
-        edge[i] = add2(e1, e2);
+        edge[i] = add2(e1, e2, var - 1);
         dEdge::revertDmChangesToEdges(e1, e2);
       } else {
-        edge[i] = add2(e1, e2);
+        edge[i] = add2(e1, e2, var - 1);
       }
 
-      if (!x.isTerminal() && x.p->v == w) {
+      if (!x.isTerminal() && x.p->v == var) {
         cn.returnToCache(e1.w);
       }
 
-      if (!y.isTerminal() && y.p->v == w) {
+      if (!y.isTerminal() && y.p->v == var) {
         cn.returnToCache(e2.w);
       }
     }
 
-    auto e = makeDDNode(w, edge, true);
+    auto e = makeDDNode(var, edge, true);
 
     computeTable.insert({x.p, x.w}, {y.p, y.w}, {e.p, e.w});
     return e;
@@ -1917,7 +1928,7 @@ private:
             } else if (!m.w.exactlyZero()) {
               dEdge::applyDmChangesToEdges(edge[idx], m);
               const auto w = edge[idx].w;
-              edge[idx] = add2(edge[idx], m);
+              edge[idx] = add2(edge[idx], m, v);
               dEdge::revertDmChangesToEdges(edge[idx], e2);
               cn.returnToCache(w);
               cn.returnToCache(m.w);
@@ -1931,7 +1942,7 @@ private:
               edge[idx] = m;
             } else if (!m.w.exactlyZero()) {
               const auto w = edge[idx].w;
-              edge[idx] = add2(edge[idx], m);
+              edge[idx] = add2(edge[idx], m, v);
               cn.returnToCache(w);
               cn.returnToCache(m.w);
             }
@@ -2262,11 +2273,11 @@ private:
       auto r = mEdge::zero;
 
       const auto t0 = trace(a.p->e[0], eliminate, elims);
-      r = add2(r, t0);
+      r = add2(r, t0, v - 1);
       auto r1 = r;
 
       const auto t1 = trace(a.p->e[3], eliminate, elims);
-      r = add2(r, t1);
+      r = add2(r, t1, v - 1);
       auto r2 = r;
 
       if (r.w.exactlyOne()) {

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1578,11 +1578,9 @@ public:
 
     Qubit var{};
     if (!x.isTerminal()) {
-      assert(x.p != nullptr);
       var = x.p->v;
     }
     if (!y.isTerminal() && (y.p->v) > var) {
-      assert(y.p != nullptr);
       var = y.p->v;
     }
 
@@ -1628,11 +1626,6 @@ public:
     constexpr std::size_t n = std::tuple_size_v<decltype(x.p->e)>;
     std::array<Edge<Node>, n> edge{};
     for (std::size_t i = 0U; i < n; i++) {
-      if constexpr (std::is_same_v<Node, vNode>) {
-        assert(!x.isTerminal() && "x must not be terminal");
-        assert(!y.isTerminal() && "y must not be terminal");
-        assert(x.p->v == y.p->v && "x and y must be at the same level");
-      }
       Edge<Node> e1{};
       if (!x.isTerminal()) {
         e1 = x.p->e[i];

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1882,20 +1882,13 @@ private:
         auto idx = cols * i + j;
         edge[idx] = ResultEdge::zero;
         for (auto k = 0U; k < rows; k++) {
-          LEdge e1{};
-          if (!x.isTerminal() && x.p->v == var) {
-            e1 = x.p->e[rows * i + k];
-          } else {
-            e1 = xCopy;
-          }
+          const auto xIdx = rows * i + k;
+          LEdge e1 = x.p->e[xIdx];
 
-          REdge e2{};
-          if (!y.isTerminal() && y.p->v == var) {
-            e2 = y.p->e[j + cols * k];
-          } else {
-            e2 = yCopy;
-          }
+          const auto yIdx = j + cols * k;
+          REdge e2 = y.p->e[yIdx];
 
+          const auto v = static_cast<Qubit>(var - 1);
           if constexpr (std::is_same_v<LeftOperandNode, dNode>) {
             dEdge m;
             dEdge::applyDmChangesToEdges(e1, e2);
@@ -1903,7 +1896,7 @@ private:
               // When generateDensityMatrix is false or I have the first edge I
               // don't optimize anything and set generateDensityMatrix to false
               // for all child edges
-              m = multiply2(e1, e2, static_cast<Qubit>(var - 1), start, false);
+              m = multiply2(e1, e2, v, start, false);
             } else if (idx == 2) {
               // When I have the second edge and generateDensityMatrix == false,
               // then edge[2] == edge[1]
@@ -1916,8 +1909,7 @@ private:
               }
               continue;
             } else {
-              m = multiply2(e1, e2, static_cast<Qubit>(var - 1), start,
-                            generateDensityMatrix);
+              m = multiply2(e1, e2, v, start, generateDensityMatrix);
             }
 
             if (k == 0 || edge[idx].w.exactlyZero()) {
@@ -1933,7 +1925,7 @@ private:
             // Undo modifications on density matrices
             dEdge::revertDmChangesToEdges(e1, e2);
           } else {
-            auto m = multiply2(e1, e2, static_cast<Qubit>(var - 1), start);
+            auto m = multiply2(e1, e2, v, start);
 
             if (k == 0 || edge[idx].w.exactlyZero()) {
               edge[idx] = m;

--- a/src/dd/Edge.cpp
+++ b/src/dd/Edge.cpp
@@ -22,6 +22,13 @@ template <class Node> bool Edge<Node>::isOneTerminal() const {
   return isTerminal() && w == Complex::one;
 }
 
+template <class Node> bool Edge<Node>::isIdentity() const {
+  if constexpr (std::is_same_v<Node, mNode> || std::is_same_v<Node, dNode>) {
+    return Node::isIdentity(p);
+  }
+  return false;
+}
+
 template <typename Node>
 CachedEdge<Node>::CachedEdge(Node* n, const Complex& c) : p(n) {
   w.r = RealNumber::val(c.r);


### PR DESCRIPTION
## Description

Due to a typing issue, the code responsible for shortcutting DD multiplication upon encountering identity nodes was never actually compiled (it checked on `mCachedEdge` instead of on `mEdge`).
This PR addresses the underlying issue and furthermore aligns the code base a little more with what's to come in #358.

This speeds-up the test suite by roughly a factor of 2.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
