### PR TITLE
⚡ Small performance improvements to `RealNumberUniqueTable`

### DIFF
--- a/src/dd/RealNumberUniqueTable.cpp
+++ b/src/dd/RealNumberUniqueTable.cpp
@@ -55,19 +55,16 @@ void RealNumberUniqueTable::decRef(RealNumber* num) noexcept {
 RealNumber* RealNumberUniqueTable::lookupNonNegative(const fp val) {
   assert(!std::isnan(val));
   assert(val > 0);
-  ++stats.lookups;
 
   if (RealNumber::approximatelyOne(val)) {
-    ++stats.hits;
     return &constants::one;
   }
 
   if (RealNumber::approximatelyEquals(val, SQRT2_2)) {
-    ++stats.hits;
     return &constants::sqrt2over2;
   }
-  assert(val - RealNumber::eps >= 0); // should be handle above as special case
 
+  ++stats.lookups;
   const auto lowerKey = hash(val - RealNumber::eps);
   const auto upperKey = hash(val + RealNumber::eps);
 

--- a/src/dd/RealNumberUniqueTable.cpp
+++ b/src/dd/RealNumberUniqueTable.cpp
@@ -28,12 +28,11 @@ std::int64_t RealNumberUniqueTable::hash(const fp val) noexcept {
 }
 
 RealNumber* RealNumberUniqueTable::lookup(const fp val) {
+  // if the value is close enough to zero, return the zero entry (avoiding -0.0)
+  if (RealNumber::approximatelyZero(val)) {
+    return &constants::zero;
+  }
   if (const auto sign = std::signbit(val); sign) {
-    // if absolute value is close enough to zero, just return the zero entry
-    // (avoiding -0.0)
-    if (RealNumber::approximatelyZero(val)) {
-      return &constants::zero;
-    }
     return RealNumber::getNegativePointer(lookupNonNegative(std::abs(val)));
   }
   return lookupNonNegative(val);
@@ -55,12 +54,8 @@ void RealNumberUniqueTable::decRef(RealNumber* num) noexcept {
 
 RealNumber* RealNumberUniqueTable::lookupNonNegative(const fp val) {
   assert(!std::isnan(val));
-  assert(val >= 0); // required anyway for the hash function
+  assert(val > 0);
   ++stats.lookups;
-  if (RealNumber::approximatelyZero(val)) {
-    ++stats.hits;
-    return &constants::zero;
-  }
 
   if (RealNumber::approximatelyOne(val)) {
     ++stats.hits;


### PR DESCRIPTION
## Description

This PR slightly improves the lookup logic in the `RealNumberUniqueTable` to avoid a redundant check on zero for negative values.
Furthermore, it updates the statistics tracking code to only track actual lookups that did not result in one of the static constants.
It is another PR in the series of improvements coming from #444

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
