### PR TITLE
⚡ fix performance regression for `RealNumber` computations

### DIFF
--- a/src/dd/ComplexNumbers.cpp
+++ b/src/dd/ComplexNumbers.cpp
@@ -1,5 +1,7 @@
 #include "dd/ComplexNumbers.hpp"
 
+#include "dd/ComplexValue.hpp"
+
 #include <cassert>
 #include <cmath>
 
@@ -39,18 +41,11 @@ void ComplexNumbers::mul(Complex& r, const Complex& a,
   assert(r.i != a.r && "r.i and a.r point to the same entry!");
   assert(r.r != b.i && "r.r and b.i point to the same entry!");
   assert(r.i != b.r && "r.i and b.r point to the same entry!");
-  if (a.approximatelyZero() || b.approximatelyZero()) {
-    r.r->value = 0.;
-    r.i->value = 0.;
-  } else {
-    const auto ar = RealNumber::val(a.r);
-    const auto ai = RealNumber::val(a.i);
-    const auto br = RealNumber::val(b.r);
-    const auto bi = RealNumber::val(b.i);
-
-    r.r->value = ar * br - ai * bi;
-    r.i->value = ar * bi + ai * br;
-  }
+  const auto aVal = static_cast<ComplexValue>(a);
+  const auto bVal = static_cast<ComplexValue>(b);
+  const auto rVal = aVal * bVal;
+  r.r->value = rVal.r;
+  r.i->value = rVal.i;
 }
 
 void ComplexNumbers::div(Complex& r, const Complex& a,
@@ -61,14 +56,11 @@ void ComplexNumbers::div(Complex& r, const Complex& a,
   assert(r.i != a.r && "r.i and a.r point to the same entry!");
   assert(r.r != b.i && "r.r and b.i point to the same entry!");
   assert(r.i != b.r && "r.i and b.r point to the same entry!");
-  const auto ar = RealNumber::val(a.r);
-  const auto ai = RealNumber::val(a.i);
-  const auto br = RealNumber::val(b.r);
-  const auto bi = RealNumber::val(b.i);
-
-  const auto cmag = br * br + bi * bi;
-  r.r->value = (ar * br + ai * bi) / cmag;
-  r.i->value = (ai * br - ar * bi) / cmag;
+  const auto aVal = static_cast<ComplexValue>(a);
+  const auto bVal = static_cast<ComplexValue>(b);
+  const auto rVal = aVal / bVal;
+  r.r->value = rVal.r;
+  r.i->value = rVal.i;
 }
 
 fp ComplexNumbers::mag2(const Complex& a) noexcept {

--- a/src/dd/ComplexValue.cpp
+++ b/src/dd/ComplexValue.cpp
@@ -239,6 +239,15 @@ ComplexValue operator*(fp r, const ComplexValue& c1) {
 }
 
 ComplexValue operator*(const ComplexValue& c1, const ComplexValue& c2) {
+  if (c1.approximatelyOne()) {
+    return c2;
+  }
+  if (c2.approximatelyOne()) {
+    return c1;
+  }
+  if (c1.approximatelyZero() || c2.approximatelyZero()) {
+    return {0., 0.};
+  }
   return {c1.r * c2.r - c1.i * c2.i, c1.r * c2.i + c1.i * c2.r};
 }
 
@@ -247,6 +256,12 @@ ComplexValue operator/(const ComplexValue& c1, fp r) {
 }
 
 ComplexValue operator/(const ComplexValue& c1, const ComplexValue& c2) {
+  if (c2.approximatelyOne()) {
+    return c1;
+  }
+  if (c1.approximatelyEquals(c2)) {
+    return {1., 0.};
+  }
   const auto denom = c2.r * c2.r + c2.i * c2.i;
   return {(c1.r * c2.r + c1.i * c2.i) / denom,
           (c1.i * c2.r - c1.r * c2.i) / denom};


### PR DESCRIPTION
## Description

The omission of some of the approximation checks (partly introduced in #458 and #457) has surfaced as a performance regression during recent testing.
This PR adds back the corresponding checks so that performance is on the expected level again.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
