### PR TITLE
✨ Add support for OpenQASM 3.0 `else`

### DIFF
--- a/include/Definitions.hpp
+++ b/include/Definitions.hpp
@@ -110,4 +110,18 @@ combineHash(const std::size_t lhs, const std::size_t rhs) noexcept {
 constexpr void hashCombine(std::size_t& hash, const std::size_t with) noexcept {
   hash = combineHash(hash, with);
 }
+
+/**
+ * @brief Function used to mark unreachable code
+ * @details Uses compiler specific extensions if possible. Even if no extension
+ * is used, undefined behavior is still raised by an empty function body and the
+ * noreturn attribute.
+ */
+[[noreturn]] inline void unreachable() {
+#ifdef __GNUC__ // GCC, Clang, ICC
+  __builtin_unreachable();
+#elif defined(_MSC_VER) // MSVC
+  __assume(false);
+#endif
+}
 } // namespace qc

--- a/include/operations/ClassicControlledOperation.hpp
+++ b/include/operations/ClassicControlledOperation.hpp
@@ -6,7 +6,7 @@
 
 namespace qc {
 
-enum ComparisonKind {
+enum ComparisonKind: std::uint8_t {
   Eq,
   Neq,
   Lt,
@@ -15,7 +15,7 @@ enum ComparisonKind {
   Geq,
 };
 
-ComparisonKind getInvertedComparsionKind(const ComparisonKind kind);
+ComparisonKind getInvertedComparsionKind(ComparisonKind kind);
 
 std::ostream& operator<<(std::ostream& os, const ComparisonKind& kind);
 

--- a/include/operations/ClassicControlledOperation.hpp
+++ b/include/operations/ClassicControlledOperation.hpp
@@ -17,6 +17,8 @@ enum ComparisonKind : std::uint8_t {
 
 ComparisonKind getInvertedComparsionKind(ComparisonKind kind);
 
+std::string toString(const ComparisonKind& kind);
+
 std::ostream& operator<<(std::ostream& os, const ComparisonKind& kind);
 
 class ClassicControlledOperation final : public Operation {

--- a/include/operations/ClassicControlledOperation.hpp
+++ b/include/operations/ClassicControlledOperation.hpp
@@ -6,7 +6,7 @@
 
 namespace qc {
 
-enum ComparisonKind: std::uint8_t {
+enum ComparisonKind : std::uint8_t {
   Eq,
   Neq,
   Lt,

--- a/include/operations/ClassicControlledOperation.hpp
+++ b/include/operations/ClassicControlledOperation.hpp
@@ -15,6 +15,8 @@ enum ComparisonKind {
   Geq,
 };
 
+ComparisonKind getInvertedComparsionKind(const ComparisonKind kind);
+
 std::ostream& operator<<(std::ostream& os, const ComparisonKind& kind);
 
 class ClassicControlledOperation final : public Operation {

--- a/include/parsers/qasm3_parser/Statement.hpp
+++ b/include/parsers/qasm3_parser/Statement.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <variant>

--- a/include/parsers/qasm3_parser/Statement.hpp
+++ b/include/parsers/qasm3_parser/Statement.hpp
@@ -125,8 +125,7 @@ public:
   std::string getName() override { return "BinaryExpr"; }
 };
 
-std::optional<qc::ComparisonKind>
-getComparisonKind(BinaryExpression::Op op);
+std::optional<qc::ComparisonKind> getComparisonKind(BinaryExpression::Op op);
 
 class UnaryExpression : public Expression,
                         public std::enable_shared_from_this<UnaryExpression> {
@@ -171,8 +170,8 @@ class IdentifierList : public Expression,
 public:
   std::vector<std::shared_ptr<IdentifierExpression>> identifiers{};
 
-  explicit
-  IdentifierList(std::vector<std::shared_ptr<IdentifierExpression>> ids)
+  explicit IdentifierList(
+      std::vector<std::shared_ptr<IdentifierExpression>> ids)
       : identifiers(std::move(ids)) {}
 
   explicit IdentifierList() = default;

--- a/include/parsers/qasm3_parser/Statement.hpp
+++ b/include/parsers/qasm3_parser/Statement.hpp
@@ -3,6 +3,7 @@
 #include "InstVisitor.hpp"
 #include "Permutation.hpp"
 #include "Types.hpp"
+#include "operations/ClassicControlledOperation.hpp"
 
 #include <cassert>
 #include <cstddef>
@@ -124,6 +125,9 @@ public:
   std::string getName() override { return "BinaryExpr"; }
 };
 
+std::optional<qc::ComparisonKind>
+getComparisonKind(BinaryExpression::Op op);
+
 class UnaryExpression : public Expression,
                         public std::enable_shared_from_this<UnaryExpression> {
 public:
@@ -167,8 +171,8 @@ class IdentifierList : public Expression,
 public:
   std::vector<std::shared_ptr<IdentifierExpression>> identifiers{};
 
-  explicit IdentifierList(
-      std::vector<std::shared_ptr<IdentifierExpression>> ids)
+  explicit
+  IdentifierList(std::vector<std::shared_ptr<IdentifierExpression>> ids)
       : identifiers(std::move(ids)) {}
 
   explicit IdentifierList() = default;

--- a/include/parsers/qasm3_parser/passes/ConstEvalPass.hpp
+++ b/include/parsers/qasm3_parser/passes/ConstEvalPass.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CompilerPass.hpp"
+#include "Definitions.hpp"
 #include "parsers/qasm3_parser/Exception.hpp"
 #include "parsers/qasm3_parser/NestedEnvironment.hpp"
 
@@ -32,14 +33,9 @@ struct ConstEvalValue {
     case ConstBool:
       return std::make_shared<Constant>(
           Constant(static_cast<int64_t>(std::get<2>(value)), false));
+    default:
+      qc::unreachable();
     }
-
-#if defined(__GNUC__) || defined(__clang__)
-    __builtin_unreachable();
-#elif defined(_MSC_VER)
-    __assume(0);
-#else
-#endif
   }
 
   bool operator==(const ConstEvalValue& rhs) const {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,7 @@ if(NOT TARGET ${PROJECT_NAME})
     parsers/qasm3_parser/Parser.cpp
     parsers/qasm3_parser/Scanner.cpp
     parsers/qasm3_parser/Types.cpp
+    parsers/qasm3_parser/Statement.cpp
     parsers/qasm3_parser/passes/ConstEvalPass.cpp
     parsers/qasm3_parser/passes/TypeCheckPass.cpp
     QuantumComputation.cpp)

--- a/src/operations/ClassicControlledOperation.cpp
+++ b/src/operations/ClassicControlledOperation.cpp
@@ -2,28 +2,32 @@
 
 namespace qc {
 
-std::ostream& operator<<(std::ostream& os, const ComparisonKind& kind) {
+std::string toString(const ComparisonKind& kind) {
   switch (kind) {
   case ComparisonKind::Eq:
-    os << "==";
-    break;
+    return "==";
   case ComparisonKind::Neq:
-    os << "!=";
-    break;
+    return "!=";
   case ComparisonKind::Lt:
-    os << "<";
-    break;
+    return "<";
   case ComparisonKind::Leq:
-    os << "<=";
-    break;
+    return "<=";
   case ComparisonKind::Gt:
-    os << ">";
-    break;
+    return ">";
   case ComparisonKind::Geq:
-    os << ">=";
-    break;
+    return ">=";
+  default:
+#if defined(__GNUC__) || defined(__clang__)
+    __builtin_unreachable();
+#elif defined(_MSC_VER)
+    __assume(0);
+#else
+#endif
   }
+}
 
+std::ostream& operator<<(std::ostream& os, const ComparisonKind& kind) {
+  os << toString(kind);
   return os;
 }
 

--- a/src/operations/ClassicControlledOperation.cpp
+++ b/src/operations/ClassicControlledOperation.cpp
@@ -17,12 +17,7 @@ std::string toString(const ComparisonKind& kind) {
   case ComparisonKind::Geq:
     return ">=";
   default:
-#if defined(__GNUC__) || defined(__clang__)
-    __builtin_unreachable();
-#elif defined(_MSC_VER)
-    __assume(0);
-#else
-#endif
+    unreachable();
   }
 }
 
@@ -46,12 +41,7 @@ ComparisonKind getInvertedComparsionKind(const ComparisonKind kind) {
   case Neq:
     return Eq;
   default:
-#if defined(__GNUC__) || defined(__clang__)
-    __builtin_unreachable();
-#elif defined(_MSC_VER)
-    __assume(0);
-#else
-#endif
+    unreachable();
   }
 }
 } // namespace qc

--- a/src/operations/ClassicControlledOperation.cpp
+++ b/src/operations/ClassicControlledOperation.cpp
@@ -26,4 +26,28 @@ std::ostream& operator<<(std::ostream& os, const ComparisonKind& kind) {
 
   return os;
 }
+
+ComparisonKind getInvertedComparsionKind(const ComparisonKind kind) {
+  switch (kind) {
+  case Lt:
+    return Geq;
+  case Leq:
+    return Gt;
+  case Gt:
+    return Leq;
+  case Geq:
+    return Lt;
+  case Eq:
+    return Neq;
+  case Neq:
+    return Eq;
+  default:
+#if defined(__GNUC__) || defined(__clang__)
+    __builtin_unreachable();
+#elif defined(_MSC_VER)
+    __assume(0);
+#else
+#endif
+  }
+}
 } // namespace qc

--- a/src/parsers/QASM3Parser.cpp
+++ b/src/parsers/QASM3Parser.cpp
@@ -342,7 +342,7 @@ public:
                    const std::string& identifier,
                    const std::vector<std::shared_ptr<Expression>>& parameters,
                    std::vector<std::shared_ptr<GateOperand>> targets,
-                   qc::QuantumRegisterMap& qregs) {
+                   const qc::QuantumRegisterMap& qregs) {
     auto iter = gates.find(identifier);
     std::shared_ptr<Gate> gate;
     size_t implicitControls{0};
@@ -773,7 +773,7 @@ public:
         error("Only quantum statements are supported in blocks.",
               statement->debugInfo);
       }
-      auto qregs = qc->getQregs();
+      const auto& qregs = qc->getQregs();
 
       auto op =
           evaluateGateCall(gateCall, gateCall->identifier, gateCall->arguments,

--- a/src/parsers/QASM3Parser.cpp
+++ b/src/parsers/QASM3Parser.cpp
@@ -725,36 +725,11 @@ public:
             ifStatement->debugInfo);
     }
 
-    qc::ComparisonKind comparisonKind = qc::ComparisonKind::Eq;
-    qc::ComparisonKind flippedComparisonKind = qc::ComparisonKind::Eq;
-    switch (condition->op) {
-    case BinaryExpression::Op::LessThan:
-      comparisonKind = qc::ComparisonKind::Lt;
-      flippedComparisonKind = qc::ComparisonKind::Geq;
-      break;
-    case BinaryExpression::Op::LessThanOrEqual:
-      comparisonKind = qc::ComparisonKind::Leq;
-      flippedComparisonKind = qc::ComparisonKind::Gt;
-      break;
-    case BinaryExpression::Op::GreaterThan:
-      comparisonKind = qc::ComparisonKind::Gt;
-      flippedComparisonKind = qc::ComparisonKind::Leq;
-      break;
-    case BinaryExpression::Op::GreaterThanOrEqual:
-      comparisonKind = qc::ComparisonKind::Geq;
-      flippedComparisonKind = qc::ComparisonKind::Lt;
-      break;
-    case BinaryExpression::Op::Equal:
-      comparisonKind = qc::ComparisonKind::Eq;
-      flippedComparisonKind = qc::ComparisonKind::Neq;
-      break;
-    case BinaryExpression::Op::NotEqual:
-      comparisonKind = qc::ComparisonKind::Neq;
-      flippedComparisonKind = qc::ComparisonKind::Eq;
-      break;
-    default:
+    const auto comparisonKind = getComparisonKind(condition->op);
+    if (!comparisonKind) {
       error("Unsupported comparison operator.", ifStatement->debugInfo);
     }
+    qc::ComparisonKind flippedComparisonKind = qc::getInvertedComparsionKind(*comparisonKind);
 
     const auto lhs =
         std::dynamic_pointer_cast<IdentifierExpression>(condition->lhs);
@@ -779,7 +754,7 @@ public:
     if (!ifStatement->thenStatements.empty()) {
       auto thenOps = translateBlockOperations(ifStatement->thenStatements);
       qc->emplace_back(std::make_unique<qc::ClassicControlledOperation>(
-          thenOps, creg->second, rhs->getUInt(), comparisonKind));
+          thenOps, creg->second, rhs->getUInt(), *comparisonKind));
     }
     if (!ifStatement->elseStatements.empty()) {
       auto elseOps = translateBlockOperations(ifStatement->elseStatements);

--- a/src/parsers/QASM3Parser.cpp
+++ b/src/parsers/QASM3Parser.cpp
@@ -729,7 +729,8 @@ public:
     if (!comparisonKind) {
       error("Unsupported comparison operator.", ifStatement->debugInfo);
     }
-    qc::ComparisonKind flippedComparisonKind = qc::getInvertedComparsionKind(*comparisonKind);
+    qc::ComparisonKind flippedComparisonKind =
+        qc::getInvertedComparsionKind(*comparisonKind);
 
     const auto lhs =
         std::dynamic_pointer_cast<IdentifierExpression>(condition->lhs);

--- a/src/parsers/QASM3Parser.cpp
+++ b/src/parsers/QASM3Parser.cpp
@@ -766,7 +766,7 @@ public:
 
   [[nodiscard]] std::unique_ptr<qc::Operation> translateBlockOperations(
       const std::vector<std::shared_ptr<Statement>>& statements) {
-    auto thenOps = std::make_unique<qc::CompoundOperation>(qc->getNqubits());
+    auto blockOps = std::make_unique<qc::CompoundOperation>(qc->getNqubits());
     for (const auto& statement : statements) {
       auto gateCall = std::dynamic_pointer_cast<GateCallStatement>(statement);
       if (gateCall == nullptr) {
@@ -779,10 +779,10 @@ public:
           evaluateGateCall(gateCall, gateCall->identifier, gateCall->arguments,
                            gateCall->operands, qregs);
 
-      thenOps->emplace_back(std::move(op));
+      blockOps->emplace_back(std::move(op));
     }
 
-    return thenOps;
+    return blockOps;
   }
 
   [[nodiscard]] std::unique_ptr<qc::Operation>

--- a/src/parsers/QASM3Parser.cpp
+++ b/src/parsers/QASM3Parser.cpp
@@ -729,8 +729,6 @@ public:
     if (!comparisonKind) {
       error("Unsupported comparison operator.", ifStatement->debugInfo);
     }
-    qc::ComparisonKind flippedComparisonKind =
-        qc::getInvertedComparsionKind(*comparisonKind);
 
     const auto lhs =
         std::dynamic_pointer_cast<IdentifierExpression>(condition->lhs);
@@ -758,9 +756,11 @@ public:
           thenOps, creg->second, rhs->getUInt(), *comparisonKind));
     }
     if (!ifStatement->elseStatements.empty()) {
+      const auto invertedComparsionKind =
+          qc::getInvertedComparsionKind(*comparisonKind);
       auto elseOps = translateBlockOperations(ifStatement->elseStatements);
       qc->emplace_back(std::make_unique<qc::ClassicControlledOperation>(
-          elseOps, creg->second, rhs->getUInt(), flippedComparisonKind));
+          elseOps, creg->second, rhs->getUInt(), invertedComparsionKind));
     }
   }
 

--- a/src/parsers/qasm3_parser/Statement.cpp
+++ b/src/parsers/qasm3_parser/Statement.cpp
@@ -1,0 +1,23 @@
+#include "parsers/qasm3_parser/Statement.hpp"
+
+namespace qasm3 {
+
+std::optional<qc::ComparisonKind> getComparisonKind(BinaryExpression::Op op) {
+  switch (op) {
+  case BinaryExpression::Op::LessThan:
+    return qc::ComparisonKind::Lt;
+  case BinaryExpression::Op::LessThanOrEqual:
+    return qc::ComparisonKind::Leq;
+  case BinaryExpression::Op::GreaterThan:
+    return qc::ComparisonKind::Gt;
+  case BinaryExpression::Op::GreaterThanOrEqual:
+    return qc::ComparisonKind::Geq;
+  case BinaryExpression::Op::Equal:
+    return qc::ComparisonKind::Eq;
+  case BinaryExpression::Op::NotEqual:
+    return qc::ComparisonKind::Neq;
+  default:
+    return std::nullopt;
+  }
+}
+} // namespace qasm3

--- a/src/parsers/qasm3_parser/passes/ConstEvalPass.cpp
+++ b/src/parsers/qasm3_parser/passes/ConstEvalPass.cpp
@@ -333,8 +333,7 @@ std::optional<ConstEvalValue> ConstEvalPass::visitBinaryExpression(
     rhsVal->type = ConstEvalValue::Type::ConstInt;
   } else if (lhsVal->type == ConstEvalValue::Type::ConstUint &&
              rhsVal->type == ConstEvalValue::Type::ConstFloat) {
-    lhsVal->value =
-        static_cast<double>(std::get<0>(lhsVal->value));
+    lhsVal->value = static_cast<double>(std::get<0>(lhsVal->value));
     lhsVal->type = ConstEvalValue::Type::ConstFloat;
   } else if (lhsVal->type == ConstEvalValue::Type::ConstInt &&
              rhsVal->type == ConstEvalValue::Type::ConstFloat) {

--- a/src/parsers/qasm3_parser/passes/ConstEvalPass.cpp
+++ b/src/parsers/qasm3_parser/passes/ConstEvalPass.cpp
@@ -331,11 +331,8 @@ std::optional<ConstEvalValue> ConstEvalPass::visitBinaryExpression(
        rhsVal->type == ConstEvalValue::Type::ConstInt)) {
     lhsVal->type = ConstEvalValue::Type::ConstInt;
     rhsVal->type = ConstEvalValue::Type::ConstInt;
-  } else if (lhsVal->type == ConstEvalValue::Type::ConstUint &&
-             rhsVal->type == ConstEvalValue::Type::ConstFloat) {
-    lhsVal->value = static_cast<double>(std::get<0>(lhsVal->value));
-    lhsVal->type = ConstEvalValue::Type::ConstFloat;
-  } else if (lhsVal->type == ConstEvalValue::Type::ConstInt &&
+  } else if ((lhsVal->type == ConstEvalValue::Type::ConstUint ||
+              lhsVal->type == ConstEvalValue::Type::ConstInt) &&
              rhsVal->type == ConstEvalValue::Type::ConstFloat) {
     lhsVal->value = static_cast<double>(std::get<0>(lhsVal->value));
     lhsVal->type = ConstEvalValue::Type::ConstFloat;

--- a/test/unittests/test_qasm3_parser.cpp
+++ b/test/unittests/test_qasm3_parser.cpp
@@ -502,6 +502,29 @@ TEST_F(Qasm3ParserTest, ImportQasm3IfElseNoBlock) {
   EXPECT_EQ(out.str(), expected);
 }
 
+TEST_F(Qasm3ParserTest, ImportQasm3InvalidStatementInBlock) {
+  std::stringstream ss{};
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit q;\n"
+                               "bit c = measure q;\n"
+                               "if (c == 1) {\n"
+                               "  qubit invalid;\n"
+                               "}";
+
+  ss << testfile;
+  auto qc = QuantumComputation();
+  EXPECT_THROW(
+      try {
+        qc.import(ss, Format::OpenQASM3);
+      } catch (const qasm3::CompilerError& e) {
+        EXPECT_EQ(e.message,
+                  "Only quantum statements are supported in blocks.");
+        throw;
+      },
+      qasm3::CompilerError);
+}
+
 TEST_F(Qasm3ParserTest, ImportQasm3ImplicitInclude) {
   std::stringstream ss{};
   const std::string testfile = "qubit q;\n"

--- a/test/unittests/test_qasm3_parser.cpp
+++ b/test/unittests/test_qasm3_parser.cpp
@@ -381,6 +381,114 @@ TEST_F(Qasm3ParserTest, ImportQasm3IfStatement) {
   EXPECT_EQ(out.str(), expected);
 }
 
+TEST_F(Qasm3ParserTest, ImportQasm3IfElseStatement) {
+  std::stringstream ss{};
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[2] q;\n"
+                               "h q[0];\n"
+                               "bit c = measure q[0];\n"
+                               "if (c == 1) {\n"
+                               "  x q[1];\n"
+                               "} else {\n"
+                               "  x q[0];\n"
+                               "  x q[1];\n"
+                               "}";
+
+  ss << testfile;
+  auto qc = QuantumComputation();
+  qc.import(ss, Format::OpenQASM3);
+
+  std::stringstream out{};
+  qc.dump(out, Format::OpenQASM3);
+
+  const std::string expected = "// i 0 1\n"
+                               "// o 0\n"
+                               "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[2] q;\n"
+                               "bit[1] c;\n"
+                               "h q[0];\n"
+                               "c[0] = measure q[0];\n"
+                               "if (c == 1) {\n"
+                               "  x q[1];\n"
+                               "}\n"
+                               "if (c != 1) {\n"
+                               "  x q[0];\n"
+                               "  x q[1];\n"
+                               "}\n"
+                               "";
+
+  EXPECT_EQ(out.str(), expected);
+}
+
+TEST_F(Qasm3ParserTest, ImportQasm3EmptyIfElse) {
+  std::stringstream ss{};
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[2] q;\n"
+                               "h q[0];\n"
+                               "bit c = measure q[0];\n"
+                               "if (c == 1) {\n"
+                               "} else {\n"
+                               "}";
+
+  ss << testfile;
+  auto qc = QuantumComputation();
+  qc.import(ss, Format::OpenQASM3);
+
+  std::stringstream out{};
+  qc.dump(out, Format::OpenQASM3);
+
+  const std::string expected = "// i 0 1\n"
+                               "// o 0\n"
+                               "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[2] q;\n"
+                               "bit[1] c;\n"
+                               "h q[0];\n"
+                               "c[0] = measure q[0];\n"
+                               "";
+
+  EXPECT_EQ(out.str(), expected);
+}
+
+TEST_F(Qasm3ParserTest, ImportQasm3IfElseNoBlock) {
+  std::stringstream ss{};
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[2] q;\n"
+                               "h q[0];\n"
+                               "bit c = measure q[0];\n"
+                               "if (c == 1) {} else \n"
+                               "  x q[1];\n"
+                               "x q[0];\n"
+                               "";
+
+  ss << testfile;
+  auto qc = QuantumComputation();
+  qc.import(ss, Format::OpenQASM3);
+
+  std::stringstream out{};
+  qc.dump(out, Format::OpenQASM3);
+
+  const std::string expected = "// i 0 1\n"
+                               "// o 0\n"
+                               "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[2] q;\n"
+                               "bit[1] c;\n"
+                               "h q[0];\n"
+                               "c[0] = measure q[0];\n"
+                               "if (c != 1) {\n"
+                               "  x q[1];\n"
+                               "}\n"
+                               "x q[0];\n"
+                               "";
+
+  EXPECT_EQ(out.str(), expected);
+}
+
 TEST_F(Qasm3ParserTest, ImportQasm3ImplicitInclude) {
   std::stringstream ss{};
   const std::string testfile = "qubit q;\n"


### PR DESCRIPTION
## Description

This PR adds support for the `else` branch in `if` statements when parsing OpenQASM 3.0.

Example:

```qasm
if (c == 1) {
  x q[1];
} else {
  x q[0];
  x q[1];
}
```

This is implemented by adding a second ClassicalControlledOperation to the Quantum Computation with a flipped condition.
When dumping the circuit above, the following is printed:

```qasm
if (c == 1) {
  x q[1];
}
if (c != 1) {
  x q[0];
  x q[1];
}
```

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
