### PR TITLE
🐛 Miscellaneous fixes for qubit and register handling

### DIFF
--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -121,33 +121,22 @@ protected:
 
   template <class RegisterType>
   static void createRegisterArray(const RegisterMap<RegisterType>& regs,
-                                  RegisterNames& regnames,
-                                  decltype(RegisterType::second) defaultnumber,
-                                  const std::string& defaultname) {
+                                  RegisterNames& regnames) {
     regnames.clear();
-
     std::stringstream ss;
-    if (!regs.empty()) {
-      // sort regs by start index
-      std::map<decltype(RegisterType::first),
-               std::pair<std::string, RegisterType>>
-          sortedRegs{};
-      for (const auto& reg : regs) {
-        sortedRegs.insert({reg.second.first, reg});
-      }
+    // sort regs by start index
+    std::map<decltype(RegisterType::first),
+             std::pair<std::string, RegisterType>>
+        sortedRegs{};
+    for (const auto& reg : regs) {
+      sortedRegs.insert({reg.second.first, reg});
+    }
 
-      for (const auto& reg : sortedRegs) {
-        for (decltype(RegisterType::second) i = 0; i < reg.second.second.second;
-             i++) {
-          ss << reg.second.first << "[" << i << "]";
-          regnames.push_back(std::make_pair(reg.second.first, ss.str()));
-          ss.str(std::string());
-        }
-      }
-    } else {
-      for (decltype(RegisterType::second) i = 0; i < defaultnumber; i++) {
-        ss << defaultname << "[" << i << "]";
-        regnames.emplace_back(defaultname, ss.str());
+    for (const auto& reg : sortedRegs) {
+      for (decltype(RegisterType::second) i = 0; i < reg.second.second.second;
+           i++) {
+        ss << reg.second.first << "[" << i << "]";
+        regnames.push_back(std::make_pair(reg.second.first, ss.str()));
         ss.str(std::string());
       }
     }

--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -310,10 +310,9 @@ public:
     if (logicalQubitIsAncillary(logicalQubitIndex)) {
       return;
     }
-    // remove the logical qubit and add it back as an ancillary
-    const auto [initialLayoutIndex, outputPermutationIndex] =
-        removeQubit(logicalQubitIndex);
-    addAncillaryQubit(initialLayoutIndex, outputPermutationIndex);
+    ancillary[logicalQubitIndex] = true;
+    nancillae++;
+    nqubits--;
   }
   [[nodiscard]] bool
   logicalQubitIsGarbage(const Qubit logicalQubitIndex) const {

--- a/include/QuantumComputation.hpp
+++ b/include/QuantumComputation.hpp
@@ -310,9 +310,10 @@ public:
     if (logicalQubitIsAncillary(logicalQubitIndex)) {
       return;
     }
-    ancillary[logicalQubitIndex] = true;
-    nancillae++;
-    nqubits--;
+    // remove the logical qubit and add it back as an ancillary
+    const auto [initialLayoutIndex, outputPermutationIndex] =
+        removeQubit(logicalQubitIndex);
+    addAncillaryQubit(initialLayoutIndex, outputPermutationIndex);
   }
   [[nodiscard]] bool
   logicalQubitIsGarbage(const Qubit logicalQubitIndex) const {

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -673,10 +673,6 @@ void QuantumComputation::dumpOpenQASM(std::ostream& of) {
     of << "opaque teleport src, anc, tgt;\n";
   }
 
-  assert(nqubits == 0U || !qregs.empty());
-  assert(nclassics == 0U || !cregs.empty());
-  assert(nancillae == 0U || !ancregs.empty());
-
   // combine qregs and ancregs
   QuantumRegisterMap combinedRegs = qregs;
   for (const auto& [regName, reg] : ancregs) {
@@ -685,10 +681,13 @@ void QuantumComputation::dumpOpenQASM(std::ostream& of) {
   printSortedRegisters(combinedRegs, "qreg", of);
   RegisterNames combinedRegNames{};
   createRegisterArray(combinedRegs, combinedRegNames);
+  assert(combinedRegNames.size() == nqubits + nancillae);
 
   printSortedRegisters(cregs, "creg", of);
   RegisterNames cregnames{};
   createRegisterArray(cregs, cregnames);
+  assert(cregnames.size() == nclassics);
+
   for (const auto& op : ops) {
     op->dumpOpenQASM(of, combinedRegNames, cregnames);
   }

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -674,27 +674,23 @@ void QuantumComputation::dumpOpenQASM(std::ostream& of) {
   }
 
   assert(nqubits == 0U || !qregs.empty());
-  printSortedRegisters(qregs, "qreg", of);
-
   assert(nclassics == 0U || !cregs.empty());
-  printSortedRegisters(cregs, "creg", of);
-
   assert(nancillae == 0U || !ancregs.empty());
-  printSortedRegisters(ancregs, "qreg", of);
 
-  RegisterNames qregnames{};
-  RegisterNames cregnames{};
-  RegisterNames ancregnames{};
-  createRegisterArray(qregs, qregnames, nqubits, "q");
-  createRegisterArray(cregs, cregnames, nclassics, "c");
-  createRegisterArray(ancregs, ancregnames, nancillae, "anc");
-
-  for (const auto& ancregname : ancregnames) {
-    qregnames.push_back(ancregname);
+  // combine qregs and ancregs
+  QuantumRegisterMap combinedRegs = qregs;
+  for (const auto& [regName, reg] : ancregs) {
+    combinedRegs.try_emplace(regName, reg.first, reg.second);
   }
+  printSortedRegisters(combinedRegs, "qreg", of);
+  RegisterNames combinedRegNames{};
+  createRegisterArray(combinedRegs, combinedRegNames);
 
+  printSortedRegisters(cregs, "creg", of);
+  RegisterNames cregnames{};
+  createRegisterArray(cregs, cregnames);
   for (const auto& op : ops) {
-    op->dumpOpenQASM(of, qregnames, cregnames);
+    op->dumpOpenQASM(of, combinedRegNames, cregnames);
   }
 }
 

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -974,8 +974,9 @@ bool QuantumComputation::isLastOperationOnQubit(
 void QuantumComputation::unifyQuantumRegisters(const std::string& regName) {
   ancregs.clear();
   qregs.clear();
-  qregs[regName] = {0, getNqubits()};
+  nqubits += nancillae;
   nancillae = 0;
+  qregs[regName] = {0, nqubits};
 }
 
 void QuantumComputation::appendMeasurementsAccordingToOutputPermutation(

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -572,7 +572,7 @@ std::ostream& QuantumComputation::print(std::ostream& os) const {
   size_t i = 0U;
   for (const auto& op : ops) {
     os << std::setw(width) << ++i << ":";
-    op->print(os, initialLayout, static_cast<std::size_t>(width) + 1U);
+    op->print(os, {}, static_cast<std::size_t>(width) + 1U);
     os << "\n";
   }
 

--- a/src/mqt/core/plugins/qiskit.py
+++ b/src/mqt/core/plugins/qiskit.py
@@ -45,14 +45,11 @@ def qiskit_to_mqt(circ: QuantumCircuit) -> QuantumComputation:
         size = reg.size
         if isinstance(reg, AncillaRegister):
             qc.add_ancillary_register(size, reg.name)
-            for qubit in reg:
-                qubit_map[qubit] = qubit_index
-                qubit_index += 1
         else:
             qc.add_qubit_register(size, reg.name)
-            for qubit in reg:
-                qubit_map[qubit] = qubit_index
-                qubit_index += 1
+        for qubit in reg:
+            qubit_map[qubit] = qubit_index
+            qubit_index += 1
 
     clbit_index = 0
     clbit_map: dict[Clbit, int] = {}

--- a/src/operations/NonUnitaryOperation.cpp
+++ b/src/operations/NonUnitaryOperation.cpp
@@ -63,11 +63,12 @@ std::ostream& NonUnitaryOperation::print(
 void NonUnitaryOperation::dumpOpenQASM(std::ostream& of,
                                        const RegisterNames& qreg,
                                        const RegisterNames& creg) const {
-  if (isWholeQubitRegister(qreg, targets.front(), targets.back())) {
+  if (isWholeQubitRegister(qreg, targets.front(), targets.back()) &&
+      (type != Measure ||
+       isWholeQubitRegister(creg, classics.front(), classics.back()))) {
     of << toString(type) << " " << qreg[targets.front()].first;
     if (type == Measure) {
       of << " -> ";
-      assert(isWholeQubitRegister(creg, classics.front(), classics.back()));
       of << creg[classics.front()].first;
     }
     of << ";\n";

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -667,4 +667,22 @@ TEST_F(IO, SingleRegistersDoubleCreg) {
   std::stringstream ss2{};
   qc->dump(ss2, qc::Format::OpenQASM);
   std::cout << ss2.str() << "\n";
+  EXPECT_NE(ss2.str().find(ss.str()), std::string::npos);
+}
+
+TEST_F(IO, MarkAncillaryAndDump) {
+  std::stringstream ss{};
+  ss << "qreg q[2];\n"
+     << "x q[0];\n"
+     << "x q[1];\n";
+  qc->import(ss, qc::Format::OpenQASM);
+  std::cout << *qc << "\n";
+  qc->setLogicalQubitAncillary(0U);
+  EXPECT_EQ(qc->getNancillae(), 1U);
+  EXPECT_TRUE(qc->logicalQubitIsAncillary(0U));
+  std::cout << *qc << "\n";
+  std::stringstream ss2{};
+  qc->dump(ss2, qc::Format::OpenQASM);
+  std::cout << ss2.str() << "\n";
+  EXPECT_NE(ss2.str().find(ss.str()), std::string::npos);
 }

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -655,3 +655,16 @@ TEST_F(IO, NonStandardInclude) {
   EXPECT_EQ(qc->at(0)->getType(), qc::H);
   std::filesystem::remove("defs.inc");
 }
+
+TEST_F(IO, SingleRegistersDoubleCreg) {
+  std::stringstream ss{};
+  ss << "qreg p[1];\n"
+     << "qreg q[1];\n"
+     << "creg c[2];\n"
+     << "measure p[0] -> c[0];\n";
+  qc->import(ss, qc::Format::OpenQASM);
+  std::cout << *qc << "\n";
+  std::stringstream ss2{};
+  qc->dump(ss2, qc::Format::OpenQASM);
+  std::cout << ss2.str() << "\n";
+}


### PR DESCRIPTION
## Description

This PR brings some improvements and fixes to the handling of qubits and registers in MQT Core.
First of all, it fixes the routine that marks qubits as ancillaries so that qubits are really properly transformed from regular qubits in a regular register to ancillary qubits in an ancillary register.
Second, it improves the stability of the QASM dump by making sure that the registers are dumped in the proper order that they were declared in.
Lastly, it fixes an oversight in the routine for unifying registers that effectively erased any ancillary qubits from the qubit count.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
