### PR TITLE
♻️ switch back from nanobind to pybind

### DIFF
--- a/.github/workflows/reusable-code-ql-python.yml
+++ b/.github/workflows/reusable-code-ql-python.yml
@@ -12,7 +12,7 @@ on:
         type: string
       build-time-dependencies:
         description: "The build-time dependencies to install"
-        default: "nanobind scikit-build-core[pyproject] setuptools_scm pybind11"
+        default: "scikit-build-core[pyproject] setuptools_scm pybind11"
         type: string
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,7 +127,6 @@ repos:
       - id: check-sdist
         args: [--inject-junk]
         additional_dependencies:
-          - nanobind>=1.5.2
           - scikit-build-core[pyproject]>=0.5.0
           - setuptools-scm>=7
           - pybind11>=2.11

--- a/include/python/pybind11.hpp
+++ b/include/python/pybind11.hpp
@@ -2,10 +2,10 @@
 
 #pragma once
 
-#include <nanobind/nanobind.h>
+#include <pybind11/pybind11.h>
 
 namespace mqt {
-namespace nb = nanobind;
-using namespace nb::literals;
+namespace py = pybind11;
+using namespace py::literals;
 
 } // namespace mqt

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ def lint(session: nox.Session) -> None:
 @nox.session(reuse_venv=True)
 def pylint(session: nox.Session) -> None:
     """Run PyLint."""
-    session.install("nanobind", "scikit-build-core[pyproject]", "setuptools_scm", "pybind11")
+    session.install("scikit-build-core[pyproject]", "setuptools_scm", "pybind11")
     session.install("--no-build-isolation", "-ve.", "pylint")
     session.run("pylint", "mqt.core", *session.posargs)
 
@@ -53,7 +53,7 @@ def _run_tests(
         _extras.append("coverage")
         posargs.append("--cov-config=pyproject.toml")
 
-    session.install("nanobind", "scikit-build-core[pyproject]", "setuptools_scm", "pybind11", *install_args, env=env)
+    session.install("scikit-build-core[pyproject]", "setuptools_scm", "pybind11", *install_args, env=env)
     install_arg = f"-ve.[{','.join(_extras)}]"
     session.install("--no-build-isolation", install_arg, *install_args, env=env)
     session.run("pytest", *run_args, *posargs, env=env)
@@ -87,7 +87,7 @@ def docs(session: nox.Session) -> None:
     if args.builder != "html" and args.serve:
         session.error("Must not specify non-HTML builder with --serve")
 
-    build_requirements = ["nanobind", "scikit-build-core[pyproject]", "setuptools_scm", "pybind11"]
+    build_requirements = ["scikit-build-core[pyproject]", "setuptools_scm", "pybind11"]
     extra_installs = ["sphinx-autobuild"] if args.serve else []
     session.install(*build_requirements, *extra_installs)
     session.install("--no-build-isolation", "-ve.[docs]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.5.0", "nanobind>=1.5.2", "setuptools-scm>=7", "pybind11>=2.11"]
+requires = ["scikit-build-core>=0.5.0", "setuptools-scm>=7", "pybind11>=2.11"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT SKBUILD)
   in your environment once and use the following command that avoids
   a costly creation of a new virtual environment at every compilation:
   =====================================================================
-   $ pip install nanobind 'scikit-build-core[pyproject]' setuptools_scm pybind11
+   $ pip install 'scikit-build-core[pyproject]' setuptools_scm pybind11
    $ pip install --no-build-isolation -ve .
   =====================================================================
   You may optionally add -Ceditable.rebuild=true to auto-rebuild when
@@ -24,45 +24,29 @@ if(NOT SKBUILD)
 endif()
 
 if(NOT SKBUILD)
-  # Manually detect the installed nanobind package and import it into CMake.
+  # Manually detect the installed pybind11 package and import it into CMake.
   execute_process(
-    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    COMMAND "${Python_EXECUTABLE}" -m pybind11 --cmakedir
     OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE nanobind_DIR)
-  list(APPEND CMAKE_PREFIX_PATH "${nanobind_DIR}")
+    OUTPUT_VARIABLE pybind11_DIR)
+  list(APPEND CMAKE_PREFIX_PATH "${pybind11_DIR}")
 endif()
 
-# Import nanobind through CMake's find_package mechanism
-find_package(nanobind CONFIG REQUIRED)
+# Import pybind11 through CMake's find_package mechanism
+find_package(pybind11 CONFIG REQUIRED)
 
 # We are now ready to compile the actual extension module
-nanobind_add_module(
+pybind11_add_module(
   # Name of the extension
   _core
   # Target the stable ABI for Python 3.12+, which reduces the number of binary wheels that must be
   # built. This does nothing on older Python versions
-  STABLE_ABI
-  # Build libnanobind statically and merge it into the extension (which itself remains a shared
-  # library)
-  NB_STATIC
+  WITH_SOABI
   # Source code goes here
-  ${PROJECT_SOURCE_DIR}/include/python/nanobind.hpp
-  module.cpp)
-target_link_libraries(_core PRIVATE MQT::Core)
-
-if(TARGET nanobind-static)
-  set(NANOBIND_LIB nanobind-static)
-elseif(TARGET nanobind-static-abi3)
-  set(NANOBIND_LIB nanobind-static-abi3)
-else()
-  message(FATAL_ERROR "nanobind library not found")
-endif()
-
-# the following sets the SYSTEM flag for the include dirs of the nanobind libs to suppress warnings
-# cmake-lint: disable=C0307
-set_target_properties(
-  ${NANOBIND_LIB} PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                             $<TARGET_PROPERTY:${NANOBIND_LIB},INTERFACE_INCLUDE_DIRECTORIES>)
+  ${PROJECT_SOURCE_DIR}/include/python/pybind11.hpp
+  module.cpp
+  dd.cpp)
+target_link_libraries(_core PRIVATE MQT::CoreDD)
 
 # Install directive for scikit-build-core
 install(TARGETS _core LIBRARY DESTINATION mqt/core)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -44,8 +44,7 @@ pybind11_add_module(
   WITH_SOABI
   # Source code goes here
   ${PROJECT_SOURCE_DIR}/include/python/pybind11.hpp
-  module.cpp
-  dd.cpp)
+  module.cpp)
 target_link_libraries(_core PRIVATE MQT::CoreDD)
 
 # Install directive for scikit-build-core

--- a/src/python/module.cpp
+++ b/src/python/module.cpp
@@ -1,8 +1,8 @@
-#include <python/nanobind.hpp>
+#include <python/pybind11.hpp>
 
 namespace mqt {
 
-NB_MODULE(_core, m) {
+PYBIND11_MODULE(_core, m) {
   m.def(
       "add", [](int a, int b) { return a + b; }, "a"_a, "b"_a);
 }


### PR DESCRIPTION
## Description

This PR moves the project back to pybind11 from nanobind.
While playing around, it turns out that nanobind is not yet mature enough and would require quite some workarounds to get working for everything.

Closes #344

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
