### PR TITLE
✨ Circuit optimisation for replacing Toffoli gates with MCZ gates and Hadamards

### DIFF
--- a/include/CircuitOptimizer.hpp
+++ b/include/CircuitOptimizer.hpp
@@ -52,6 +52,15 @@ public:
 
   static void cancelCNOTs(QuantumComputation& qc);
 
+  /**
+   * @brief Replaces all MCX gates with MCZ gates (and H gates surrounding the
+   * target qubit) in the given circuit.
+   * @param qc the quantum circuit
+   */
+  static void replaceMCXWithMCZ(qc::QuantumComputation& qc) {
+    replaceMCXWithMCZ(qc.ops);
+  }
+
 protected:
   static void removeDiagonalGatesBeforeMeasureRecursive(
       DAG& dag, DAGReverseIterators& dagIterators, Qubit idx,
@@ -77,5 +86,7 @@ protected:
   static Iterator
   flattenCompoundOperation(std::vector<std::unique_ptr<Operation>>& ops,
                            Iterator it);
+
+  static void replaceMCXWithMCZ(std::vector<std::unique_ptr<Operation>>& ops);
 };
 } // namespace qc

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -2292,3 +2292,84 @@ TEST_F(QFRFunctionality, MeasurementSanityCheck) {
   EXPECT_THROW(qc.measure(0, {"c", 1U}), QFRException);
   EXPECT_THROW(qc.measure(0, {"d", 0U}), QFRException);
 }
+
+TEST_F(QFRFunctionality, replaceCXwithCZ) {
+  qc::QuantumComputation qc(2U);
+  qc.cx(0, 1);
+  CircuitOptimizer::replaceMCXWithMCZ(qc);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.getNops(), 3U);
+  EXPECT_EQ(qc.at(0)->getType(), qc::H);
+  EXPECT_EQ(qc.at(0)->getTargets()[0], 1U);
+  EXPECT_EQ(qc.at(1)->getType(), qc::Z);
+  EXPECT_EQ(qc.at(1)->getTargets()[0], 1U);
+  EXPECT_EQ(*qc.at(1)->getControls().begin(), 0U);
+  EXPECT_EQ(qc.at(2)->getType(), qc::H);
+  EXPECT_EQ(qc.at(2)->getTargets()[0], 1U);
+}
+
+TEST_F(QFRFunctionality, replaceCCXwithCCZ) {
+  std::size_t const nqubits = 3U;
+  qc::QuantumComputation qc(nqubits);
+  Controls const controls = {0, 1};
+  Qubit const target = 2U;
+  qc.mcx(controls, target);
+  CircuitOptimizer::replaceMCXWithMCZ(qc);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.getNops(), 3U);
+  EXPECT_EQ(qc.at(0)->getType(), qc::H);
+  EXPECT_EQ(qc.at(0)->getTargets()[0], target);
+  EXPECT_EQ(qc.at(1)->getType(), qc::Z);
+  EXPECT_EQ(qc.at(1)->getTargets()[0], target);
+  EXPECT_EQ(qc.at(1)->getControls(), controls);
+  EXPECT_EQ(qc.at(2)->getType(), qc::H);
+  EXPECT_EQ(qc.at(2)->getTargets()[0], target);
+}
+
+TEST_F(QFRFunctionality, replaceCXwithCZinCompoundOperation) {
+  std::size_t const nqubits = 2U;
+  qc::QuantumComputation op(nqubits);
+  op.cx(0, 1);
+
+  qc::QuantumComputation qc(nqubits);
+  qc.emplace_back(op.asCompoundOperation());
+
+  CircuitOptimizer::replaceMCXWithMCZ(qc);
+  std::cout << qc << "\n";
+
+  CircuitOptimizer::flattenOperations(qc);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.getNops(), 3U);
+  EXPECT_EQ(qc.at(0)->getType(), qc::H);
+  EXPECT_EQ(qc.at(0)->getTargets()[0], 1U);
+  EXPECT_EQ(qc.at(1)->getType(), qc::Z);
+  EXPECT_EQ(qc.at(1)->getTargets()[0], 1U);
+  EXPECT_EQ(*qc.at(1)->getControls().begin(), 0U);
+  EXPECT_EQ(qc.at(2)->getType(), qc::H);
+  EXPECT_EQ(qc.at(2)->getTargets()[0], 1U);
+}
+
+TEST_F(QFRFunctionality, testToffoliSequenceSimplification) {
+  std::size_t const nqubits = 3U;
+  qc::QuantumComputation qc(nqubits);
+  Controls const controls = {0, 1};
+  Qubit const target = 2U;
+  qc.cx(0, target);
+  qc.mcx(controls, target);
+  CircuitOptimizer::replaceMCXWithMCZ(qc);
+  CircuitOptimizer::singleQubitGateFusion(qc);
+  CircuitOptimizer::flattenOperations(qc);
+  std::cout << qc << "\n";
+
+  qc::QuantumComputation reference(nqubits);
+  reference.h(target);
+  reference.cz(0, target);
+  reference.mcz(controls, target);
+  reference.h(target);
+
+  for (std::size_t i = 0; i < reference.getNops(); ++i) {
+    EXPECT_EQ(qc.at(i)->getType(), reference.at(i)->getType());
+    EXPECT_EQ(qc.at(i)->getTargets(), reference.at(i)->getTargets());
+    EXPECT_EQ(qc.at(i)->getControls(), reference.at(i)->getControls());
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a small new optimization routine that iterates over a circuit and replaces every occurrence of a (multi-)controlled X gate with a (multi-)controlled Z gate that is sandwiched by Hadamard gates on its target.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
