### PR TITLE
⚡ Completely eliminate temporary numbers borrowed from the cache

### DIFF
--- a/include/dd/CachedEdge.hpp
+++ b/include/dd/CachedEdge.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "dd/Complex.hpp"
 #include "dd/ComplexValue.hpp"
 #include "dd/DDDefinitions.hpp"
 
+#include <complex>
 #include <utility>
 
 namespace dd {
@@ -25,7 +27,8 @@ template <typename Node> struct CachedEdge {
 
   CachedEdge() = default;
   CachedEdge(Node* n, const ComplexValue& v) : p(n), w(v) {}
-  CachedEdge(Node* n, const Complex& c);
+  CachedEdge(Node* n, const Complex& c)
+      : p(n), w(static_cast<ComplexValue>(c)) {}
 
   /// Comparing two DD edges with another involves comparing the respective
   /// pointers and checking whether the corresponding weights are "close enough"
@@ -35,6 +38,50 @@ template <typename Node> struct CachedEdge {
     return p == other.p && w.approximatelyEquals(other.w);
   }
   bool operator!=(const CachedEdge& other) const { return !operator==(other); }
+
+  /**
+   * @brief Create a terminal edge with the given weight.
+   * @param w The weight of the terminal edge.
+   * @return A terminal edge with the given weight.
+   */
+  [[nodiscard]] static constexpr CachedEdge terminal(const ComplexValue& w) {
+    return CachedEdge{Node::getTerminal(), w};
+  }
+
+  /**
+   * @brief Create a terminal edge with the given weight.
+   * @param w The weight of the terminal edge.
+   * @return A terminal edge with the given weight.
+   */
+  [[nodiscard]] static constexpr CachedEdge
+  terminal(const std::complex<fp>& w) {
+    return CachedEdge{Node::getTerminal(), static_cast<ComplexValue>(w)};
+  }
+
+  /**
+   * @brief Create a terminal edge with the given weight.
+   * @param w The weight of the terminal edge.
+   * @return A terminal edge with the given weight.
+   */
+  [[nodiscard]] static constexpr CachedEdge terminal(const Complex& w) {
+    return terminal(static_cast<ComplexValue>(w));
+  }
+
+  /**
+   * @brief Create a zero terminal edge.
+   * @return A zero terminal edge.
+   */
+  [[nodiscard]] static constexpr CachedEdge zero() {
+    return terminal(ComplexValue(0.));
+  }
+
+  /**
+   * @brief Create a one terminal edge.
+   * @return A one terminal edge.
+   */
+  [[nodiscard]] static constexpr CachedEdge one() {
+    return terminal(ComplexValue(1.));
+  }
 };
 
 } // namespace dd

--- a/include/dd/Complex.hpp
+++ b/include/dd/Complex.hpp
@@ -141,6 +141,14 @@ struct Complex {
  */
 std::ostream& operator<<(std::ostream& os, const Complex& c);
 
+ComplexValue operator*(const Complex& c1, const ComplexValue& c2);
+ComplexValue operator*(const ComplexValue& c1, const Complex& c2);
+ComplexValue operator*(const Complex& c1, const Complex& c2);
+
+ComplexValue operator/(const Complex& c1, const ComplexValue& c2);
+ComplexValue operator/(const ComplexValue& c1, const Complex& c2);
+ComplexValue operator/(const Complex& c1, const Complex& c2);
+
 } // namespace dd
 
 namespace std {

--- a/include/dd/Complex.hpp
+++ b/include/dd/Complex.hpp
@@ -144,10 +144,13 @@ std::ostream& operator<<(std::ostream& os, const Complex& c);
 ComplexValue operator*(const Complex& c1, const ComplexValue& c2);
 ComplexValue operator*(const ComplexValue& c1, const Complex& c2);
 ComplexValue operator*(const Complex& c1, const Complex& c2);
+ComplexValue operator*(const Complex& c1, fp real);
+ComplexValue operator*(fp real, const Complex& c1);
 
 ComplexValue operator/(const Complex& c1, const ComplexValue& c2);
 ComplexValue operator/(const ComplexValue& c1, const Complex& c2);
 ComplexValue operator/(const Complex& c1, const Complex& c2);
+ComplexValue operator/(const Complex& c1, fp real);
 
 } // namespace dd
 

--- a/include/dd/ComplexNumbers.hpp
+++ b/include/dd/ComplexNumbers.hpp
@@ -136,50 +136,6 @@ public:
   [[nodiscard]] Complex divCached(const Complex& a, const Complex& b);
 
   /**
-   * @brief Add two complex numbers and return the result in temporary complex
-   * number taken from the cache.
-   * @param a The first operand.
-   * @param b The second operand.
-   * @return The result.
-   * @note The result is only valid until the next call to any function that
-   * requests a temporary or cached complex number.
-   */
-  [[nodiscard]] Complex addTemp(const Complex& a, const Complex& b);
-
-  /**
-   * @brief Subtract two complex numbers and return the result in temporary
-   * complex number taken from the cache.
-   * @param a The first operand.
-   * @param b The second operand.
-   * @return The result.
-   * @note The result is only valid until the next call to any function that
-   * requests a temporary or cached complex number.
-   */
-  [[nodiscard]] Complex subTemp(const Complex& a, const Complex& b);
-
-  /**
-   * @brief Multiply two complex numbers and return the result in temporary
-   * complex number taken from the cache.
-   * @param a The first operand.
-   * @param b The second operand.
-   * @return The result.
-   * @note The result is only valid until the next call to any function that
-   * requests a temporary or cached complex number.
-   */
-  [[nodiscard]] Complex mulTemp(const Complex& a, const Complex& b);
-
-  /**
-   * @brief Divide two complex numbers and return the result in temporary
-   * complex number taken from the cache.
-   * @param a The first operand.
-   * @param b The second operand.
-   * @return The result.
-   * @note The result is only valid until the next call to any function that
-   * requests a temporary or cached complex number.
-   */
-  [[nodiscard]] Complex divTemp(const Complex& a, const Complex& b);
-
-  /**
    * @brief Lookup a complex value in the complex table; if not found add it.
    * @param c The complex number.
    * @param cached Used to indicate whether the number to be looked up is from
@@ -242,38 +198,6 @@ public:
   [[nodiscard]] static constexpr bool isStaticComplex(const Complex& c) {
     return c.exactlyZero() || c.exactlyOne();
   }
-
-  /**
-   * @brief Get a temporary complex number from the complex cache.
-   * @return The temporary complex number.
-   * @see MemoryManager::getTemporaryPair
-   */
-  [[nodiscard]] Complex getTemporary();
-
-  /**
-   * @brief Get a temporary complex number from the complex cache.
-   * @param r The real part.
-   * @param i The imaginary part.
-   * @return The temporary complex number.
-   * @see MemoryManager::getTemporaryPair
-   */
-  [[nodiscard]] Complex getTemporary(fp r, fp i);
-
-  /**
-   * @brief Get a temporary complex number from the complex cache.
-   * @param c The complex value.
-   * @return The temporary complex number.
-   * @see MemoryManager::getTemporaryPair
-   */
-  [[nodiscard]] Complex getTemporary(const ComplexValue& c);
-
-  /**
-   * @brief Get a temporary complex number from the complex cache.
-   * @param c The complex number.
-   * @return The temporary complex number.
-   * @see MemoryManager::getTemporaryPair
-   */
-  [[nodiscard]] Complex getTemporary(const Complex& c);
 
   /**
    * @brief Get a complex number from the complex cache.

--- a/include/dd/ComplexValue.hpp
+++ b/include/dd/ComplexValue.hpp
@@ -2,6 +2,7 @@
 
 #include "dd/DDDefinitions.hpp"
 
+#include <cmath>
 #include <complex>
 #include <cstddef>
 #include <iostream>
@@ -12,9 +13,16 @@ namespace dd {
 /// A complex number represented by two floating point values.
 struct ComplexValue {
   /// real part
-  fp r;
+  fp r{};
   /// imaginary part
-  fp i;
+  fp i{};
+
+  ComplexValue() = default;
+  // NOLINTNEXTLINE(google-explicit-constructor) We want impl. conv. from reals
+  ComplexValue(const fp real) noexcept : r{real} {}
+  explicit ComplexValue(const std::complex<fp>& c) noexcept
+      : r{c.real()}, i{c.imag()} {}
+  ComplexValue(const fp real, const fp imag) noexcept : r{real}, i{imag} {}
 
   /**
    * @brief Check for exact equality.
@@ -121,10 +129,15 @@ struct ComplexValue {
   /// In-place addition of two complex numbers
   ComplexValue& operator+=(const ComplexValue& rhs) noexcept;
 
-  /// Addition of two complex numbers
-  friend ComplexValue operator+(ComplexValue lhs,
-                                const ComplexValue& rhs) noexcept;
+  ComplexValue& operator*=(const fp& real) noexcept;
 };
+
+ComplexValue operator+(const ComplexValue& c1, const ComplexValue& c2);
+ComplexValue operator*(const ComplexValue& c1, fp r);
+ComplexValue operator*(fp r, const ComplexValue& c1);
+ComplexValue operator*(const ComplexValue& c1, const ComplexValue& c2);
+ComplexValue operator/(const ComplexValue& c1, fp r);
+ComplexValue operator/(const ComplexValue& c1, const ComplexValue& c2);
 
 /**
  * @brief Print a complex value to the given output stream.

--- a/include/dd/MemoryManager.hpp
+++ b/include/dd/MemoryManager.hpp
@@ -85,25 +85,6 @@ public:
   [[nodiscard]] std::pair<T*, T*> getPair();
 
   /**
-   * @brief Get a temporary entry from the manager.
-   * @details In contrast to `get()`, this method does not consume an entry from
-   * the manager. It just provides access to a temporary entry. Any subsequent
-   * call to `get()` or `getTemporary()` might invalidate the returned pointer.
-   * @return A pointer to an entry.
-   * @see get()
-   */
-  [[nodiscard]] T* getTemporary();
-
-  /**
-   * @brief Get a pair of temporary entries from the manager.
-   * @return A pair of pointers to entries.
-   * @see getTemporary()
-   * @note This method assumes that there is an even number of entries available
-   * from the manager. If this is not the case, the behavior is undefined.
-   */
-  [[nodiscard]] std::pair<T*, T*> getTemporaryPair();
-
-  /**
    * @brief Return an entry to the manager.
    * @details The entry is added to the list of available entries. The entry
    * must not be used after it has been returned to the manager. Entries should

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1454,9 +1454,7 @@ public:
     vEdge e = multiply(measurementGate, rootEdge);
 
     assert(probability > 0.);
-    Complex c = cn.getTemporary(std::sqrt(1.0 / probability), 0);
-    ComplexNumbers::mul(c, e.w, c);
-    e.w = cn.lookup(c);
+    e.w = cn.lookup(e.w / std::sqrt(probability));
     incRef(e);
     decRef(rootEdge);
     rootEdge = e;

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -2771,12 +2771,7 @@ public:
         result = deserializeNode(nodeIndex, v, edgeIndices, edgeWeights, nodes);
       }
     }
-
-    auto w = cn.getTemporary(rootweight.r, rootweight.i);
-    ComplexNumbers::mul(w, w, result.w);
-    result.w = cn.lookup(w);
-
-    return result;
+    return {result.p, cn.lookup(result.w * rootweight)};
   }
 
   template <class Node, class Edge = Edge<Node>>

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1330,9 +1330,9 @@ public:
       const fp prob = probsMone[ptr];
 
       const auto& s0 = ptr->e[0];
-      if (!s0.w.approximatelyZero()) {
-        const fp tmp1 = prob * ComplexNumbers::mag2(s0.w);
-
+      if (const auto s0w = static_cast<ComplexValue>(s0.w);
+          !s0w.approximatelyZero()) {
+        const fp tmp1 = prob * s0w.mag2();
         if (visited.find(s0.p) != visited.end()) {
           probsMone[s0.p] = probsMone[s0.p] + tmp1;
         } else {
@@ -1343,9 +1343,9 @@ public:
       }
 
       const auto& s1 = ptr->e[1];
-      if (!s1.w.approximatelyZero()) {
-        const fp tmp1 = prob * ComplexNumbers::mag2(s1.w);
-
+      if (const auto s1w = static_cast<ComplexValue>(s1.w);
+          !s1w.approximatelyZero()) {
+        const fp tmp1 = prob * s1w.mag2();
         if (visited.find(s1.p) != visited.end()) {
           probsMone[s1.p] = probsMone[s1.p] + tmp1;
         } else {
@@ -1364,12 +1364,14 @@ public:
         const auto* ptr = q.front();
         q.pop();
         const auto& s0 = ptr->e[0];
-        if (!s0.w.approximatelyZero()) {
-          pzero += probsMone[ptr] * ComplexNumbers::mag2(s0.w);
+        if (const auto s0w = static_cast<ComplexValue>(s0.w);
+            !s0w.approximatelyZero()) {
+          pzero += probsMone[ptr] * s0w.mag2();
         }
         const auto& s1 = ptr->e[1];
-        if (!s1.w.approximatelyZero()) {
-          pone += probsMone[ptr] * ComplexNumbers::mag2(s1.w);
+        if (const auto s1w = static_cast<ComplexValue>(s1.w);
+            !s1w.approximatelyZero()) {
+          pone += probsMone[ptr] * s1w.mag2();
         }
       }
     } else {
@@ -1381,12 +1383,14 @@ public:
         q.pop();
 
         const auto& s0 = ptr->e[0];
-        if (!s0.w.approximatelyZero()) {
-          pzero += probsMone[ptr] * probs[s0.p] * ComplexNumbers::mag2(s0.w);
+        if (const auto s0w = static_cast<ComplexValue>(s0.w);
+            !s0w.approximatelyZero()) {
+          pzero += probsMone[ptr] * probs[s0.p] * s0w.mag2();
         }
         const auto& s1 = ptr->e[1];
-        if (!s1.w.approximatelyZero()) {
-          pone += probsMone[ptr] * probs[s1.p] * ComplexNumbers::mag2(s1.w);
+        if (const auto s1w = static_cast<ComplexValue>(s1.w);
+            !s1w.approximatelyZero()) {
+          pone += probsMone[ptr] * probs[s1.p] * s1w.mag2();
         }
       }
     }

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1173,10 +1173,10 @@ private:
       return e;
     }
 
-    const auto& nodeit = nodes.find(e.p);
-    Edge<Node> newedge{};
-    if (nodeit != nodes.end()) {
-      newedge = nodeit->second;
+    const auto& nodeIt = nodes.find(e.p);
+    Edge<Node> r{};
+    if (nodeIt != nodes.end()) {
+      r = nodeIt->second;
     } else {
       constexpr std::size_t n = std::tuple_size_v<decltype(e.p->e)>;
       std::array<Edge<Node>, n> edges{};
@@ -1193,17 +1193,16 @@ private:
         }
       }
 
-      newedge = makeDDNode(e.p->v, edges);
-      nodes[e.p] = newedge;
+      r = makeDDNode(e.p->v, edges);
+      nodes[e.p] = r;
     }
 
-    if (newedge.w.approximatelyOne()) {
-      newedge.w = e.w;
+    if (r.w.approximatelyOne()) {
+      r.w = e.w;
     } else {
-      newedge.w = cn.lookup(cn.mulTemp(newedge.w, e.w));
+      r.w = cn.lookup(cn.mulTemp(r.w, e.w));
     }
-
-    return newedge;
+    return r;
   }
 
   ///

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -376,7 +376,7 @@ public:
       ComplexNumbers::div(min.w, min.w, r.w);
       min.w = cn.lookup(min.w, true);
     } else {
-      min.w = cn.lookup(cn.divTemp(min.w, r.w));
+      min.w = cn.lookup(min.w / r.w);
     }
     if (min.w.exactlyZero()) {
       min = vEdge::zero();
@@ -620,7 +620,7 @@ public:
           if (cached) {
             ComplexNumbers::mul(r.w, r.w, maxc);
           } else {
-            r.w = cn.lookup(cn.mulTemp(r.w, maxc));
+            r.w = cn.lookup(r.w * maxc);
           }
         } else {
           auto& successor = r.p->e[i];
@@ -637,7 +637,7 @@ public:
             }
             successor.w = Complex::one();
           }
-          const auto c = cn.divTemp(successor.w, maxc);
+          const auto c = successor.w / maxc;
           if (cached) {
             cn.returnToCache(successor.w);
           }
@@ -1200,7 +1200,7 @@ private:
     if (r.w.approximatelyOne()) {
       r.w = e.w;
     } else {
-      r.w = cn.lookup(cn.mulTemp(r.w, e.w));
+      r.w = cn.lookup(r.w * e.w);
     }
     return r;
   }
@@ -1612,7 +1612,7 @@ public:
     auto res = makeDDNode(a.p->v, e);
 
     // adjust top weight including conjugate
-    res.w = cn.lookup(cn.mulTemp(res.w, ComplexNumbers::conj(a.w)));
+    res.w = cn.lookup(res.w * ComplexNumbers::conj(a.w));
 
     // put it in the compute table
     conjugateMatrixTranspose.insert(a, res);
@@ -2153,7 +2153,7 @@ private:
       } else {
         // better safe than sorry. this may result in complex
         // values with magnitude > 1 in the complex table
-        r.w = cn.lookup(cn.mulTemp(r.w, a.w));
+        r.w = cn.lookup(r.w * a.w);
       }
 
       cn.returnToCache(r1.w);
@@ -2177,7 +2177,7 @@ private:
     if (r.w.exactlyOne()) {
       r.w = a.w;
     } else {
-      r.w = cn.lookup(cn.mulTemp(r.w, a.w));
+      r.w = cn.lookup(r.w * a.w);
     }
     return r;
   }
@@ -2436,7 +2436,7 @@ private:
         }
       }
     }
-    f.w = cn.lookup(cn.mulTemp(f.w, e.w));
+    f.w = cn.lookup(f.w * e.w);
     return f;
   }
 
@@ -2482,7 +2482,7 @@ private:
         f = makeDDNode(e.p->v, std::array{g, vEdge::zero()});
       }
     }
-    f.w = cn.lookup(cn.mulTemp(f.w, e.w));
+    f.w = cn.lookup(f.w * e.w);
 
     // Quick-fix for normalization bug
     if (ComplexNumbers::mag2(f.w) > 1.0) {
@@ -2567,7 +2567,7 @@ private:
         }
       }
     }
-    f.w = cn.lookup(cn.mulTemp(f.w, e.w));
+    f.w = cn.lookup(f.w * e.w);
 
     // Quick-fix for normalization bug
     if (ComplexNumbers::mag2(f.w) > 1.0) {
@@ -2656,7 +2656,7 @@ public:
         currentEdge = nullptr;
       }
     } while (!stack.empty());
-    root.w = cn.lookup(cn.mulTemp(original.w, root.w));
+    root.w = cn.lookup(original.w * root.w);
     return root;
   }
 

--- a/src/dd/CachedEdge.cpp
+++ b/src/dd/CachedEdge.cpp
@@ -1,16 +1,9 @@
 #include "dd/CachedEdge.hpp"
 
-#include "dd/Complex.hpp"
 #include "dd/Node.hpp"
 #include "dd/RealNumber.hpp"
 
 namespace dd {
-
-template <typename Node>
-CachedEdge<Node>::CachedEdge(Node* n, const Complex& c) : p(n) {
-  w.r = RealNumber::val(c.r);
-  w.i = RealNumber::val(c.i);
-}
 
 template struct CachedEdge<vNode>;
 template struct CachedEdge<mNode>;

--- a/src/dd/Complex.cpp
+++ b/src/dd/Complex.cpp
@@ -66,6 +66,10 @@ ComplexValue operator*(const ComplexValue& c1, const Complex& c2) {
 ComplexValue operator*(const Complex& c1, const Complex& c2) {
   return static_cast<ComplexValue>(c1) * static_cast<ComplexValue>(c2);
 }
+ComplexValue operator*(const Complex& c1, const fp real) {
+  return static_cast<ComplexValue>(c1) * real;
+}
+ComplexValue operator*(const fp real, const Complex& c1) { return c1 * real; }
 
 ComplexValue operator/(const Complex& c1, const ComplexValue& c2) {
   return static_cast<ComplexValue>(c1) / c2;
@@ -75,5 +79,8 @@ ComplexValue operator/(const ComplexValue& c1, const Complex& c2) {
 }
 ComplexValue operator/(const Complex& c1, const Complex& c2) {
   return static_cast<ComplexValue>(c1) / static_cast<ComplexValue>(c2);
+}
+ComplexValue operator/(const Complex& c1, const fp real) {
+  return static_cast<ComplexValue>(c1) / real;
 }
 } // namespace dd

--- a/src/dd/Complex.cpp
+++ b/src/dd/Complex.cpp
@@ -56,4 +56,24 @@ Complex::operator ComplexValue() const noexcept {
 std::ostream& operator<<(std::ostream& os, const Complex& c) {
   return os << c.toString();
 }
+
+ComplexValue operator*(const Complex& c1, const ComplexValue& c2) {
+  return static_cast<ComplexValue>(c1) * c2;
+}
+ComplexValue operator*(const ComplexValue& c1, const Complex& c2) {
+  return c1 * static_cast<ComplexValue>(c2);
+}
+ComplexValue operator*(const Complex& c1, const Complex& c2) {
+  return static_cast<ComplexValue>(c1) * static_cast<ComplexValue>(c2);
+}
+
+ComplexValue operator/(const Complex& c1, const ComplexValue& c2) {
+  return static_cast<ComplexValue>(c1) / c2;
+}
+ComplexValue operator/(const ComplexValue& c1, const Complex& c2) {
+  return c1 / static_cast<ComplexValue>(c2);
+}
+ComplexValue operator/(const Complex& c1, const Complex& c2) {
+  return static_cast<ComplexValue>(c1) / static_cast<ComplexValue>(c2);
+}
 } // namespace dd

--- a/src/dd/ComplexNumbers.cpp
+++ b/src/dd/ComplexNumbers.cpp
@@ -128,30 +128,6 @@ Complex ComplexNumbers::divCached(const Complex& a, const Complex& b) {
   return c;
 }
 
-Complex ComplexNumbers::addTemp(const dd::Complex& a, const dd::Complex& b) {
-  auto c = getTemporary();
-  add(c, a, b);
-  return c;
-}
-
-Complex ComplexNumbers::subTemp(const dd::Complex& a, const dd::Complex& b) {
-  auto c = getTemporary();
-  sub(c, a, b);
-  return c;
-}
-
-Complex ComplexNumbers::mulTemp(const dd::Complex& a, const dd::Complex& b) {
-  auto c = getTemporary();
-  mul(c, a, b);
-  return c;
-}
-
-Complex ComplexNumbers::divTemp(const dd::Complex& a, const dd::Complex& b) {
-  auto c = getTemporary();
-  div(c, a, b);
-  return c;
-}
-
 Complex ComplexNumbers::lookup(const Complex& c, const bool cached) {
   if (isStaticComplex(c)) {
     return c;
@@ -191,26 +167,6 @@ Complex ComplexNumbers::lookup(const fp r) {
 
 Complex ComplexNumbers::lookup(const fp r, const fp i) {
   return {uniqueTable->lookup(r), uniqueTable->lookup(i)};
-}
-
-Complex ComplexNumbers::getTemporary() {
-  const auto [rv, iv] = cacheManager->getTemporaryPair();
-  return {rv, iv};
-}
-
-Complex ComplexNumbers::getTemporary(const fp r, const fp i) {
-  const auto [rv, iv] = cacheManager->getTemporaryPair();
-  rv->value = r;
-  iv->value = i;
-  return {rv, iv};
-}
-
-Complex ComplexNumbers::getTemporary(const ComplexValue& c) {
-  return getTemporary(c.r, c.i);
-}
-
-Complex ComplexNumbers::getTemporary(const Complex& c) {
-  return getTemporary(RealNumber::val(c.r), RealNumber::val(c.i));
 }
 
 Complex ComplexNumbers::getCached() {

--- a/src/dd/ComplexValue.cpp
+++ b/src/dd/ComplexValue.cpp
@@ -6,7 +6,11 @@
 #include <cassert>
 #include <cmath>
 #include <iomanip>
+#include <istream>
+#include <ostream>
 #include <sstream>
+#include <string>
+#include <utility>
 
 namespace dd {
 bool ComplexValue::operator==(const ComplexValue& other) const noexcept {

--- a/src/dd/ComplexValue.cpp
+++ b/src/dd/ComplexValue.cpp
@@ -216,9 +216,36 @@ ComplexValue& ComplexValue::operator+=(const ComplexValue& rhs) noexcept {
   return *this;
 }
 
-ComplexValue operator+(ComplexValue lhs, const ComplexValue& rhs) noexcept {
-  lhs += rhs;
-  return lhs;
+ComplexValue& ComplexValue::operator*=(const fp& real) noexcept {
+  r *= real;
+  i *= real;
+  return *this;
+}
+
+ComplexValue operator+(const ComplexValue& c1, const ComplexValue& c2) {
+  return {c1.r + c2.r, c1.i + c2.i};
+}
+
+ComplexValue operator*(const ComplexValue& c1, fp r) {
+  return {c1.r * r, c1.i * r};
+}
+
+ComplexValue operator*(fp r, const ComplexValue& c1) {
+  return {c1.r * r, c1.i * r};
+}
+
+ComplexValue operator*(const ComplexValue& c1, const ComplexValue& c2) {
+  return {c1.r * c2.r - c1.i * c2.i, c1.r * c2.i + c1.i * c2.r};
+}
+
+ComplexValue operator/(const ComplexValue& c1, fp r) {
+  return {c1.r / r, c1.i / r};
+}
+
+ComplexValue operator/(const ComplexValue& c1, const ComplexValue& c2) {
+  const auto denom = c2.r * c2.r + c2.i * c2.i;
+  return {(c1.r * c2.r + c1.i * c2.i) / denom,
+          (c1.i * c2.r - c1.r * c2.i) / denom};
 }
 
 std::ostream& operator<<(std::ostream& os, const ComplexValue& c) {

--- a/src/dd/MemoryManager.cpp
+++ b/src/dd/MemoryManager.cpp
@@ -42,33 +42,6 @@ template <typename T> std::pair<T*, T*> MemoryManager<T>::getPair() {
   return {r, i};
 }
 
-template <typename T> T* MemoryManager<T>::getTemporary() {
-  if (entryAvailableForReuse()) {
-    return available;
-  }
-
-  if (!entryAvailableInChunk()) {
-    allocateNewChunk();
-  }
-
-  return &(*chunkIt);
-}
-
-template <typename T> std::pair<T*, T*> MemoryManager<T>::getTemporaryPair() {
-  if (entryAvailableForReuse()) {
-    assert(available->next != nullptr &&
-           "At least two entries must be available");
-    return {available, available->next};
-  }
-
-  if (!entryAvailableInChunk()) {
-    allocateNewChunk();
-  }
-
-  assert(chunkIt + 1 != chunkEndIt && "At least two entries must be available");
-  return {&(*chunkIt), &(*(chunkIt + 1))};
-}
-
 template <typename T> void MemoryManager<T>::returnEntry(T* entry) noexcept {
   assert(entry != nullptr);
   assert(entry->ref == 0);

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -367,10 +367,7 @@ void extractProbabilityVectorRecursive(const QuantumComputation* qc,
             MEAS_ZERO_MAT, static_cast<std::size_t>(state.p->v) + 1U,
             targets[0]);
         qc::VectorDD measuredState = dd->multiply(measurementGate, state);
-
-        auto c = dd->cn.getTemporary(1. / std::sqrt(pzero), 0);
-        ComplexNumbers::mul(c, c, measuredState.w);
-        measuredState.w = dd->cn.lookup(c);
+        measuredState.w = dd->cn.lookup(measuredState.w / std::sqrt(pzero));
         dd->incRef(measuredState);
         dd->decRef(state);
         // recursive call from here
@@ -392,10 +389,7 @@ void extractProbabilityVectorRecursive(const QuantumComputation* qc,
             MEAS_ONE_MAT, static_cast<std::size_t>(state.p->v) + 1U,
             targets[0]);
         qc::VectorDD measuredState = dd->multiply(measurementGate, state);
-
-        auto c = dd->cn.getTemporary(1. / std::sqrt(pone), 0);
-        ComplexNumbers::mul(c, measuredState.w, c);
-        measuredState.w = dd->cn.lookup(c);
+        measuredState.w = dd->cn.lookup(measuredState.w / std::sqrt(pone));
         dd->incRef(measuredState);
         dd->decRef(state);
         // recursive call from here

--- a/test/dd/test_complex.cpp
+++ b/test/dd/test_complex.cpp
@@ -74,33 +74,6 @@ TEST_F(CNTest, ComplexNumberCreation) {
   std::cout << ut.getStats();
 }
 
-TEST_F(CNTest, ComplexNumberArithmetic) {
-  auto c = cn.lookup(0., 1.);
-  auto d = ComplexNumbers::conj(c);
-  EXPECT_EQ(RealNumber::val(d.r), 0.);
-  EXPECT_EQ(RealNumber::val(d.i), -1.);
-  c = cn.lookup(-1., -1.);
-  d = ComplexNumbers::neg(c);
-  EXPECT_EQ(RealNumber::val(d.r), 1.);
-  EXPECT_EQ(RealNumber::val(d.i), 1.);
-  c = cn.lookup(0.5, 0.5);
-  cn.incRef(c);
-  d = cn.lookup(-0.5, 0.5);
-  cn.incRef(d);
-  auto e = cn.getTemporary();
-  ComplexNumbers::sub(e, c, d);
-  cn.decRef(c);
-  cn.decRef(d);
-  e = cn.lookup(e);
-  EXPECT_EQ(e, Complex::one());
-  auto f = cn.getTemporary();
-  ComplexNumbers::div(f, Complex::zero(), Complex::one());
-
-  const dd::ComplexValue zero{0., 0.};
-  const dd::ComplexValue one{1., 0.};
-  EXPECT_EQ(one + zero, one);
-}
-
 TEST_F(CNTest, NearZeroLookup) {
   auto d = cn.lookup(RealNumber::eps / 10., RealNumber::eps / 10.);
   EXPECT_TRUE(d.exactlyZero());
@@ -529,19 +502,6 @@ TEST_F(CNTest, ComplexCacheAllocation) {
   for (auto i = 0U; i < allocs; i += 2) {
     cnums[i % 2] = cn.getCached();
   }
-
-  // trigger new allocation for obtaining a temporary from cache
-  const auto tmp = cn.getTemporary();
-  ASSERT_NE(tmp.r, nullptr);
-  ASSERT_NE(tmp.i, nullptr);
-  EXPECT_EQ(cm.getStats().numAllocated,
-            (1. + MemoryManager<RealNumber>::GROWTH_FACTOR) *
-                static_cast<fp>(allocs));
-
-  // clearing the unique table should reduce the allocated size to the original
-  // size
-  cm.reset();
-  EXPECT_EQ(cm.getStats().numAllocated, allocs);
 }
 
 TEST_F(CNTest, DoubleHitInFindOrInsert) {


### PR DESCRIPTION
## Description

This PR is "just" another one in the series of bringing over improvements from #444.
This time it starts with the reduction of the complex cache being used by completely eliminating any temporary use of cache entries. This is enabled by extending the computation support and interoperability between `Complex` and `ComplexValue`.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
