### PR TITLE
🐛 properly handle repeated cancellation in single-qubit gate fusion

### DIFF
--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -243,6 +243,13 @@ void CircuitOptimizer::singleQubitGateFusion(QuantumComputation& qc) {
         continue;
       }
 
+      // check if the compound operation is empty (e.g., -X-H-H-X-Z-)
+      if (compop->empty()) {
+        compop->emplace_back(it->clone());
+        it->setGate(I);
+        continue;
+      }
+
       // check if inverse
       auto lastop = (--(compop->end()));
       auto inverseIt = INVERSE_MAP.find((*lastop)->getType());

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -275,6 +275,37 @@ TEST_F(QFRFunctionality, unknownInverseInCompoundOperation) {
   EXPECT_EQ(qc.getNops(), 1);
 }
 
+TEST_F(QFRFunctionality, repeatedCancellationInSingleQubitGateFusion) {
+  const std::size_t nqubits = 1U;
+  QuantumComputation qc(nqubits);
+  qc.x(0);
+  qc.h(0); // causes the creation of a CompoundOperation
+  qc.h(0); // cancels a gate in the compound operation
+  qc.x(0); // cancels the first gate, making the CompoundOperation empty
+  qc.z(0); // adds another gate to the CompoundOperation
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  CircuitOptimizer::singleQubitGateFusion(qc);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  EXPECT_EQ(qc.getNops(), 1U);
+}
+
+TEST_F(QFRFunctionality, emptyCompoundGatesRemovedInSingleQubitGateFusion) {
+  const std::size_t nqubits = 1U;
+  QuantumComputation qc(nqubits);
+  qc.x(0);
+  qc.h(0); // causes the creation of a CompoundOperation
+  qc.h(0); // cancels a gate in the compound operation
+  qc.x(0); // cancels the first gate, making the CompoundOperation empty
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  CircuitOptimizer::singleQubitGateFusion(qc);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  EXPECT_EQ(qc.getNops(), 0U);
+}
+
 TEST_F(QFRFunctionality, removeDiagonalSingleQubitBeforeMeasure) {
   const std::size_t nqubits = 1;
   QuantumComputation qc(nqubits, nqubits);


### PR DESCRIPTION
## Description

This PR fixes a small bug in the single-qubit gate fusion optimisation method where repeated cancellations would lead to empty compound operations that were then directly accessed without checking whether there are actually elements to access.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
