### PR TITLE
🚚 move `check-sdist` from pre-commit to CI

### DIFF
--- a/.github/workflows/reusable-python-linter.yml
+++ b/.github/workflows/reusable-python-linter.yml
@@ -46,3 +46,6 @@ jobs:
       - uses: pre-commit/action@v3.0.0
         with:
           extra_args: mypy --all-files
+      - name: Run check-sdist
+        run: |
+          pipx run check-sdist --inject-junk

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,14 +116,3 @@ repos:
         language: pygrep
         entry: PyBind|Numpy|Cmake|CCache|Github|PyTest|Mqt|Tum
         exclude: .pre-commit-config.yaml
-
-  # Checking sdist validity
-  - repo: https://github.com/henryiii/check-sdist
-    rev: v0.1.3
-    hooks:
-      - id: check-sdist
-        args: [--inject-junk]
-        additional_dependencies:
-          - scikit-build-core[pyproject]>=0.6.1
-          - setuptools-scm>=7
-          - pybind11>=2.11


### PR DESCRIPTION
## Description

Even when pre-installing build dependencies, the `check-sdist` pre-commit check still is pretty slow and slows down developer experience. This PR just moves the corresponding check to the reusable CI workflows.
That way, it is still run and any problems with SDists can still be caught, but DX is faster again.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
