### PR TITLE
🩹 Improved qubit and register management

### DIFF
--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -299,82 +299,87 @@ void QuantumComputation::addAncillaryRegister(std::size_t nq,
   }
 }
 
+void QuantumComputation::removeQubitfromQubitRegister(QuantumRegisterMap& regs,
+                                                      const std::string& reg,
+                                                      const Qubit idx) {
+  if (idx == 0) {
+    // last remaining qubit of register
+    if (regs[reg].second == 1) {
+      // delete register
+      regs.erase(reg);
+    }
+    // first qubit of register
+    else {
+      regs[reg].first++;
+      regs[reg].second--;
+    }
+    // last index
+  } else if (idx == regs[reg].second - 1) {
+    // reduce count of register
+    regs[reg].second--;
+  } else {
+    auto qreg = regs.at(reg);
+    auto lowPart = reg + "_l";
+    auto lowIndex = qreg.first;
+    auto lowCount = idx;
+    auto highPart = reg + "_h";
+    auto highIndex = qreg.first + idx + 1;
+    auto highCount = qreg.second - idx - 1;
+
+    regs.erase(reg);
+    regs.try_emplace(lowPart, lowIndex, lowCount);
+    regs.try_emplace(highPart, highIndex, highCount);
+  }
+}
+
+void QuantumComputation::addQubitToQubitRegister(
+    QuantumRegisterMap& regs, const Qubit physicalQubitIndex,
+    const std::string& defaultRegName) {
+  bool fusionPossible = false;
+  for (auto& reg : regs) {
+    auto& startIndex = reg.second.first;
+    auto& count = reg.second.second;
+    // 1st case: can append to start of existing register
+    if (startIndex == physicalQubitIndex + 1) {
+      startIndex--;
+      count++;
+      fusionPossible = true;
+      break;
+    }
+    // 2nd case: can append to end of existing register
+    if (startIndex + count == physicalQubitIndex) {
+      count++;
+      fusionPossible = true;
+      break;
+    }
+  }
+
+  consolidateRegister(regs);
+
+  if (regs.empty()) {
+    regs.try_emplace(defaultRegName, physicalQubitIndex, 1);
+  } else if (!fusionPossible) {
+    auto newRegName = defaultRegName + "_" + std::to_string(physicalQubitIndex);
+    regs.try_emplace(newRegName, physicalQubitIndex, 1);
+  }
+}
+
 // removes the i-th logical qubit and returns the index j it was assigned to in
 // the initial layout i.e., initialLayout[j] = i
 std::pair<Qubit, std::optional<Qubit>>
 QuantumComputation::removeQubit(const Qubit logicalQubitIndex) {
   // Find index of the physical qubit i is assigned to
-  Qubit physicalQubitIndex = 0;
-  for (const auto& [physical, logical] : initialLayout) {
-    if (logical == logicalQubitIndex) {
-      physicalQubitIndex = physical;
-    }
-  }
+  const auto physicalQubitIndex = getPhysicalQubitIndex(logicalQubitIndex);
 
   // get register and register-index of the corresponding qubit
-  auto reg = getQubitRegisterAndIndex(physicalQubitIndex);
+  const auto [reg, idx] = getQubitRegisterAndIndex(physicalQubitIndex);
 
   if (physicalQubitIsAncillary(physicalQubitIndex)) {
-    // first index
-    if (reg.second == 0) {
-      // last remaining qubit of register
-      if (ancregs[reg.first].second == 1) {
-        // delete register
-        ancregs.erase(reg.first);
-      }
-      // first qubit of register
-      else {
-        ancregs[reg.first].first++;
-        ancregs[reg.first].second--;
-      }
-      // last index
-    } else if (reg.second == ancregs[reg.first].second - 1) {
-      // reduce count of register
-      ancregs[reg.first].second--;
-    } else {
-      auto ancreg = ancregs.at(reg.first);
-      auto lowPart = reg.first + "_l";
-      auto lowIndex = ancreg.first;
-      auto lowCount = reg.second;
-      auto highPart = reg.first + "_h";
-      auto highIndex = ancreg.first + reg.second + 1;
-      auto highCount = ancreg.second - reg.second - 1;
-
-      ancregs.erase(reg.first);
-      ancregs.try_emplace(lowPart, lowIndex, lowCount);
-      ancregs.try_emplace(highPart, highIndex, highCount);
-    }
+    removeQubitfromQubitRegister(ancregs, reg, idx);
     // reduce ancilla count
     nancillae--;
   } else {
-    if (reg.second == 0) {
-      // last remaining qubit of register
-      if (qregs[reg.first].second == 1) {
-        // delete register
-        qregs.erase(reg.first);
-      }
-      // first qubit of register
-      else {
-        qregs[reg.first].first++;
-        qregs[reg.first].second--;
-      }
-      // last index
-    } else if (reg.second == qregs[reg.first].second - 1) {
-      // reduce count of register
-      qregs[reg.first].second--;
-    } else {
-      auto qreg = qregs.at(reg.first);
-      auto lowPart = reg.first + "_l";
-      auto lowIndex = qreg.first;
-      auto lowCount = reg.second;
-      auto highPart = reg.first + "_h";
-      auto highIndex = qreg.first + reg.second + 1;
-      auto highCount = qreg.second - reg.second - 1;
-
-      qregs.erase(reg.first);
-      qregs.try_emplace(lowPart, lowIndex, lowCount);
-      qregs.try_emplace(highPart, highIndex, highCount);
-    }
+    removeQubitfromQubitRegister(qregs, reg, idx);
     // reduce qubit count
     nqubits--;
   }
@@ -419,31 +424,7 @@ void QuantumComputation::addAncillaryQubit(
                        "qubit that is already assigned");
   }
 
-  bool fusionPossible = false;
-  for (auto& ancreg : ancregs) {
-    auto& ancStartIndex = ancreg.second.first;
-    auto& ancCount = ancreg.second.second;
-    // 1st case: can append to start of existing register
-    if (ancStartIndex == physicalQubitIndex + 1) {
-      ancStartIndex--;
-      ancCount++;
-      fusionPossible = true;
-      break;
-    }
-    // 2nd case: can append to end of existing register
-    if (ancStartIndex + ancCount == physicalQubitIndex) {
-      ancCount++;
-      fusionPossible = true;
-      break;
-    }
-  }
-
-  if (ancregs.empty()) {
-    ancregs.try_emplace("anc", physicalQubitIndex, 1);
-  } else if (!fusionPossible) {
-    auto newRegName = "anc_" + std::to_string(physicalQubitIndex);
-    ancregs.try_emplace(newRegName, physicalQubitIndex, 1);
-  }
+  addQubitToQubitRegister(ancregs, physicalQubitIndex, "anc");
 
   // index of logical qubit
   const auto logicalQubitIndex = nqubits + nancillae;
@@ -492,40 +473,7 @@ void QuantumComputation::addQubit(const Qubit logicalQubitIndex,
     // register could be created and all ancillaries shifted
   }
 
-  // check if qubit fits in existing register
-  bool fusionPossible = false;
-  for (auto& qreg : qregs) {
-    auto& qStartIndex = qreg.second.first;
-    auto& qCount = qreg.second.second;
-    // 1st case: can append to start of existing register
-    if (qStartIndex == physicalQubitIndex + 1) {
-      qStartIndex--;
-      qCount++;
-      fusionPossible = true;
-      break;
-    }
-    // 2nd case: can append to end of existing register
-    if (qStartIndex + qCount == physicalQubitIndex) {
-      if (physicalQubitIndex == nqubits) {
-        // need to shift ancillaries
-        for (auto& ancreg : ancregs) {
-          ancreg.second.first++;
-        }
-      }
-      qCount++;
-      fusionPossible = true;
-      break;
-    }
-  }
-
-  consolidateRegister(qregs);
-
-  if (qregs.empty()) {
-    qregs.try_emplace("q", physicalQubitIndex, 1);
-  } else if (!fusionPossible) {
-    auto newRegName = "q_" + std::to_string(physicalQubitIndex);
-    qregs.try_emplace(newRegName, physicalQubitIndex, 1);
-  }
+  addQubitToQubitRegister(qregs, physicalQubitIndex, "q");
 
   // increase qubit count
   nqubits++;
@@ -848,9 +796,19 @@ std::pair<std::string, Bit> QuantumComputation::getClassicalRegisterAndIndex(
   auto it = cregs.find(regName);
   if (it != cregs.end()) {
     index = classicalIndex - it->second.first;
-  } // else branch not needed since getClassicalRegister already covers this
-    // case
+  } // else branch not needed since getClassicalRegister covers this case
   return {regName, index};
+}
+
+Qubit QuantumComputation::getPhysicalQubitIndex(const Qubit logicalQubitIndex) {
+  for (const auto& [physical, logical] : initialLayout) {
+    if (logical == logicalQubitIndex) {
+      return physical;
+    }
+  }
+  throw QFRException("[getPhysicalQubitIndex] Logical qubit index " +
+                     std::to_string(logicalQubitIndex) +
+                     " not found in initial layout");
 }
 
 Qubit QuantumComputation::getIndexFromQubitRegister(
@@ -914,6 +872,23 @@ bool QuantumComputation::physicalQubitIsAncillary(
                               physicalQubitIndex <
                                   ancreg.second.first + ancreg.second.second;
                      });
+}
+
+void QuantumComputation::setLogicalQubitAncillary(
+    const Qubit logicalQubitIndex) {
+  if (logicalQubitIsAncillary(logicalQubitIndex)) {
+    return;
+  }
+
+  const auto physicalQubitIndex = getPhysicalQubitIndex(logicalQubitIndex);
+
+  // get register and register-index of the corresponding qubit
+  const auto [reg, idx] = getQubitRegisterAndIndex(physicalQubitIndex);
+  removeQubitfromQubitRegister(qregs, reg, idx);
+  addQubitToQubitRegister(ancregs, physicalQubitIndex, "anc");
+  nqubits--;
+  nancillae++;
+  ancillary[logicalQubitIndex] = true;
 }
 
 void QuantumComputation::setLogicalQubitGarbage(const Qubit logicalQubitIndex) {

--- a/src/mqt/core/plugins/qiskit.py
+++ b/src/mqt/core/plugins/qiskit.py
@@ -383,7 +383,7 @@ def _import_layouts(qc: QuantumComputation, circ: QuantumCircuit) -> None:
         is_ancilla = register.name == "ancilla" or isinstance(register, AncillaRegister)
         if not is_ancilla:
             continue
-        for qubit in register:
+        for qubit in reversed(register):
             qc.set_circuit_qubit_ancillary(qubit_to_idx[qubit])
 
     # create initial layout (and assume identical output permutation)

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -694,5 +694,14 @@ TEST_F(IO, MarkAncillaryAndDump) {
   std::stringstream ss2{};
   qc->dump(ss2, qc::Format::OpenQASM);
   std::cout << ss2.str() << "\n";
-  EXPECT_NE(ss2.str().find(ss.str()), std::string::npos);
+  std::stringstream expected{};
+  expected << "// i 0 1\n"
+           << "// o 0 1\n"
+           << "OPENQASM 2.0;\n"
+           << "include \"qelib1.inc\";\n"
+           << "qreg anc[1];\n"
+           << "qreg q[1];\n"
+           << "x anc[0];\n"
+           << "x q[0];\n";
+  EXPECT_STREQ(ss2.str().c_str(), expected.str().c_str());
 }


### PR DESCRIPTION
## Description

This PR slightly improves the handling of registers and qubits and is one more step towards making sure that the individual qubit/ancillary counts and the registers stored in a quantum circuit are aligned and match up.
This has surfaced in QCEC since the `setLogicalQubitAncillary` method only manipulated `nqubits` and `nancillae`, but did not alter the registers of the circuit.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
