### PR TITLE
🩹 temporarily disable editable installs in nox jobs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -31,7 +31,7 @@ def lint(session: nox.Session) -> None:
 def pylint(session: nox.Session) -> None:
     """Run PyLint."""
     session.install("scikit-build-core[pyproject]", "setuptools_scm", "pybind11")
-    session.install("--no-build-isolation", ".", "pylint")
+    session.install("--no-build-isolation", "-ve.", "pylint")
     session.run("pylint", "mqt.core", *session.posargs)
 
 
@@ -90,7 +90,7 @@ def docs(session: nox.Session) -> None:
     build_requirements = ["scikit-build-core[pyproject]", "setuptools_scm", "pybind11"]
     extra_installs = ["sphinx-autobuild"] if args.serve else []
     session.install(*build_requirements, *extra_installs)
-    session.install("--no-build-isolation", ".[docs]")
+    session.install("--no-build-isolation", "-ve.[docs]")
     session.chdir("docs")
 
     if args.builder == "linkcheck":

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,7 +31,7 @@ def lint(session: nox.Session) -> None:
 def pylint(session: nox.Session) -> None:
     """Run PyLint."""
     session.install("scikit-build-core[pyproject]", "setuptools_scm", "pybind11")
-    session.install("--no-build-isolation", "-ve.", "pylint")
+    session.install("--no-build-isolation", ".", "pylint")
     session.run("pylint", "mqt.core", *session.posargs)
 
 
@@ -54,7 +54,7 @@ def _run_tests(
         posargs.append("--cov-config=pyproject.toml")
 
     session.install("scikit-build-core[pyproject]", "setuptools_scm", "pybind11", *install_args, env=env)
-    install_arg = f"-ve.[{','.join(_extras)}]"
+    install_arg = f".[{','.join(_extras)}]"
     session.install("--no-build-isolation", install_arg, *install_args, env=env)
     session.run("pytest", *run_args, *posargs, env=env)
 
@@ -90,7 +90,7 @@ def docs(session: nox.Session) -> None:
     build_requirements = ["scikit-build-core[pyproject]", "setuptools_scm", "pybind11"]
     extra_installs = ["sphinx-autobuild"] if args.serve else []
     session.install(*build_requirements, *extra_installs)
-    session.install("--no-build-isolation", "-ve.[docs]")
+    session.install("--no-build-isolation", ".[docs]")
     session.chdir("docs")
 
     if args.builder == "linkcheck":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ testpaths = ["test/python"]
 [tool.coverage]
 run.source = ["mqt.core"]
 run.omit = [
-    'src/mqt/core/_compat/*',
+    '*/_compat/*',
 ]
 report.exclude_also = [
     '\.\.\.',


### PR DESCRIPTION
## Description

This PR temporarily disables editable installs in the nox sessions to circumvent a bug that surfaced in the latest scikit-build-core version (>=0.6).
This should allow CI to pass again.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
