### PR TITLE
⚡ Skip `symmetry` computation and 🔥 remove `transpose` method

### DIFF
--- a/include/dd/DDpackageConfig.hpp
+++ b/include/dd/DDpackageConfig.hpp
@@ -12,7 +12,6 @@ struct DDPackageConfig {
   static constexpr std::size_t UT_MAT_INITIAL_ALLOCATION_SIZE = 2048U;
   static constexpr std::size_t CT_VEC_ADD_NBUCKET = 16384U;
   static constexpr std::size_t CT_MAT_ADD_NBUCKET = 16384U;
-  static constexpr std::size_t CT_MAT_TRANS_NBUCKET = 4096U;
   static constexpr std::size_t CT_MAT_CONJ_TRANS_NBUCKET = 4096U;
   static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET = 16384U;
   static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET = 16384U;

--- a/include/dd/Node.hpp
+++ b/include/dd/Node.hpp
@@ -39,7 +39,7 @@ struct mNode {                        // NOLINT(readability-identifier-naming)
   RefCount ref{};                     // reference count
   Qubit v{};                          // variable index
   std::uint8_t flags = 0;
-  // 32 = marks a node with is symmetric.
+  // 32 = unused (was used to mark a node with is symmetric).
   // 16 = marks a node resembling identity
   // 8 = marks a reduced dm node,
   // 4 = marks a dm (tmp flag),
@@ -51,20 +51,6 @@ struct mNode {                        // NOLINT(readability-identifier-naming)
   }
   [[nodiscard]] static constexpr mNode* getTerminal() noexcept {
     return nullptr;
-  }
-
-  [[nodiscard]] inline bool isSymmetric() const noexcept {
-    return (flags & static_cast<std::uint8_t>(32U)) != 0;
-  }
-  [[nodiscard]] static constexpr bool isSymmetric(const mNode* p) noexcept {
-    return p == nullptr || p->isSymmetric();
-  }
-  inline void setSymmetric(const bool symmetric) noexcept {
-    if (symmetric) {
-      flags = (flags | static_cast<std::uint8_t>(32U));
-    } else {
-      flags = (flags & static_cast<std::uint8_t>(~32U));
-    }
   }
 
   [[nodiscard]] inline bool isIdentity() const noexcept {
@@ -94,7 +80,7 @@ struct dNode {                        // NOLINT(readability-identifier-naming)
   RefCount ref{};                     // reference count
   Qubit v{};                          // variable index
   std::uint8_t flags = 0;
-  // 32 = marks a node with is symmetric.
+  // 32 = unused (was used to mark a node with is symmetric).
   // 16 = marks a node resembling identity
   // 8 = marks a reduced dm node,
   // 4 = marks a dm (tmp flag),

--- a/include/dd/statistics/PackageStatistics.hpp
+++ b/include/dd/statistics/PackageStatistics.hpp
@@ -126,8 +126,6 @@ getStatistics(Package<Config>* package,
   computeTables["vector_add"] = package->vectorAdd.getStats().json();
   computeTables["matrix_add"] = package->matrixAdd.getStats().json();
   computeTables["density_matrix_add"] = package->densityAdd.getStats().json();
-  computeTables["matrix_transpose"] =
-      package->matrixTranspose.getStats().json();
   computeTables["matrix_conjugate_transpose"] =
       package->conjugateMatrixTranspose.getStats().json();
   computeTables["matrix_vector_mult"] =
@@ -227,12 +225,6 @@ getDataStructureStatistics(Package<Config>* package) {
   densityAdd["size_B"] = sizeof(typename decltype(package->densityAdd)::Entry);
   densityAdd["alignment_B"] =
       alignof(typename decltype(package->densityAdd)::Entry);
-
-  auto& matrixTranspose = ctEntries["matrix_transpose"];
-  matrixTranspose["size_B"] =
-      sizeof(typename decltype(package->matrixTranspose)::Entry);
-  matrixTranspose["alignment_B"] =
-      alignof(typename decltype(package->matrixTranspose)::Entry);
 
   auto& conjugateMatrixTranspose = ctEntries["conjugate_matrix_transpose"];
   conjugateMatrixTranspose["size_B"] =

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -766,28 +766,6 @@ TEST(DDPackageTest, UniqueTableAllocation) {
   EXPECT_EQ(dd->vMemoryManager.getStats().numAllocated, allocs);
 }
 
-TEST(DDPackageTest, MatrixTranspose) {
-  auto dd = std::make_unique<dd::Package<>>(2);
-  auto cx = dd->makeGateDD(dd::Xmat, 2, 1_pc, 0);
-
-  // transposing a symmetric matrix shall yield a symmetric matrix
-  auto cxTransposed = dd->transpose(cx);
-  EXPECT_EQ(cxTransposed, cx);
-
-  // the Y gate is not symmetric
-  auto y = dd->makeGateDD(dd::Ymat, 2, 0);
-  auto yTransposed = dd->transpose(y);
-  EXPECT_NE(yTransposed, y);
-
-  // transposing twice should yield the original matrix
-  auto yTT = dd->transpose(yTransposed);
-  EXPECT_EQ(yTT, y);
-
-  // perform the same computation again -> trigger a compute table hit
-  auto yAgain = dd->transpose(yTransposed);
-  EXPECT_EQ(yAgain, y);
-}
-
 TEST(DDPackageTest, SpecialCaseTerminal) {
   auto dd = std::make_unique<dd::Package<>>(2);
   auto one = dd::vEdge::one;


### PR DESCRIPTION
## Description

This PR removes the computation of the `isSymmetric` property in matrix DDs.
The corresponding check was conducted on every node creation in `makeDDNode` and the resulting property was only used as a shortcut in the `transpose` method.
However, the `transpose` method is not used anywhere in our codebase.
As a consequence, this PR also removes the `transpose` method to reduce the amount of code bloat in our code base.

Overall, this should yield a small net performance gain for every operation involving matrices.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
