### PR TITLE
🐛 fix compiler errors in GCC-10 due to abstract return type

### DIFF
--- a/src/python/operations/register_operation.cpp
+++ b/src/python/operations/register_operation.cpp
@@ -60,9 +60,14 @@ void registerOperation(py::module& m) {
           },
           "qreg"_a, "creg"_a,
           "Return the OpenQASM string representation of this operation.")
-      .def(py::self == py::self)
-      .def(py::self != py::self)
-      .def(hash(py::self))
+      .def("__eq__", [](const qc::Operation& op,
+                        const qc::Operation& other) { return op == other; })
+      .def("__ne__", [](const qc::Operation& op,
+                        const qc::Operation& other) { return op != other; })
+      .def("__hash__",
+           [](const qc::Operation& op) {
+             return std::hash<qc::Operation>{}(op);
+           })
       .def("__str__",
            [](const qc::Operation& op) {
              std::ostringstream oss;


### PR DESCRIPTION
## Description

For some reason, GCC 10 and older have a problem with the pybind11 way of automatically defining `operator==`, `operator!=` and `hash` when the class they are defined on is abstract.
Newer versions of GCC do not complain about this and just work.
This PR works around the underlying issue by defining the respective functions manually again.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
