### PR TITLE
♻️ Revised qubit register handling

### DIFF
--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -381,7 +381,12 @@ QuantumComputation::removeQubit(const Qubit logicalQubitIndex) {
   } else {
     removeQubitfromQubitRegister(qregs, reg, idx);
     // reduce qubit count
-    nqubits--;
+    if (ancillary.at(logicalQubitIndex)) {
+      // if the qubit is ancillary, it is not counted as a qubit
+      nancillae--;
+    } else {
+      nqubits--;
+    }
   }
 
   // adjust initial layout permutation
@@ -880,12 +885,6 @@ void QuantumComputation::setLogicalQubitAncillary(
     return;
   }
 
-  const auto physicalQubitIndex = getPhysicalQubitIndex(logicalQubitIndex);
-
-  // get register and register-index of the corresponding qubit
-  const auto [reg, idx] = getQubitRegisterAndIndex(physicalQubitIndex);
-  removeQubitfromQubitRegister(qregs, reg, idx);
-  addQubitToQubitRegister(ancregs, physicalQubitIndex, "anc");
   nqubits--;
   nancillae++;
   ancillary[logicalQubitIndex] = true;

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -699,9 +699,8 @@ TEST_F(IO, MarkAncillaryAndDump) {
            << "// o 0 1\n"
            << "OPENQASM 2.0;\n"
            << "include \"qelib1.inc\";\n"
-           << "qreg anc[1];\n"
-           << "qreg q[1];\n"
-           << "x anc[0];\n"
-           << "x q[0];\n";
+           << "qreg q[2];\n"
+           << "x q[0];\n"
+           << "x q[1];\n";
   EXPECT_STREQ(ss2.str().c_str(), expected.str().c_str());
 }

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -2402,12 +2402,9 @@ TEST_F(QFRFunctionality, testSettingAncillariesProperlyCreatesRegisters) {
   qc.setLogicalQubitAncillary(1U);
   ASSERT_EQ(qregs.size(), 1U);
   ASSERT_EQ(reg.second.first, 0U);
-  ASSERT_EQ(reg.second.second, 1U);
+  ASSERT_EQ(reg.second.second, 3U);
   ASSERT_EQ(name, reg.first);
-  ASSERT_EQ(ancRegs.size(), 1U);
-  const auto& ancReg = *ancRegs.begin();
-  ASSERT_EQ(ancReg.second.first, 1U);
-  ASSERT_EQ(ancReg.second.second, 2U);
+  ASSERT_TRUE(ancRegs.empty());
   ASSERT_EQ(qc.getNqubitsWithoutAncillae(), 1U);
   ASSERT_EQ(qc.getNancillae(), 2U);
 
@@ -2422,7 +2419,7 @@ TEST_F(QFRFunctionality, testSettingAncillariesProperlyCreatesRegisters) {
   ASSERT_EQ(reg.second.first, 0U);
   ASSERT_EQ(reg.second.second, 1U);
   ASSERT_EQ(name, reg.first);
-  ASSERT_EQ(ancRegs.size(), 0U);
+  ASSERT_TRUE(ancRegs.empty());
   ASSERT_EQ(qc.getNqubitsWithoutAncillae(), 1U);
   ASSERT_EQ(qc.getNancillae(), 0U);
 }

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -2459,11 +2459,12 @@ TEST_F(QFRFunctionality, StripIdleQubitsInMiddleOfCircuit) {
   qc.stripIdleQubits();
 
   ASSERT_EQ(qregs.size(), 2U);
-  ASSERT_EQ(reg.second.first, 1U);
-  ASSERT_EQ(reg.second.second, 1U);
-  const auto& reg2 = *(++qregs.begin());
-  ASSERT_EQ(reg2.second.first, 3U);
-  ASSERT_EQ(reg2.second.second, 2U);
+  const auto& regAfter = *qregs.begin();
+  ASSERT_EQ(regAfter.second.first, 1U);
+  ASSERT_EQ(regAfter.second.second, 1U);
+  const auto& reg2After = *(++qregs.begin());
+  ASSERT_EQ(reg2After.second.first, 3U);
+  ASSERT_EQ(reg2After.second.second, 2U);
   ASSERT_TRUE(ancRegs.empty());
   ASSERT_EQ(qc.getNqubitsWithoutAncillae(), 3U);
   ASSERT_EQ(qc.getNancillae(), 0U);


### PR DESCRIPTION
## Description

This kind of supersedes #493 and provides an alternative, less intrusive version that properly handles ancillary qubits and marking qubits in existing registers as ancillaries.
It simply checks on the removal of a qubit from a `qreg` whether that qubit is marked as ancillary and correspondingly decrements the right qubit number counter. 

This has also been tested in QCEC to resolve the errors that were popping up over there.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
