### PR TITLE
🐛 Fix recursive circuit flattening

### DIFF
--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1536,6 +1536,7 @@ TEST_F(QFRFunctionality, FlattenRecursive) {
   // create a nested compound operation
   QuantumComputation op(nqubits);
   op.x(0);
+  op.z(0);
   QuantumComputation op2(nqubits);
   op2.emplace_back(op.asCompoundOperation());
   QuantumComputation qc(nqubits);
@@ -1549,10 +1550,15 @@ TEST_F(QFRFunctionality, FlattenRecursive) {
     EXPECT_FALSE(g->isCompoundOperation());
   }
 
-  auto& gate = **qc.begin();
-  EXPECT_EQ(gate.getType(), qc::X);
-  EXPECT_EQ(gate.getTargets().at(0), 0U);
-  EXPECT_TRUE(gate.getControls().empty());
+  ASSERT_EQ(qc.getNops(), 2U);
+  auto& gate = qc.at(0);
+  EXPECT_EQ(gate->getType(), qc::X);
+  EXPECT_EQ(gate->getTargets().at(0), 0U);
+  EXPECT_TRUE(gate->getControls().empty());
+  auto& gate2 = qc.at(1);
+  EXPECT_EQ(gate2->getType(), qc::Z);
+  EXPECT_EQ(gate2->getTargets().at(0), 0U);
+  EXPECT_TRUE(gate2->getControls().empty());
 }
 
 TEST_F(QFRFunctionality, OperationEquality) {


### PR DESCRIPTION
## Description

This PR addresses an issue in the circuit flattening pass where nested CompoundOperations were not handled properly and silently discarded operations.
This furthermore simplifies the implementation a little bit.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
