### PR TITLE
Fixing `QuantumComputation::dump` file name dot count check

### DIFF
--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -611,6 +611,7 @@ std::ostream& QuantumComputation::printStatistics(std::ostream& os) const {
 
 void QuantumComputation::dump(const std::string& filename) {
   const std::size_t dot = filename.find_last_of('.');
+  assert(dot != std::string::npos);
   std::string extension = filename.substr(dot + 1);
   std::transform(
       extension.begin(), extension.end(), extension.begin(),
@@ -698,7 +699,6 @@ void QuantumComputation::dumpOpenQASM(std::ostream& of) {
 }
 
 void QuantumComputation::dump(const std::string& filename, Format format) {
-  assert(std::count(filename.begin(), filename.end(), '.') == 1);
   auto of = std::ofstream(filename);
   if (!of.good()) {
     throw QFRException("[dump] Error opening file: " + filename);

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -74,18 +74,18 @@ TEST_P(IO, importAndDump) {
 }
 
 TEST_F(IO, dumpValidFilenames) {
-  
+
   qc::QuantumComputation qc{4, 4};
   qc.x(0);
   qc.cx(qc::Control{3}, 2);
   ASSERT_NO_THROW(qc.dump(output3, qc::Format::OpenQASM));
   ASSERT_NO_THROW(qc.dump(output4, qc::Format::OpenQASM));
   ASSERT_NO_THROW(qc.dump(output4));
-  
+
   std::filesystem::create_directory(output5dir);
   ASSERT_NO_THROW(qc.dump(output5, qc::Format::OpenQASM));
   ASSERT_NO_THROW(qc.dump(output5));
-  
+
   std::filesystem::remove(output3);
   std::filesystem::remove(output4);
   std::filesystem::remove(output5);

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -15,6 +15,10 @@ protected:
   unsigned int seed = 0;
   std::string output = "tmp.txt";
   std::string output2 = "tmp2.txt";
+  std::string output3 = "tmp";
+  std::string output4 = "tmp.tmp.qasm";
+  std::string output5 = "./tmpdir/circuit.qasm";
+  std::string output5dir = "tmpdir";
   std::unique_ptr<qc::QuantumComputation> qc;
 };
 
@@ -67,6 +71,25 @@ TEST_P(IO, importAndDump) {
   compareFiles(output, output2, true);
   std::filesystem::remove(output);
   std::filesystem::remove(output2);
+}
+
+TEST_F(IO, dumpValidFilenames) {
+  
+  qc::QuantumComputation qc{4, 4};
+  qc.x(0);
+  qc.cx(qc::Control{3}, 2);
+  ASSERT_NO_THROW(qc.dump(output3, qc::Format::OpenQASM));
+  ASSERT_NO_THROW(qc.dump(output4, qc::Format::OpenQASM));
+  ASSERT_NO_THROW(qc.dump(output4));
+  
+  std::filesystem::create_directory(output5dir);
+  ASSERT_NO_THROW(qc.dump(output5, qc::Format::OpenQASM));
+  ASSERT_NO_THROW(qc.dump(output5));
+  
+  std::filesystem::remove(output3);
+  std::filesystem::remove(output4);
+  std::filesystem::remove(output5);
+  std::filesystem::remove(output5dir);
 }
 
 TEST_F(IO, importFromString) {


### PR DESCRIPTION
## Description

Removing the superfluous assertion in `QuantumComputation::dump(filename, format)`, that the file name needs to contain exactly 1 dot.
Instead, added an equivalent check (for >= 1 dot) in `QuantumComputation::dump(filename)`, where it is actually necessary.

Fixes #446 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
