### PR TITLE
♻️ Replace static `zero` and `one` members with constexpr functions

### DIFF
--- a/include/dd/Complex.hpp
+++ b/include/dd/Complex.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dd/DDDefinitions.hpp"
+#include "dd/RealNumber.hpp"
 
 #include <complex>
 #include <cstddef>
@@ -19,12 +20,22 @@ struct Complex {
   /// Compute table entry for the imaginary part.
   RealNumber* i;
 
-  // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
-  /// The static zero constant.
-  static Complex zero;
-  /// The static one constant.
-  static Complex one;
-  // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+  /**
+   * @brief The static constant for the complex number zero.
+   * @return A complex number with real and imaginary part equal to zero.
+   */
+  static constexpr Complex zero() noexcept {
+    return {&constants::zero, &constants::zero};
+  }
+
+  /**
+   * @brief The static constant for the complex number one.
+   * @return A complex number with real part equal to one and imaginary part
+   * equal to zero.
+   */
+  static constexpr Complex one() noexcept {
+    return {&constants::one, &constants::zero};
+  }
 
   /**
    * @brief Set the value based on the given complex number.
@@ -36,18 +47,22 @@ struct Complex {
    * @brief Check whether the complex number is exactly equal to zero.
    * @returns True if the complex number is exactly equal to zero, false
    * otherwise.
-   * @see CTEntry::exactlyZero
+   * @see RealNumber::exactlyZero
    */
-  [[nodiscard]] bool exactlyZero() const noexcept;
+  [[nodiscard]] constexpr bool exactlyZero() const noexcept {
+    return RealNumber::exactlyZero(r) && RealNumber::exactlyZero(i);
+  }
 
   /**
    * @brief Check whether the complex number is exactly equal to one.
    * @returns True if the complex number is exactly equal to one, false
    * otherwise.
-   * @see CTEntry::exactlyOne
-   * @see CTEntry::exactlyZero
+   * @see RealNumber::exactlyOne
+   * @see RealNumber::exactlyZero
    */
-  [[nodiscard]] bool exactlyOne() const noexcept;
+  [[nodiscard]] constexpr bool exactlyOne() const noexcept {
+    return RealNumber::exactlyOne(r) && RealNumber::exactlyZero(i);
+  }
 
   /**
    * @brief Check whether the complex number is approximately equal to the
@@ -55,7 +70,7 @@ struct Complex {
    * @param c The complex number to compare to.
    * @returns True if the complex number is approximately equal to the given
    * complex number, false otherwise.
-   * @see CTEntry::approximatelyEquals
+   * @see RealNumber::approximatelyEquals
    */
   [[nodiscard]] bool approximatelyEquals(const Complex& c) const noexcept;
 
@@ -63,7 +78,7 @@ struct Complex {
    * @brief Check whether the complex number is approximately equal to zero.
    * @returns True if the complex number is approximately equal to zero, false
    * otherwise.
-   * @see CTEntry::approximatelyZero
+   * @see RealNumber::approximatelyZero
    */
   [[nodiscard]] bool approximatelyZero() const noexcept;
 
@@ -71,8 +86,8 @@ struct Complex {
    * @brief Check whether the complex number is approximately equal to one.
    * @returns True if the complex number is approximately equal to one, false
    * otherwise.
-   * @see CTEntry::approximatelyOne
-   * @see CTEntry::approximatelyZero
+   * @see RealNumber::approximatelyOne
+   * @see RealNumber::approximatelyZero
    */
   [[nodiscard]] bool approximatelyOne() const noexcept;
 
@@ -100,7 +115,7 @@ struct Complex {
   /**
    * @brief Write the complex number to a binary stream.
    * @param os The output stream to write to.
-   * @see CTEntry::writeBinary
+   * @see RealNumber::writeBinary
    */
   void writeBinary(std::ostream& os) const;
 

--- a/include/dd/ComplexNumbers.hpp
+++ b/include/dd/ComplexNumbers.hpp
@@ -231,8 +231,8 @@ public:
    * @param c The complex number.
    * @return Whether the complex number is one of the static ones.
    */
-  [[nodiscard]] static bool isStaticComplex(const Complex& c) {
-    return &c == &Complex::zero || &c == &Complex::one;
+  [[nodiscard]] static constexpr bool isStaticComplex(const Complex& c) {
+    return c.exactlyZero() || c.exactlyOne();
   }
 
   /**

--- a/include/dd/Edge.hpp
+++ b/include/dd/Edge.hpp
@@ -61,9 +61,17 @@ template <class Node> struct Edge {
     return !operator==(other);
   }
 
-  // edges pointing to zero and one terminals
-  static const Edge zero; // NOLINT(readability-identifier-naming)
-  static const Edge one;  // NOLINT(readability-identifier-naming)
+  /**
+   * @brief Get the static zero terminal
+   * @return the zero terminal
+   */
+  static constexpr Edge zero() { return terminal(Complex::zero()); }
+
+  /**
+   * @brief Get the static one terminal
+   * @return the one terminal
+   */
+  static constexpr Edge one() { return terminal(Complex::one()); }
 
   ///---------------------------------------------------------------------------
   ///                     \n General purpose methods \n
@@ -74,7 +82,7 @@ template <class Node> struct Edge {
    * @param w the edge weight
    * @return the terminal DD representing (w)
    */
-  [[nodiscard]] static Edge terminal(const Complex& w) {
+  [[nodiscard]] static constexpr Edge terminal(const Complex& w) {
     return Edge{Node::getTerminal(), w};
   }
 
@@ -82,22 +90,24 @@ template <class Node> struct Edge {
    * @brief Check whether this is a terminal
    * @return whether this is a terminal
    */
-  [[nodiscard]] bool isTerminal() const { return Node::isTerminal(p); }
+  [[nodiscard]] constexpr bool isTerminal() const {
+    return Node::isTerminal(p);
+  }
 
   /**
    * @brief Check whether this is a zero terminal
    * @return whether this is a zero terminal
    */
-  [[nodiscard]] bool isZeroTerminal() const {
-    return isTerminal() && w == Complex::zero;
+  [[nodiscard]] constexpr bool isZeroTerminal() const {
+    return isTerminal() && w.exactlyZero();
   }
 
   /**
    * @brief Check whether this is a one terminal
    * @return whether this is a one terminal
    */
-  [[nodiscard]] bool isOneTerminal() const {
-    return isTerminal() && w == Complex::one;
+  [[nodiscard]] constexpr bool isOneTerminal() const {
+    return isTerminal() && w.exactlyOne();
   }
 
   /**
@@ -342,13 +352,6 @@ private:
   void traverseDiagonal(const fp& prob, std::size_t i, ProbabilityFunc f,
                         fp threshold = 0.) const;
 };
-
-// NOLINTBEGIN(cppcoreguidelines-interfaces-global-init)
-template <class Node>
-const Edge<Node> Edge<Node>::zero{Node::getTerminal(), Complex::zero};
-template <class Node>
-const Edge<Node> Edge<Node>::one{Node::getTerminal(), Complex::one};
-// NOLINTEND(cppcoreguidelines-interfaces-global-init)
 } // namespace dd
 
 ///-----------------------------------------------------------------------------

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -232,9 +232,9 @@ static std::ostream& memoryHeader(const Edge<Node>& e, std::ostream& os,
      << "\" color=\"" << color << "\"";
   if (edgeLabels) {
     os << ",label=<<font point-size=\"8\">&nbsp;[";
-    if (e.w == Complex::zero) {
+    if (e.w.exactlyZero()) {
       os << "0";
-    } else if (e.w == Complex::one) {
+    } else if (e.w.exactlyOne()) {
       os << "1";
     } else {
       if (RealNumber::exactlyZero(e.w.r)) {
@@ -426,7 +426,7 @@ static std::ostream& memoryNode(const Edge<Node>& e, std::ostream& os) {
   for (std::size_t i = 0; i < n; ++i) {
     os << "<td port=\"" << i << R"(" href="javascript:;" border="0" tooltip=")"
        << e.p->e[i].w.toString(false, 4) << "\">";
-    if (e.p->e[i] == Edge<Node>::zero) {
+    if (e.p->e[i].isZeroTerminal()) {
       os << "&nbsp;0 "
             "";
     } else {
@@ -614,7 +614,7 @@ static std::ostream& memoryEdge(const Edge<Node>& from, const Edge<Node>& to,
      << "\" color=\"" << color << "\"";
   if (edgeLabels) {
     os << ",label=<<font point-size=\"8\">&nbsp;[";
-    if (to.w == Complex::one) {
+    if (to.w.exactlyOne()) {
       os << "1";
     } else {
       if (RealNumber::exactlyZero(to.w.r)) {
@@ -706,7 +706,7 @@ static void toDot(const Edge<Node>& e, std::ostream& os, bool colored = true,
     for (auto i = static_cast<std::int16_t>(node->p->e.size() - 1); i >= 0;
          --i) {
       auto& edge = node->p->e[static_cast<std::size_t>(i)];
-      if ((!memory && edge.w.approximatelyZero()) || edge.w == Complex::zero) {
+      if ((!memory && edge.w.approximatelyZero()) || edge.w.exactlyZero()) {
         // potentially add zero stubs here
         continue;
       }

--- a/include/dd/NoiseFunctionality.hpp
+++ b/include/dd/NoiseFunctionality.hpp
@@ -123,7 +123,7 @@ public:
                                                   true, multiQubitOperation);
         tmp = package->multiply(stackedOperation, state);
       }
-      tmp.w = Complex::one;
+      tmp.w = Complex::one();
 
       package->incRef(tmp);
       package->decRef(state);
@@ -327,7 +327,7 @@ private:
       return {originalEdge.p, package->cn.getCached(originalEdge.w)};
     }
 
-    auto originalCopy = qc::DensityMatrixDD{originalEdge.p, Complex::one};
+    auto originalCopy = qc::DensityMatrixDD{originalEdge.p, Complex::one()};
     ArrayOfEdges newEdges{};
     for (size_t i = 0; i < newEdges.size(); i++) {
       auto& successor = originalCopy.p->e[i];
@@ -484,7 +484,7 @@ private:
         complexProb.r->value = (2 - probability) * 0.5;
         helperEdge[0].w = package->cn.mulCached(e[0].w, complexProb);
       } else {
-        helperEdge[0].w = Complex::zero;
+        helperEdge[0].w = Complex::zero();
       }
 
       // helperEdge[1] = 0.5*p*e[3]
@@ -493,7 +493,7 @@ private:
         complexProb.r->value = probability * 0.5;
         helperEdge[1].w = package->cn.mulCached(e[3].w, complexProb);
       } else {
-        helperEdge[1].w = Complex::zero;
+        helperEdge[1].w = Complex::zero();
       }
 
       // e[0] = helperEdge[0] + helperEdge[1]
@@ -532,7 +532,7 @@ private:
         complexProb.r->value = (2 - probability) * 0.5;
         helperEdge[0].w = package->cn.mulCached(e[3].w, complexProb);
       } else {
-        helperEdge[0].w = Complex::zero;
+        helperEdge[0].w = Complex::zero();
       }
 
       // helperEdge[1] = 0.5*p*e[0]
@@ -541,7 +541,7 @@ private:
         complexProb.r->value = probability * 0.5;
         helperEdge[1].w = package->cn.mulCached(oldE0Edge.w, complexProb);
       } else {
-        helperEdge[1].w = Complex::zero;
+        helperEdge[1].w = Complex::zero();
       }
 
       package->cn.returnToCache(e[3].w);

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1116,10 +1116,12 @@ private:
     const auto l = static_cast<Qubit>(level - 1U);
 
     return makeDDNode<mNode>(
-        level, {makeDDFromMatrix(matrix, l, rowStart, rowMid, colStart, colMid),
-                makeDDFromMatrix(matrix, l, rowStart, rowMid, colMid, colEnd),
-                makeDDFromMatrix(matrix, l, rowMid, rowEnd, colStart, colMid),
-                makeDDFromMatrix(matrix, l, rowMid, rowEnd, colMid, colEnd)});
+        level,
+        {makeDDFromMatrix(matrix, l, rowStart, rowMid, colStart, colMid),
+         makeDDFromMatrix(matrix, l, rowStart, rowMid, colMid, colEnd),
+         makeDDFromMatrix(matrix, l, rowMid, rowEnd, colStart, colMid),
+         makeDDFromMatrix(matrix, l, rowMid, rowEnd, colMid, colEnd)},
+        true);
   }
 
 public:

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1301,7 +1301,6 @@ public:
       incRef(e);
       decRef(rootEdge);
       rootEdge = e;
-      garbageCollect();
     }
 
     return std::string{result.rbegin(), result.rend()};
@@ -2024,9 +2023,6 @@ public:
     const ComplexValue expValue = innerProduct(y, yPrime);
 
     assert(RealNumber::approximatelyZero(expValue.i));
-
-    garbageCollect();
-
     return expValue.r;
   }
 

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -2069,7 +2069,7 @@ private:
   Edge<Node> kronecker2(const Edge<Node>& x, const Edge<Node>& y,
                         const bool incIdx = true) {
     if (x.w.approximatelyZero() || y.w.approximatelyZero()) {
-      return Edge<Node>::zero;
+      return Edge<Node>::zero();
     }
 
     if (x.isTerminal()) {

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -299,7 +299,7 @@ public:
       for (auto i = 0U; i < RADIX; i++) {
         if (zero[i]) {
           cn.returnToCache(e.p->e[i].w);
-          e.p->e[i] = vEdge::zero;
+          e.p->e[i] = vEdge::zero();
         }
       }
     }
@@ -312,7 +312,7 @@ public:
           // the chain
           vMemoryManager.returnEntry(e.p);
         }
-        return vEdge::zero;
+        return vEdge::zero();
       }
 
       auto r = e;
@@ -322,7 +322,7 @@ public:
       } else {
         r.w = cn.lookup(w);
       }
-      w = Complex::one;
+      w = Complex::one();
       return r;
     }
 
@@ -334,7 +334,7 @@ public:
       } else {
         r.w = cn.lookup(w);
       }
-      w = Complex::one;
+      w = Complex::one();
       return r;
     }
 
@@ -361,13 +361,13 @@ public:
       r.w = cn.lookup(RealNumber::val(max.w.r) * commonFactor,
                       RealNumber::val(max.w.i) * commonFactor);
       if (r.w.approximatelyZero()) {
-        return vEdge::zero;
+        return vEdge::zero();
       }
     }
 
     max.w = cn.lookup(magMax / norm, 0.);
-    if (max.w == Complex::zero) {
-      max = vEdge::zero;
+    if (max.w.exactlyZero()) {
+      max = vEdge::zero();
     }
 
     const auto argMin = (argMax + 1) % 2;
@@ -378,18 +378,19 @@ public:
     } else {
       min.w = cn.lookup(cn.divTemp(min.w, r.w));
     }
-    if (min.w == Complex::zero) {
-      min = vEdge::zero;
+    if (min.w.exactlyZero()) {
+      min = vEdge::zero();
     }
 
     return r;
   }
 
   dEdge makeZeroDensityOperator(const std::size_t n) {
-    auto f = dEdge::one;
+    auto f = dEdge::one();
     for (std::size_t p = 0; p < n; p++) {
-      f = makeDDNode(static_cast<Qubit>(p),
-                     std::array{f, dEdge::zero, dEdge::zero, dEdge::zero});
+      f = makeDDNode(
+          static_cast<Qubit>(p),
+          std::array{f, dEdge::zero(), dEdge::zero(), dEdge::zero()});
     }
     return f;
   }
@@ -403,9 +404,9 @@ public:
           std::to_string(nqubits) +
           " qubits. Please allocate a larger package instance."};
     }
-    auto f = vEdge::one;
+    auto f = vEdge::one();
     for (std::size_t p = start; p < n + start; p++) {
-      f = makeDDNode(static_cast<Qubit>(p), std::array{f, vEdge::zero});
+      f = makeDDNode(static_cast<Qubit>(p), std::array{f, vEdge::zero()});
     }
     return f;
   }
@@ -419,12 +420,12 @@ public:
           std::to_string(nqubits) +
           " qubits. Please allocate a larger package instance."};
     }
-    auto f = vEdge::one;
+    auto f = vEdge::one();
     for (std::size_t p = start; p < n + start; ++p) {
       if (!state[p]) {
-        f = makeDDNode(static_cast<Qubit>(p), std::array{f, vEdge::zero});
+        f = makeDDNode(static_cast<Qubit>(p), std::array{f, vEdge::zero()});
       } else {
-        f = makeDDNode(static_cast<Qubit>(p), std::array{vEdge::zero, f});
+        f = makeDDNode(static_cast<Qubit>(p), std::array{vEdge::zero(), f});
       }
     }
     return f;
@@ -446,14 +447,14 @@ public:
           ", but received " + std::to_string(state.size()));
     }
 
-    auto f = vEdge::one;
+    auto f = vEdge::one();
     for (std::size_t p = start; p < n + start; ++p) {
       switch (state[p]) {
       case BasisStates::zero:
-        f = makeDDNode(static_cast<Qubit>(p), std::array{f, vEdge::zero});
+        f = makeDDNode(static_cast<Qubit>(p), std::array{f, vEdge::zero()});
         break;
       case BasisStates::one:
-        f = makeDDNode(static_cast<Qubit>(p), std::array{vEdge::zero, f});
+        f = makeDDNode(static_cast<Qubit>(p), std::array{vEdge::zero(), f});
         break;
       case BasisStates::plus:
         f = makeDDNode(
@@ -487,7 +488,7 @@ public:
   // generate the decision diagram from an arbitrary state vector
   vEdge makeStateFromVector(const CVec& stateVector) {
     if (stateVector.empty()) {
-      return vEdge::one;
+      return vEdge::one();
     }
     const auto& length = stateVector.size();
     if ((length & (length - 1)) != 0) {
@@ -522,7 +523,7 @@ public:
   **/
   mEdge makeDDFromMatrix(const CMat& matrix) {
     if (matrix.empty()) {
-      return mEdge::one;
+      return mEdge::one();
     }
 
     const auto& length = matrix.size();
@@ -571,13 +572,13 @@ public:
           auto& successor = e.p->e[i];
           if (zero[i]) {
             cn.returnToCache(successor.w);
-            successor = Edge<Node>::zero;
+            successor = Edge<Node>::zero();
           }
         }
       }
 
       fp max = 0;
-      auto maxc = Complex::one;
+      auto maxc = Complex::one();
       // determine max amplitude
       for (auto i = 0U; i < NEDGE; ++i) {
         if (zero[i]) {
@@ -603,14 +604,14 @@ public:
         if (!e.isTerminal()) {
           getMemoryManager<Node>().returnEntry(e.p);
         }
-        return Edge<Node>::zero;
+        return Edge<Node>::zero();
       }
 
       auto r = e;
       // divide each entry by max
       for (auto i = 0U; i < NEDGE; ++i) {
         if (static_cast<decltype(argmax)>(i) == argmax) {
-          r.p->e[i].w = Complex::one;
+          r.p->e[i].w = Complex::one();
           if (r.w.exactlyOne()) {
             r.w = maxc;
             continue;
@@ -634,7 +635,7 @@ public:
             if (cached) {
               cn.returnToCache(successor.w);
             }
-            successor.w = Complex::one;
+            successor.w = Complex::one();
           }
           const auto c = cn.divTemp(successor.w, maxc);
           if (cached) {
@@ -673,7 +674,7 @@ public:
     for (auto i = 0U; i < NEDGE; ++i) {
       // NOLINTNEXTLINE(clang-diagnostic-float-equal) it has to be really zero
       if (mat[i].r == 0 && mat[i].i == 0) {
-        em[i] = mEdge::zero;
+        em[i] = mEdge::zero();
       } else {
         em[i] = mEdge::terminal(cn.lookup(mat[i]));
       }
@@ -686,13 +687,13 @@ public:
         for (auto i2 = 0U; i2 < RADIX; ++i2) {
           auto i = i1 * RADIX + i2;
           if (it != controls.end() && it->qubit == z) {
-            auto edges =
-                std::array{mEdge::zero, mEdge::zero, mEdge::zero, mEdge::zero};
+            auto edges = std::array{mEdge::zero(), mEdge::zero(), mEdge::zero(),
+                                    mEdge::zero()};
             if (it->type == qc::Control::Type::Neg) { // neg. control
               edges[0] = em[i];
               if (i1 == i2) {
                 if (z == 0U) {
-                  edges[3] = mEdge::one;
+                  edges[3] = mEdge::one();
                 } else {
                   edges[3] = makeIdent(start, z - 1U);
                 }
@@ -701,7 +702,7 @@ public:
               edges[3] = em[i];
               if (i1 == i2) {
                 if (z == 0U) {
-                  edges[0] = mEdge::one;
+                  edges[0] = mEdge::one();
                 } else {
                   edges[0] = makeIdent(start, z - 1U);
                 }
@@ -710,7 +711,7 @@ public:
             em[i] = makeDDNode(z, edges);
           } else { // not connected
             em[i] = makeDDNode(
-                z, std::array{em[i], mEdge::zero, mEdge::zero, em[i]});
+                z, std::array{em[i], mEdge::zero(), mEdge::zero(), em[i]});
           }
         }
       }
@@ -727,15 +728,15 @@ public:
       auto q = static_cast<Qubit>(z + 1);
       if (it != controls.end() && it->qubit == static_cast<qc::Qubit>(q)) {
         if (it->type == qc::Control::Type::Neg) { // neg. control
-          e = makeDDNode(q, std::array{e, mEdge::zero, mEdge::zero,
+          e = makeDDNode(q, std::array{e, mEdge::zero(), mEdge::zero(),
                                        makeIdent(start, q - 1U)});
         } else { // pos. control
-          e = makeDDNode(q, std::array{makeIdent(start, q - 1U), mEdge::zero,
-                                       mEdge::zero, e});
+          e = makeDDNode(q, std::array{makeIdent(start, q - 1U), mEdge::zero(),
+                                       mEdge::zero(), e});
         }
         ++it;
       } else { // not connected
-        e = makeDDNode(q, std::array{e, mEdge::zero, mEdge::zero, e});
+        e = makeDDNode(q, std::array{e, mEdge::zero(), mEdge::zero(), e});
       }
     }
     return e;
@@ -775,7 +776,7 @@ public:
         auto& emEntry = emRow.at(i2);
         // NOLINTNEXTLINE(clang-diagnostic-float-equal) it has to be really zero
         if (matEntry.r == 0 && matEntry.i == 0) {
-          emEntry = mEdge::zero;
+          emEntry = mEdge::zero();
         } else {
           emEntry = mEdge::terminal(cn.lookup(matEntry));
         }
@@ -788,8 +789,8 @@ public:
     for (; z < smallerTarget; ++z) {
       for (auto& row : em) {
         for (auto& entry : row) {
-          entry =
-              makeDDNode(z, std::array{entry, mEdge::zero, mEdge::zero, entry});
+          entry = makeDDNode(
+              z, std::array{entry, mEdge::zero(), mEdge::zero(), entry});
         }
       }
     }
@@ -822,8 +823,8 @@ public:
     // process lines between the two targets (by creating identity structures)
     for (++z; z < std::max(target0, target1); ++z) {
       for (auto& entry : em0) {
-        entry =
-            makeDDNode(z, std::array{entry, mEdge::zero, mEdge::zero, entry});
+        entry = makeDDNode(
+            z, std::array{entry, mEdge::zero(), mEdge::zero(), entry});
       }
     }
 
@@ -834,7 +835,7 @@ public:
     // process lines above the larger target (by creating identity structures)
     const auto end = static_cast<Qubit>(n + start);
     for (++z; z < end; ++z) {
-      e = makeDDNode(z, std::array{e, mEdge::zero, mEdge::zero, e});
+      e = makeDDNode(z, std::array{e, mEdge::zero(), mEdge::zero(), e});
     }
 
     return e;
@@ -1114,17 +1115,13 @@ private:
     // recursively call the function on all quadrants
     const auto rowMid = (rowStart + rowEnd) / 2;
     const auto colMid = (colStart + colEnd) / 2;
+    const auto l = static_cast<Qubit>(level - 1U);
 
-    const auto edge0 =
-        makeDDFromMatrix(matrix, level - 1, rowStart, rowMid, colStart, colMid);
-    const auto edge1 =
-        makeDDFromMatrix(matrix, level - 1, rowStart, rowMid, colMid, colEnd);
-    const auto edge2 =
-        makeDDFromMatrix(matrix, level - 1, rowMid, rowEnd, colStart, colMid);
-    const auto edge3 =
-        makeDDFromMatrix(matrix, level - 1, rowMid, rowEnd, colMid, colEnd);
-
-    return makeDDNode<mNode>(level, {edge0, edge1, edge2, edge3}, true);
+    return makeDDNode<mNode>(
+        level, {makeDDFromMatrix(matrix, l, rowStart, rowMid, colStart, colMid),
+                makeDDFromMatrix(matrix, l, rowStart, rowMid, colMid, colEnd),
+                makeDDFromMatrix(matrix, l, rowMid, rowEnd, colStart, colMid),
+                makeDDFromMatrix(matrix, l, rowMid, rowEnd, colMid, colEnd)});
   }
 
 public:
@@ -1137,7 +1134,7 @@ public:
       const bool cached = false,
       [[maybe_unused]] const bool generateDensityMatrix = false) {
     auto& memoryManager = getMemoryManager<Node>();
-    Edge<Node> e{memoryManager.get(), Complex::one};
+    Edge<Node> e{memoryManager.get(), Complex::one()};
     e.p->v = var;
     e.p->e = edges;
 
@@ -1199,7 +1196,7 @@ private:
       if (e.p->v == v) {
         for (std::size_t i = 0; i < n; i++) {
           edges[i] = i == edgeIdx
-                         ? Edge<Node>::zero
+                         ? Edge<Node>::zero()
                          : e.p->e[i]; // optimization -> node cannot occur below
                                       // again, since dd is assumed to be free
         }
@@ -1291,22 +1288,20 @@ public:
     }
 
     if (collapse) {
-      decRef(rootEdge);
-
-      vEdge e = vEdge::one;
+      vEdge e = vEdge::one();
       std::array<vEdge, 2> edges{};
-
       for (std::size_t p = 0U; p < numberOfQubits; ++p) {
         if (result[p] == '0') {
           edges[0] = e;
-          edges[1] = vEdge::zero;
+          edges[1] = vEdge::zero();
         } else {
-          edges[0] = vEdge::zero;
+          edges[0] = vEdge::zero();
           edges[1] = e;
         }
         e = makeDDNode(static_cast<Qubit>(p), edges, false);
       }
       incRef(e);
+      decRef(rootEdge);
       rootEdge = e;
       garbageCollect();
     }
@@ -1531,7 +1526,7 @@ public:
   Edge<Node> add2(const Edge<Node>& x, const Edge<Node>& y, const Qubit var) {
     if (x.w.exactlyZero()) {
       if (y.w.exactlyZero()) {
-        return Edge<Node>::zero;
+        return Edge<Node>::zero();
       }
       return {y.p, cn.getCached(y.w)};
     }
@@ -1543,7 +1538,7 @@ public:
       r.w = cn.addCached(x.w, y.w);
       if (r.w.approximatelyZero()) {
         cn.returnToCache(r.w);
-        return Edge<Node>::zero;
+        return Edge<Node>::zero();
       }
       return r;
     }
@@ -1552,7 +1547,7 @@ public:
     if (const auto* r = computeTable.lookup({x.p, x.w}, {y.p, y.w});
         r != nullptr) {
       if (r->w.approximatelyZero()) {
-        return Edge<Node>::zero;
+        return Edge<Node>::zero();
       }
       return {r->p, cn.getCached(r->w)};
     }
@@ -1570,7 +1565,7 @@ public:
       } else {
         e1 = x;
         if (y.p->e[i].isTerminal()) {
-          e1 = Edge<Node>::zero;
+          e1 = Edge<Node>::zero();
         }
       }
       Edge<Node> e2{};
@@ -1583,7 +1578,7 @@ public:
       } else {
         e2 = y;
         if (x.p->e[i].isTerminal()) {
-          e2 = Edge<Node>::zero;
+          e2 = Edge<Node>::zero();
         }
       }
 
@@ -1746,7 +1741,7 @@ private:
     using ResultEdge = Edge<RightOperandNode>;
 
     if (x.w.exactlyZero() || y.w.exactlyZero()) {
-      return ResultEdge::zero;
+      return ResultEdge::zero();
     }
 
     if (x.isIdentity()) {
@@ -1760,8 +1755,8 @@ private:
       }
     }
 
-    auto xCopy = LEdge{x.p, Complex::one};
-    auto yCopy = REdge{y.p, Complex::one};
+    auto xCopy = LEdge{x.p, Complex::one()};
+    auto yCopy = REdge{y.p, Complex::one()};
 
     auto& computeTable =
         getMultiplicationComputeTable<LeftOperandNode, RightOperandNode>();
@@ -1769,14 +1764,14 @@ private:
             computeTable.lookup(xCopy, yCopy, generateDensityMatrix);
         r != nullptr) {
       if (r->w.approximatelyZero()) {
-        return ResultEdge::zero;
+        return ResultEdge::zero();
       }
       auto e = ResultEdge{r->p, cn.getCached(r->w)};
       ComplexNumbers::mul(e.w, e.w, x.w);
       ComplexNumbers::mul(e.w, e.w, y.w);
       if (e.w.approximatelyZero()) {
         cn.returnToCache(e.w);
-        return ResultEdge::zero;
+        return ResultEdge::zero();
       }
       return e;
     }
@@ -1790,7 +1785,7 @@ private:
     for (auto i = 0U; i < rows; i++) {
       for (auto j = 0U; j < cols; j++) {
         auto idx = cols * i + j;
-        edge[idx] = ResultEdge::zero;
+        edge[idx] = ResultEdge::zero();
         for (auto k = 0U; k < rows; k++) {
           const auto xIdx = rows * i + k;
           LEdge e1 = x.p->e[xIdx];
@@ -1812,7 +1807,7 @@ private:
               // then edge[2] == edge[1]
               if (k == 0) {
                 if (edge[1].w.approximatelyZero()) {
-                  edge[2] = ResultEdge::zero;
+                  edge[2] = ResultEdge::zero();
                 } else {
                   edge[2] = {edge[1].p, cn.getCached(edge[1].w)};
                 }
@@ -1862,7 +1857,7 @@ private:
       }
       if (e.w.approximatelyZero()) {
         cn.returnToCache(e.w);
-        return ResultEdge::zero;
+        return ResultEdge::zero();
       }
     }
     return e;
@@ -1967,8 +1962,8 @@ private:
     }
 
     // Set to one to generate more lookup hits
-    auto xCopy = vEdge{x.p, Complex::one};
-    auto yCopy = vEdge{y.p, Complex::one};
+    auto xCopy = vEdge{x.p, Complex::one()};
+    auto yCopy = vEdge{y.p, Complex::one()};
     if (const auto* r = vectorInnerProduct.lookup(xCopy, yCopy); r != nullptr) {
       auto c = cn.getTemporary(r->w);
       ComplexNumbers::mul(c, c, x.w);
@@ -2092,7 +2087,7 @@ private:
     auto& computeTable = getKroneckerComputeTable<Node>();
     if (const auto* r = computeTable.lookup(x, y); r != nullptr) {
       if (r->w.approximatelyZero()) {
-        return Edge<Node>::zero;
+        return Edge<Node>::zero();
       }
       return {r->p, cn.getCached(r->w)};
     }
@@ -2103,11 +2098,11 @@ private:
       if (x.p->isIdentity()) {
         auto idx = incIdx ? static_cast<Qubit>(y.p->v + 1) : y.p->v;
         auto e = makeDDNode(
-            idx, std::array{y, Edge<Node>::zero, Edge<Node>::zero, y});
+            idx, std::array{y, Edge<Node>::zero(), Edge<Node>::zero(), y});
         for (auto i = 0; i < x.p->v; ++i) {
           idx = incIdx ? (e.p->v + 1) : e.p->v;
-          e = makeDDNode(idx,
-                         std::array{e, Edge<Node>::zero, Edge<Node>::zero, e});
+          e = makeDDNode(
+              idx, std::array{e, Edge<Node>::zero(), Edge<Node>::zero(), e});
         }
 
         e.w = cn.getCached(y.w);
@@ -2158,7 +2153,7 @@ private:
   mEdge trace(const mEdge& a, const std::vector<bool>& eliminate,
               std::size_t alreadyEliminated = 0) {
     if (a.w.approximatelyZero()) {
-      return mEdge::zero;
+      return mEdge::zero();
     }
 
     if (a.isTerminal() || std::none_of(eliminate.begin(), eliminate.end(),
@@ -2169,7 +2164,7 @@ private:
     const auto v = a.p->v;
     if (eliminate[v]) {
       const auto elims = alreadyEliminated + 1;
-      auto r = mEdge::zero;
+      auto r = mEdge::zero();
 
       const auto t0 = trace(a.p->e[0], eliminate, elims);
       r = add2(r, t0, v - 1);
@@ -2282,14 +2277,14 @@ public:
   // create n-qubit identity DD. makeIdent(n) === makeIdent(0, n-1)
   mEdge makeIdent(const std::size_t n) {
     if (n == 0U) {
-      return mEdge::one;
+      return mEdge::one();
     }
     return makeIdent(0, n - 1);
   }
   mEdge makeIdent(const std::size_t leastSignificantQubit,
                   const std::size_t mostSignificantQubit) {
     if (mostSignificantQubit < leastSignificantQubit) {
-      return mEdge::one;
+      return mEdge::one();
     }
 
     const auto& entry = idTable.at(mostSignificantQubit);
@@ -2302,17 +2297,17 @@ public:
       if (!prevEntry.isTerminal()) {
         idTable.at(mostSignificantQubit) = makeDDNode(
             static_cast<Qubit>(mostSignificantQubit),
-            std::array{prevEntry, mEdge::zero, mEdge::zero, prevEntry});
+            std::array{prevEntry, mEdge::zero(), mEdge::zero(), prevEntry});
         return idTable[mostSignificantQubit];
       }
     }
 
     auto e = makeDDNode(
         static_cast<Qubit>(leastSignificantQubit),
-        std::array{mEdge::one, mEdge::zero, mEdge::zero, mEdge::one});
+        std::array{mEdge::one(), mEdge::zero(), mEdge::zero(), mEdge::one()});
     for (auto k = leastSignificantQubit + 1; k <= mostSignificantQubit; ++k) {
       e = makeDDNode(static_cast<Qubit>(k),
-                     std::array{e, mEdge::zero, mEdge::zero, e});
+                     std::array{e, mEdge::zero(), mEdge::zero(), e});
     }
     if (leastSignificantQubit == 0) {
       idTable.at(mostSignificantQubit) = e;
@@ -2456,14 +2451,14 @@ private:
     // something to reduce for this qubit
     if (ancillary[f.p->v]) {
       if (regular) {
-        if (f.p->e[1].w != Complex::zero || f.p->e[3].w != Complex::zero) {
-          f = makeDDNode(f.p->v, std::array{f.p->e[0], mEdge::zero, f.p->e[2],
-                                            mEdge::zero});
+        if (!f.p->e[1].w.exactlyZero() || !f.p->e[3].w.exactlyZero()) {
+          f = makeDDNode(f.p->v, std::array{f.p->e[0], mEdge::zero(), f.p->e[2],
+                                            mEdge::zero()});
         }
       } else {
-        if (f.p->e[2].w != Complex::zero || f.p->e[3].w != Complex::zero) {
-          f = makeDDNode(f.p->v, std::array{f.p->e[0], f.p->e[1], mEdge::zero,
-                                            mEdge::zero});
+        if (!f.p->e[2].w.exactlyZero() || !f.p->e[3].w.exactlyZero()) {
+          f = makeDDNode(f.p->v, std::array{f.p->e[0], f.p->e[1], mEdge::zero(),
+                                            mEdge::zero()});
         }
       }
     }
@@ -2501,23 +2496,23 @@ private:
 
     // something to reduce for this qubit
     if (garbage[f.p->v]) {
-      if (f.p->e[1].w != Complex::zero) {
+      if (!f.p->e[1].w.exactlyZero()) {
         vEdge g{};
-        if (f.p->e[0].w == Complex::zero && f.p->e[1].w != Complex::zero) {
+        if (f.p->e[0].w.exactlyZero() && !f.p->e[1].w.exactlyZero()) {
           g = f.p->e[1];
-        } else if (f.p->e[1].w != Complex::zero) {
+        } else if (!f.p->e[1].w.exactlyZero()) {
           g = add(f.p->e[0], f.p->e[1]);
         } else {
           g = f.p->e[0];
         }
-        f = makeDDNode(e.p->v, std::array{g, vEdge::zero});
+        f = makeDDNode(e.p->v, std::array{g, vEdge::zero()});
       }
     }
     f.w = cn.lookup(cn.mulTemp(f.w, e.w));
 
     // Quick-fix for normalization bug
     if (ComplexNumbers::mag2(f.w) > 1.0) {
-      f.w = Complex::one;
+      f.w = Complex::one();
     }
 
     return f;
@@ -2555,44 +2550,46 @@ private:
     // something to reduce for this qubit
     if (garbage[f.p->v]) {
       if (regular) {
-        if (f.p->e[2].w != Complex::zero || f.p->e[3].w != Complex::zero) {
+        if (!f.p->e[2].w.exactlyZero() || !f.p->e[3].w.exactlyZero()) {
           mEdge g{};
-          if (f.p->e[0].w == Complex::zero && f.p->e[2].w != Complex::zero) {
+          if (f.p->e[0].w.exactlyZero() && !f.p->e[2].w.exactlyZero()) {
             g = f.p->e[2];
-          } else if (f.p->e[2].w != Complex::zero) {
+          } else if (!f.p->e[2].w.exactlyZero()) {
             g = add(f.p->e[0], f.p->e[2]);
           } else {
             g = f.p->e[0];
           }
           mEdge h{};
-          if (f.p->e[1].w == Complex::zero && f.p->e[3].w != Complex::zero) {
+          if (f.p->e[1].w.exactlyZero() && !f.p->e[3].w.exactlyZero()) {
             h = f.p->e[3];
-          } else if (f.p->e[3].w != Complex::zero) {
+          } else if (!f.p->e[3].w.exactlyZero()) {
             h = add(f.p->e[1], f.p->e[3]);
           } else {
             h = f.p->e[1];
           }
-          f = makeDDNode(e.p->v, std::array{g, h, mEdge::zero, mEdge::zero});
+          f = makeDDNode(e.p->v,
+                         std::array{g, h, mEdge::zero(), mEdge::zero()});
         }
       } else {
-        if (f.p->e[1].w != Complex::zero || f.p->e[3].w != Complex::zero) {
+        if (!f.p->e[1].w.exactlyZero() || !f.p->e[3].w.exactlyZero()) {
           mEdge g{};
-          if (f.p->e[0].w == Complex::zero && f.p->e[1].w != Complex::zero) {
+          if (f.p->e[0].w.exactlyZero() && !f.p->e[1].w.exactlyZero()) {
             g = f.p->e[1];
-          } else if (f.p->e[1].w != Complex::zero) {
+          } else if (!f.p->e[1].w.exactlyZero()) {
             g = add(f.p->e[0], f.p->e[1]);
           } else {
             g = f.p->e[0];
           }
           mEdge h{};
-          if (f.p->e[2].w == Complex::zero && f.p->e[3].w != Complex::zero) {
+          if (f.p->e[2].w.exactlyZero() && !f.p->e[3].w.exactlyZero()) {
             h = f.p->e[3];
-          } else if (f.p->e[3].w != Complex::zero) {
+          } else if (!f.p->e[3].w.exactlyZero()) {
             h = add(f.p->e[2], f.p->e[3]);
           } else {
             h = f.p->e[2];
           }
-          f = makeDDNode(e.p->v, std::array{g, mEdge::zero, h, mEdge::zero});
+          f = makeDDNode(e.p->v,
+                         std::array{g, mEdge::zero(), h, mEdge::zero()});
         }
       }
     }
@@ -2600,7 +2597,7 @@ private:
 
     // Quick-fix for normalization bug
     if (ComplexNumbers::mag2(f.w) > 1.0) {
-      f.w = Complex::one;
+      f.w = Complex::one();
     }
 
     return f;
@@ -2699,7 +2696,7 @@ public:
   template <class Node, class Edge = Edge<Node>,
             std::size_t N = std::tuple_size_v<decltype(Node::e)>>
   Edge deserialize(std::istream& is, const bool readBinary = false) {
-    auto result = Edge::zero;
+    auto result = Edge::zero();
     ComplexValue rootweight{};
 
     std::unordered_map<std::int64_t, Node*> nodes{};
@@ -2829,16 +2826,16 @@ private:
                        const std::array<ComplexValue, N>& edgeWeight,
                        std::unordered_map<std::int64_t, Node*>& nodes) {
     if (index == -1) {
-      return Edge::zero;
+      return Edge::zero();
     }
 
     std::array<Edge, N> edges{};
     for (auto i = 0U; i < N; ++i) {
       if (edgeIdx[i] == -2) {
-        edges[i] = Edge::zero;
+        edges[i] = Edge::zero();
       } else {
         if (edgeIdx[i] == -1) {
-          edges[i] = Edge::one;
+          edges[i] = Edge::one();
         } else {
           edges[i].p = nodes[edgeIdx[i]];
         }

--- a/include/dd/RealNumber.hpp
+++ b/include/dd/RealNumber.hpp
@@ -2,6 +2,8 @@
 
 #include "dd/DDDefinitions.hpp"
 
+#include <limits>
+
 namespace dd {
 /**
  * @brief A struct for representing real numbers as part of the DD package.
@@ -18,21 +20,22 @@ struct RealNumber {
    * @param e The number to check.
    * @returns Whether the number points to zero.
    */
-  [[nodiscard]] static bool exactlyZero(const RealNumber* e) noexcept;
+  [[nodiscard]] static constexpr bool exactlyZero(const RealNumber* e) noexcept;
 
   /**
    * @brief Check whether the number points to the one number.
    * @param e The number to check.
    * @returns Whether the number points to one.
    */
-  [[nodiscard]] static bool exactlyOne(const RealNumber* e) noexcept;
+  [[nodiscard]] static constexpr bool exactlyOne(const RealNumber* e) noexcept;
 
   /**
    * @brief Check whether the number points to the sqrt(2)/2 = 1/sqrt(2) number.
    * @param e The number to check.
    * @returns Whether the number points to negative one.
    */
-  [[nodiscard]] static bool exactlySqrt2over2(const RealNumber* e) noexcept;
+  [[nodiscard]] static constexpr bool
+  exactlySqrt2over2(const RealNumber* e) noexcept;
 
   /**
    * @brief Get the value of the number.
@@ -239,7 +242,20 @@ extern RealNumber sqrt2over2;
  * @return Whether the number is one of the static numbers.
  */
 [[nodiscard]] constexpr bool isStaticNumber(const RealNumber* e) noexcept {
-  return e == &zero || e == &one || e == &sqrt2over2;
+  return RealNumber::exactlyZero(e) || RealNumber::exactlyOne(e) ||
+         RealNumber::exactlySqrt2over2(e);
 }
 } // namespace constants
+
+constexpr bool RealNumber::exactlyZero(const RealNumber* e) noexcept {
+  return e == &constants::zero;
+}
+
+constexpr bool RealNumber::exactlyOne(const RealNumber* e) noexcept {
+  return e == &constants::one;
+}
+
+constexpr bool RealNumber::exactlySqrt2over2(const RealNumber* e) noexcept {
+  return e == &constants::sqrt2over2;
+}
 } // namespace dd

--- a/include/dd/UniqueTable.hpp
+++ b/include/dd/UniqueTable.hpp
@@ -387,7 +387,7 @@ private:
     }
 
     // Node not found in bucket
-    return Edge<Node>::zero;
+    return Edge<Node>::zero();
   }
 };
 

--- a/src/dd/Complex.cpp
+++ b/src/dd/Complex.cpp
@@ -6,26 +6,12 @@
 #include <cassert>
 
 namespace dd {
-// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,
-// cppcoreguidelines-interfaces-global-init)
-Complex Complex::zero{&constants::zero, &constants::zero};
-Complex Complex::one{&constants::one, &constants::zero};
-// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,
-// cppcoreguidelines-interfaces-global-init)
 
 void Complex::setVal(const Complex& c) const noexcept {
   assert(!RealNumber::isNegativePointer(r));
   assert(!RealNumber::isNegativePointer(i));
   r->value = RealNumber::val(c.r);
   i->value = RealNumber::val(c.i);
-}
-
-bool Complex::exactlyZero() const noexcept {
-  return RealNumber::exactlyZero(r) && RealNumber::exactlyZero(i);
-}
-
-bool Complex::exactlyOne() const noexcept {
-  return RealNumber::exactlyOne(r) && RealNumber::exactlyZero(i);
 }
 
 bool Complex::approximatelyEquals(const Complex& c) const noexcept {

--- a/src/dd/ComplexNumbers.cpp
+++ b/src/dd/ComplexNumbers.cpp
@@ -9,8 +9,8 @@ void ComplexNumbers::setTolerance(fp tol) noexcept { RealNumber::eps = tol; }
 
 void ComplexNumbers::add(Complex& r, const Complex& a,
                          const Complex& b) noexcept {
-  assert(r != Complex::zero);
-  assert(r != Complex::one);
+  assert(!r.exactlyZero());
+  assert(!r.exactlyOne());
   assert(r.r != a.i && "r.r and a.i point to the same entry!");
   assert(r.i != a.r && "r.i and a.r point to the same entry!");
   assert(r.r != b.i && "r.r and b.i point to the same entry!");
@@ -21,8 +21,8 @@ void ComplexNumbers::add(Complex& r, const Complex& a,
 
 void ComplexNumbers::sub(Complex& r, const Complex& a,
                          const Complex& b) noexcept {
-  assert(r != Complex::zero);
-  assert(r != Complex::one);
+  assert(!r.exactlyZero());
+  assert(!r.exactlyOne());
   assert(r.r != a.i && "r.r and a.i point to the same entry!");
   assert(r.i != a.r && "r.i and a.r point to the same entry!");
   assert(r.r != b.i && "r.r and b.i point to the same entry!");
@@ -33,8 +33,8 @@ void ComplexNumbers::sub(Complex& r, const Complex& a,
 
 void ComplexNumbers::mul(Complex& r, const Complex& a,
                          const Complex& b) noexcept {
-  assert(r != Complex::zero);
-  assert(r != Complex::one);
+  assert(!r.exactlyZero());
+  assert(!r.exactlyOne());
   assert(r.r != a.i && "r.r and a.i point to the same entry!");
   assert(r.i != a.r && "r.i and a.r point to the same entry!");
   assert(r.r != b.i && "r.r and b.i point to the same entry!");
@@ -59,8 +59,8 @@ void ComplexNumbers::mul(Complex& r, const Complex& a,
 
 void ComplexNumbers::div(Complex& r, const Complex& a,
                          const Complex& b) noexcept {
-  assert(r != Complex::zero);
-  assert(r != Complex::one);
+  assert(!r.exactlyZero());
+  assert(!r.exactlyOne());
   assert(r.r != a.i && "r.r and a.i point to the same entry!");
   assert(r.i != a.r && "r.i and a.r point to the same entry!");
   assert(r.r != b.i && "r.r and b.i point to the same entry!");

--- a/src/dd/Edge.cpp
+++ b/src/dd/Edge.cpp
@@ -79,7 +79,7 @@ std::complex<fp> Edge<Node>::getValueByIndex(const std::size_t i) const {
 
   auto decisions = std::string(p->v + 1U, '0');
   for (auto j = 0U; j <= p->v; ++j) {
-    if ((i & (1U << j)) != 0U) {
+    if ((i & (1ULL << j)) != 0U) {
       decisions[j] = '1';
     }
   }
@@ -196,12 +196,12 @@ std::complex<fp> Edge<Node>::getValueByIndex(const std::size_t i,
 
   auto decisions = std::string(p->v + 1U, '0');
   for (auto k = 0U; k <= p->v; ++k) {
-    if ((i & (1U << k)) != 0U) {
+    if ((i & (1ULL << k)) != 0U) {
       decisions[k] = '2';
     }
   }
   for (auto k = 0U; k <= p->v; ++k) {
-    if ((j & (1U << k)) != 0U) {
+    if ((j & (1ULL << k)) != 0U) {
       if (decisions[k] == '2') {
         decisions[k] = '3';
       } else {

--- a/src/dd/FunctionalityConstruction.cpp
+++ b/src/dd/FunctionalityConstruction.cpp
@@ -6,7 +6,7 @@ MatrixDD buildFunctionality(const QuantumComputation* qc,
                             std::unique_ptr<Package<Config>>& dd) {
   const auto nq = qc->getNqubits();
   if (nq == 0U) {
-    return MatrixDD::one;
+    return MatrixDD::one();
   }
 
   if (const auto* grover = dynamic_cast<const qc::Grover*>(qc)) {
@@ -37,7 +37,7 @@ template <class Config>
 MatrixDD buildFunctionalityRecursive(const QuantumComputation* qc,
                                      std::unique_ptr<Package<Config>>& dd) {
   if (qc->getNqubits() == 0U) {
-    return MatrixDD::one;
+    return MatrixDD::one();
   }
 
   if (const auto* grover = dynamic_cast<const qc::Grover*>(qc)) {

--- a/src/dd/RealNumber.cpp
+++ b/src/dd/RealNumber.cpp
@@ -16,18 +16,6 @@ RealNumber* RealNumber::getNegativePointer(const RealNumber* e) noexcept {
                                        LSB);
 }
 
-bool RealNumber::exactlyZero(const RealNumber* e) noexcept {
-  return (e == &constants::zero);
-}
-
-bool RealNumber::exactlyOne(const RealNumber* e) noexcept {
-  return (e == &constants::one);
-}
-
-bool RealNumber::exactlySqrt2over2(const dd::RealNumber* e) noexcept {
-  return (e == &constants::sqrt2over2);
-}
-
 RealNumber* RealNumber::flipPointerSign(const RealNumber* e) noexcept {
   if (exactlyZero(e)) {
     return &constants::zero;

--- a/test/dd/test_complex.cpp
+++ b/test/dd/test_complex.cpp
@@ -40,9 +40,9 @@ TEST_F(CNTest, TrivialTest) {
 }
 
 TEST_F(CNTest, ComplexNumberCreation) {
-  EXPECT_EQ(cn.lookup(Complex::zero), Complex::zero);
-  EXPECT_EQ(cn.lookup(Complex::one), Complex::one);
-  EXPECT_EQ(cn.lookup(1e-16, 0.), Complex::zero);
+  EXPECT_TRUE(cn.lookup(Complex::zero()).exactlyZero());
+  EXPECT_TRUE(cn.lookup(Complex::one()).exactlyOne());
+  EXPECT_TRUE(cn.lookup(1e-16, 0.).exactlyZero());
   EXPECT_EQ(RealNumber::val(cn.lookup(1e-16, 1.).r), 0.);
   EXPECT_EQ(RealNumber::val(cn.lookup(1e-16, 1.).i), 1.);
   EXPECT_EQ(RealNumber::val(cn.lookup(1e-16, -1.).r), 0.);
@@ -92,9 +92,9 @@ TEST_F(CNTest, ComplexNumberArithmetic) {
   cn.decRef(c);
   cn.decRef(d);
   e = cn.lookup(e);
-  EXPECT_EQ(e, Complex::one);
+  EXPECT_EQ(e, Complex::one());
   auto f = cn.getTemporary();
-  ComplexNumbers::div(f, Complex::zero, Complex::one);
+  ComplexNumbers::div(f, Complex::zero(), Complex::one());
 
   const dd::ComplexValue zero{0., 0.};
   const dd::ComplexValue one{1., 0.};
@@ -102,10 +102,8 @@ TEST_F(CNTest, ComplexNumberArithmetic) {
 }
 
 TEST_F(CNTest, NearZeroLookup) {
-  auto c = cn.getTemporary(RealNumber::eps / 10., RealNumber::eps / 10.);
-  auto d = cn.lookup(c);
-  EXPECT_EQ(d.r, Complex::zero.r);
-  EXPECT_EQ(d.i, Complex::zero.i);
+  auto d = cn.lookup(RealNumber::eps / 10., RealNumber::eps / 10.);
+  EXPECT_TRUE(d.exactlyZero());
 }
 
 TEST_F(CNTest, SortedBuckets) {
@@ -270,14 +268,14 @@ TEST(DDComplexTest, ComplexValueEquals) {
 }
 
 TEST(DDComplexTest, LowestFractions) {
-  EXPECT_THAT(dd::ComplexValue::getLowestFraction(0.0), ::testing::Pair(0, 1));
-  EXPECT_THAT(dd::ComplexValue::getLowestFraction(0.2), ::testing::Pair(1, 5));
-  EXPECT_THAT(dd::ComplexValue::getLowestFraction(0.25), ::testing::Pair(1, 4));
-  EXPECT_THAT(dd::ComplexValue::getLowestFraction(0.5), ::testing::Pair(1, 2));
-  EXPECT_THAT(dd::ComplexValue::getLowestFraction(0.75), ::testing::Pair(3, 4));
-  EXPECT_THAT(dd::ComplexValue::getLowestFraction(1.5), ::testing::Pair(3, 2));
-  EXPECT_THAT(dd::ComplexValue::getLowestFraction(2.0), ::testing::Pair(2, 1));
-  EXPECT_THAT(dd::ComplexValue::getLowestFraction(2047.0 / 2048.0, 1024U),
+  EXPECT_THAT(ComplexValue::getLowestFraction(0.0), ::testing::Pair(0, 1));
+  EXPECT_THAT(ComplexValue::getLowestFraction(0.2), ::testing::Pair(1, 5));
+  EXPECT_THAT(ComplexValue::getLowestFraction(0.25), ::testing::Pair(1, 4));
+  EXPECT_THAT(ComplexValue::getLowestFraction(0.5), ::testing::Pair(1, 2));
+  EXPECT_THAT(ComplexValue::getLowestFraction(0.75), ::testing::Pair(3, 4));
+  EXPECT_THAT(ComplexValue::getLowestFraction(1.5), ::testing::Pair(3, 2));
+  EXPECT_THAT(ComplexValue::getLowestFraction(2.0), ::testing::Pair(2, 1));
+  EXPECT_THAT(ComplexValue::getLowestFraction(2047.0 / 2048.0, 1024U),
               ::testing::Pair(1, 1));
 }
 
@@ -616,33 +614,33 @@ TEST_F(CNTest, exactlyOneComparison) {
 }
 
 TEST_F(CNTest, ExportConditionalFormat1) {
-  EXPECT_STREQ(dd::conditionalFormat(cn.getCached(1, 0)).c_str(), "1");
+  EXPECT_STREQ(dd::conditionalFormat(cn.lookup(1, 0)).c_str(), "1");
 }
 
 TEST_F(CNTest, ExportConditionalFormat2) {
-  EXPECT_STREQ(dd::conditionalFormat(cn.getCached(0, 1)).c_str(), "i");
+  EXPECT_STREQ(dd::conditionalFormat(cn.lookup(0, 1)).c_str(), "i");
 }
 
 TEST_F(CNTest, ExportConditionalFormat3) {
-  EXPECT_STREQ(dd::conditionalFormat(cn.getCached(-1, 0)).c_str(), "-1");
+  EXPECT_STREQ(dd::conditionalFormat(cn.lookup(-1, 0)).c_str(), "-1");
 }
 
 TEST_F(CNTest, ExportConditionalFormat4) {
-  EXPECT_STREQ(dd::conditionalFormat(cn.getCached(0, -1)).c_str(), "-i");
+  EXPECT_STREQ(dd::conditionalFormat(cn.lookup(0, -1)).c_str(), "-i");
 }
 
 TEST_F(CNTest, ExportConditionalFormat5) {
-  const auto num = cn.getCached(-dd::SQRT2_2, -dd::SQRT2_2);
+  const auto num = cn.lookup(-dd::SQRT2_2, -dd::SQRT2_2);
   EXPECT_STREQ(dd::conditionalFormat(num).c_str(), "ℯ(-iπ 3/4)");
   EXPECT_STREQ(dd::conditionalFormat(num, false).c_str(), "-1/√2(1+i)");
 }
 
 TEST_F(CNTest, ExportConditionalFormat6) {
-  EXPECT_STREQ(dd::conditionalFormat(cn.getCached(-1, -1)).c_str(),
+  EXPECT_STREQ(dd::conditionalFormat(cn.lookup(-1, -1)).c_str(),
                "2/√2 ℯ(-iπ 3/4)");
 }
 
 TEST_F(CNTest, ExportConditionalFormat7) {
-  EXPECT_STREQ(dd::conditionalFormat(cn.getCached(-dd::SQRT2_2, 0)).c_str(),
+  EXPECT_STREQ(dd::conditionalFormat(cn.lookup(-dd::SQRT2_2, 0)).c_str(),
                "-1/√2");
 }

--- a/test/dd/test_edge_functionality.cpp
+++ b/test/dd/test_edge_functionality.cpp
@@ -9,13 +9,13 @@ namespace dd {
 ///-----------------------------------------------------------------------------
 
 TEST(VectorFunctionality, GetValueByPathTerminal) {
-  EXPECT_EQ(vEdge::zero.getValueByPath("0"), 0.);
-  EXPECT_EQ(vEdge::one.getValueByPath("0"), 1.);
+  EXPECT_EQ(vEdge::zero().getValueByPath("0"), 0.);
+  EXPECT_EQ(vEdge::one().getValueByPath("0"), 1.);
 }
 
 TEST(VectorFunctionality, GetValueByIndexTerminal) {
-  EXPECT_EQ(vEdge::zero.getValueByIndex(0), 0.);
-  EXPECT_EQ(vEdge::one.getValueByIndex(0), 1.);
+  EXPECT_EQ(vEdge::zero().getValueByIndex(0), 0.);
+  EXPECT_EQ(vEdge::one().getValueByIndex(0), 1.);
 }
 
 TEST(VectorFunctionality, GetValueByIndexEndianness) {
@@ -30,8 +30,8 @@ TEST(VectorFunctionality, GetValueByIndexEndianness) {
 }
 
 TEST(VectorFunctionality, GetVectorTerminal) {
-  EXPECT_EQ(vEdge::zero.getVector(), CVec{0.});
-  EXPECT_EQ(vEdge::one.getVector(), CVec{1.});
+  EXPECT_EQ(vEdge::zero().getVector(), CVec{0.});
+  EXPECT_EQ(vEdge::one().getVector(), CVec{1.});
 }
 
 TEST(VectorFunctionality, GetVectorRoundtrip) {
@@ -57,9 +57,9 @@ TEST(VectorFunctionality, GetVectorTolerance) {
 
 TEST(VectorFunctionality, GetSparseVectorTerminal) {
   const auto zero = SparseCVec{{0, 0}};
-  EXPECT_EQ(vEdge::zero.getSparseVector(), zero);
+  EXPECT_EQ(vEdge::zero().getSparseVector(), zero);
   const auto one = SparseCVec{{0, 1}};
-  EXPECT_EQ(vEdge::one.getSparseVector(), one);
+  EXPECT_EQ(vEdge::one().getSparseVector(), one);
 }
 
 TEST(VectorFunctionality, GetSparseVectorConsistency) {
@@ -91,11 +91,11 @@ TEST(VectorFunctionality, GetSparseVectorTolerance) {
 
 TEST(VectorFunctionality, PrintVectorTerminal) {
   testing::internal::CaptureStdout();
-  vEdge::zero.printVector();
+  vEdge::zero().printVector();
   const auto zeroStr = testing::internal::GetCapturedStdout();
   EXPECT_EQ(zeroStr, "0: (0,0)\n");
   testing::internal::CaptureStdout();
-  vEdge::one.printVector();
+  vEdge::one().printVector();
   const auto oneStr = testing::internal::GetCapturedStdout();
   EXPECT_EQ(oneStr, "0: (1,0)\n");
 }
@@ -114,7 +114,7 @@ TEST(VectorFunctionality, PrintVector) {
 
 TEST(VectorFunctionality, AddToVectorTerminal) {
   CVec vec = {0.};
-  vEdge::one.addToVector(vec);
+  vEdge::one().addToVector(vec);
   EXPECT_EQ(vec, CVec{1.});
 }
 
@@ -130,8 +130,8 @@ TEST(VectorFunctionality, AddToVector) {
 }
 
 TEST(VectorFunctionality, SizeTerminal) {
-  EXPECT_EQ(vEdge::zero.size(), 1);
-  EXPECT_EQ(vEdge::one.size(), 1);
+  EXPECT_EQ(vEdge::zero().size(), 1);
+  EXPECT_EQ(vEdge::one().size(), 1);
 }
 
 TEST(VectorFunctionality, SizeBellState) {
@@ -146,13 +146,13 @@ TEST(VectorFunctionality, SizeBellState) {
 ///-----------------------------------------------------------------------------
 
 TEST(MatrixFunctionality, GetValueByPathTerminal) {
-  EXPECT_EQ(mEdge::zero.getValueByPath("0"), 0.);
-  EXPECT_EQ(mEdge::one.getValueByPath("0"), 1.);
+  EXPECT_EQ(mEdge::zero().getValueByPath("0"), 0.);
+  EXPECT_EQ(mEdge::one().getValueByPath("0"), 1.);
 }
 
 TEST(MatrixFunctionality, GetValueByIndexTerminal) {
-  EXPECT_EQ(mEdge::zero.getValueByIndex(0, 0), 0.);
-  EXPECT_EQ(mEdge::one.getValueByIndex(0, 0), 1.);
+  EXPECT_EQ(mEdge::zero().getValueByIndex(0, 0), 0.);
+  EXPECT_EQ(mEdge::one().getValueByIndex(0, 0), 1.);
 }
 
 TEST(MatrixFunctionality, GetValueByIndexEndianness) {
@@ -178,8 +178,8 @@ TEST(MatrixFunctionality, GetValueByIndexEndianness) {
 }
 
 TEST(MatrixFunctionality, GetMatrixTerminal) {
-  EXPECT_EQ(mEdge::zero.getMatrix(), CMat{{0.}});
-  EXPECT_EQ(mEdge::one.getMatrix(), CMat{{1.}});
+  EXPECT_EQ(mEdge::zero().getMatrix(), CMat{{0.}});
+  EXPECT_EQ(mEdge::one().getMatrix(), CMat{{1.}});
 }
 
 TEST(MatrixFunctionality, GetMatrixRoundtrip) {
@@ -234,9 +234,9 @@ TEST(MatrixFunctionality, GetMatrixTolerance) {
 
 TEST(MatrixFunctionality, GetSparseMatrixTerminal) {
   const auto zero = SparseCMat{{{0, 0}, 0.}};
-  EXPECT_EQ(mEdge::zero.getSparseMatrix(), zero);
+  EXPECT_EQ(mEdge::zero().getSparseMatrix(), zero);
   const auto one = SparseCMat{{{0, 0}, 1.}};
-  EXPECT_EQ(mEdge::one.getSparseMatrix(), one);
+  EXPECT_EQ(mEdge::one().getSparseMatrix(), one);
 }
 
 TEST(MatrixFunctionality, GetSparseMatrixConsistency) {
@@ -288,11 +288,11 @@ TEST(MatrixFunctionality, GetSparseMatrixTolerance) {
 
 TEST(MatrixFunctionality, PrintMatrixTerminal) {
   testing::internal::CaptureStdout();
-  mEdge::zero.printMatrix();
+  mEdge::zero().printMatrix();
   const auto zeroStr = testing::internal::GetCapturedStdout();
   EXPECT_EQ(zeroStr, "(0,0)\n");
   testing::internal::CaptureStdout();
-  mEdge::one.printMatrix();
+  mEdge::one().printMatrix();
   const auto oneStr = testing::internal::GetCapturedStdout();
   EXPECT_EQ(oneStr, "(1,0)\n");
 }
@@ -318,8 +318,8 @@ TEST(MatrixFunctionality, PrintMatrix) {
 }
 
 TEST(MatrixFunctionality, SizeTerminal) {
-  EXPECT_EQ(mEdge::zero.size(), 1);
-  EXPECT_EQ(mEdge::one.size(), 1);
+  EXPECT_EQ(mEdge::zero().size(), 1);
+  EXPECT_EQ(mEdge::one().size(), 1);
 }
 
 TEST(MatrixFunctionality, SizeBellState) {
@@ -341,13 +341,13 @@ TEST(MatrixFunctionality, SizeBellState) {
 ///-----------------------------------------------------------------------------
 
 TEST(DensityMatrixFunctionality, GetValueByPathTerminal) {
-  EXPECT_EQ(dEdge::zero.getValueByPath("0"), 0.);
-  EXPECT_EQ(dEdge::one.getValueByPath("0"), 1.);
+  EXPECT_EQ(dEdge::zero().getValueByPath("0"), 0.);
+  EXPECT_EQ(dEdge::one().getValueByPath("0"), 1.);
 }
 
 TEST(DensityMatrixFunctionality, GetValueByIndexTerminal) {
-  EXPECT_EQ(dEdge::zero.getValueByIndex(0, 0), 0.);
-  EXPECT_EQ(dEdge::one.getValueByIndex(0, 0), 1.);
+  EXPECT_EQ(dEdge::zero().getValueByIndex(0, 0), 0.);
+  EXPECT_EQ(dEdge::one().getValueByIndex(0, 0), 1.);
 }
 
 TEST(DensityMatrixFunctionality, GetValueByIndexProperDensityMatrix) {
@@ -380,9 +380,9 @@ TEST(DensityMatrixFunctionality, GetValueByIndexProperDensityMatrix) {
 
 TEST(DensityMatrixFunctionality, GetSparseMatrixTerminal) {
   const auto zero = SparseCMat{{{0, 0}, 0.}};
-  EXPECT_EQ(dEdge::zero.getSparseMatrix(), zero);
+  EXPECT_EQ(dEdge::zero().getSparseMatrix(), zero);
   const auto one = SparseCMat{{{0, 0}, 1.}};
-  EXPECT_EQ(dEdge::one.getSparseMatrix(), one);
+  EXPECT_EQ(dEdge::one().getSparseMatrix(), one);
 }
 
 TEST(DensityMatrixFunctionality, GetSparseMatrixConsistency) {
@@ -407,11 +407,11 @@ TEST(DensityMatrixFunctionality, GetSparseMatrixConsistency) {
 
 TEST(DensityMatrixFunctionality, PrintMatrixTerminal) {
   testing::internal::CaptureStdout();
-  dEdge::zero.printMatrix();
+  dEdge::zero().printMatrix();
   const auto zeroStr = testing::internal::GetCapturedStdout();
   EXPECT_EQ(zeroStr, "(0,0)\n");
   testing::internal::CaptureStdout();
-  dEdge::one.printMatrix();
+  dEdge::one().printMatrix();
   const auto oneStr = testing::internal::GetCapturedStdout();
   EXPECT_EQ(oneStr, "(1,0)\n");
 }


### PR DESCRIPTION
## Description

This is the first in a series of small PRs that try to extract and break apart useful parts of #444.
It replaces the obnoxious static member variables we use for the complex `zero` and `one` as well es the `zero` and `one` terminals with `constexpr` methods of the respective classes.
This makes for a nicer overall interface and fewer reasons to add clang-tidy ignores.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
