### PR TITLE
🐛⚡ fix and speed up Kronecker product for DDs

### DIFF
--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -768,6 +768,28 @@ TEST(DDPackageTest, KroneckerProduct) {
   EXPECT_EQ(kronecker, kronecker2);
 }
 
+TEST(DDPackageTest, KroneckerIdentityHandling) {
+  auto dd = std::make_unique<dd::Package<>>(3U);
+  // create a Hadamard gate on the middle qubit
+  auto h = dd->makeGateDD(dd::H_MAT, 2U, 1U);
+  // create a single qubit identity
+  auto id = dd->makeIdent(1U);
+  // kronecker both DDs
+  const auto combined = dd->kronecker(h, id);
+  const auto matrix = combined.getMatrix();
+  const auto expectedMatrix = dd::CMat{
+      {dd::SQRT2_2, 0, 0, 0, dd::SQRT2_2, 0, 0, 0},
+      {0, dd::SQRT2_2, 0, 0, 0, dd::SQRT2_2, 0, 0},
+      {0, 0, dd::SQRT2_2, 0, 0, 0, dd::SQRT2_2, 0},
+      {0, 0, 0, dd::SQRT2_2, 0, 0, 0, dd::SQRT2_2},
+      {dd::SQRT2_2, 0, 0, 0, -dd::SQRT2_2, 0, 0, 0},
+      {0, dd::SQRT2_2, 0, 0, 0, -dd::SQRT2_2, 0, 0},
+      {0, 0, dd::SQRT2_2, 0, 0, 0, -dd::SQRT2_2, 0},
+      {0, 0, 0, dd::SQRT2_2, 0, 0, 0, -dd::SQRT2_2},
+  };
+  EXPECT_EQ(matrix, expectedMatrix);
+}
+
 TEST(DDPackageTest, NearZeroNormalize) {
   auto dd = std::make_unique<dd::Package<>>(2);
   const dd::fp nearZero = dd::RealNumber::eps / 10;


### PR DESCRIPTION
## Description

This PR fixes an issue in the `kronecker` method of the DD package where (for whatever reason) the situation where `x` contained a node where `x.p->isIdentity()` is true at some point was not handled properly and some edge weights were dropped.

Furthermore, this PR optimises the compute table lookup strategy similar to how this is done for simulation since the top edge weights can just be filtered out before the lookup and multiplied in the end before returning the result.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
