### PR TITLE
⚡ improved collision logic in `RealNumberUniqueTable`

### DIFF
--- a/include/dd/RealNumberUniqueTable.hpp
+++ b/include/dd/RealNumberUniqueTable.hpp
@@ -189,14 +189,20 @@ private:
   RealNumber* findOrInsert(std::int64_t key, fp val);
 
   /**
-   * @brief Inserts a value into the bucket indexed by key.
-   * @details This function inserts a value into the bucket indexed by key.
-   * It assumes that no element within TOLERANCE is present in the bucket.
+   * @brief Inserts a value in the front of the bucket indexed by key.
    * @param key The index of the bucket to insert the value into.
    * @param val The value to insert.
-   * @returns A pointer to the inserted entry.
+   * @return A pointer to the inserted entry.
    */
-  RealNumber* insert(std::int64_t key, fp val);
+  RealNumber* insertFront(std::int64_t key, fp val);
+
+  /**
+   * @brief Inserts a value in the back of the bucket indexed by key.
+   * @param key The index of the bucket to insert the value into.
+   * @param val The value to insert.
+   * @return A pointer to the inserted entry.
+   */
+  RealNumber* insertBack(std::int64_t key, fp val);
 
   /**
    * @brief Lookup a non-negative number in the table.


### PR DESCRIPTION
## Description

This PR improves the logic for handling collisions in the unique table for real numbers.
Since we track tail pointers anyway, insertions in the back can be accomplished very cheaply.
This can be used in both lookup scenarios; the border case and the middle case.
If no match was found in a border case, it is clear that the new entry should either be added to the end of one or the beginning of the other bucket list.
In the standard case, one can first check whether the looked up value is larger (or equal) than the last element in the bucket.
If so, the new entry can just be added to the end of the collision chain.
In a 33-qubit Grover simulation this saved a couple million collisions.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
