### PR TITLE
🐛 Fix output permutation deduction

### DIFF
--- a/src/python/qiskit/QuantumCircuit.cpp
+++ b/src/python/qiskit/QuantumCircuit.cpp
@@ -468,10 +468,12 @@ void qc::qiskit::QuantumCircuit::importInitialLayout(qc::QuantumComputation& qc,
   const auto physicalQubits =
       layout.attr("get_physical_bits")().cast<py::dict>();
 
-  // create initial layout
+  // create initial layout (and assume identical output permutation)
   for (const auto& [physicalQubit, logicalQubit] : physicalQubits) {
     if (logicalQubitIndices.contains(logicalQubit)) {
       qc.initialLayout[physicalQubit.cast<Qubit>()] =
+          logicalQubitIndices[logicalQubit].cast<Qubit>();
+      qc.outputPermutation[physicalQubit.cast<Qubit>()] =
           logicalQubitIndices[logicalQubit].cast<Qubit>();
     }
   }


### PR DESCRIPTION
## Description

This PR fixes the output permutation deduction in the Qiskit circuit import.
The underlying assumption in our tools is that if a circuit contains no measurements, the identity permutation shall be assumed.
However, when an initial layout is present in the input circuit, our methods would only deduce the initial layout and keep the output permutation untouched.
This resulted in a mismatch between the initial layout and the output permutation.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
