### PR TITLE
🩹 properly reset tolerance in test

### DIFF
--- a/src/parsers/qasm3_parser/passes/ConstEvalPass.cpp
+++ b/src/parsers/qasm3_parser/passes/ConstEvalPass.cpp
@@ -333,8 +333,7 @@ std::optional<ConstEvalValue> ConstEvalPass::visitBinaryExpression(
     rhsVal->type = ConstEvalValue::Type::ConstInt;
   } else if (lhsVal->type == ConstEvalValue::Type::ConstUint &&
              rhsVal->type == ConstEvalValue::Type::ConstFloat) {
-    lhsVal->value =
-        static_cast<double>(std::get<0>(lhsVal->value));
+    lhsVal->value = static_cast<double>(std::get<0>(lhsVal->value));
     lhsVal->type = ConstEvalValue::Type::ConstFloat;
   } else if (lhsVal->type == ConstEvalValue::Type::ConstInt &&
              rhsVal->type == ConstEvalValue::Type::ConstFloat) {

--- a/src/parsers/qasm3_parser/passes/ConstEvalPass.cpp
+++ b/src/parsers/qasm3_parser/passes/ConstEvalPass.cpp
@@ -331,11 +331,8 @@ std::optional<ConstEvalValue> ConstEvalPass::visitBinaryExpression(
        rhsVal->type == ConstEvalValue::Type::ConstInt)) {
     lhsVal->type = ConstEvalValue::Type::ConstInt;
     rhsVal->type = ConstEvalValue::Type::ConstInt;
-  } else if (lhsVal->type == ConstEvalValue::Type::ConstUint &&
-             rhsVal->type == ConstEvalValue::Type::ConstFloat) {
-    lhsVal->value = static_cast<double>(std::get<0>(lhsVal->value));
-    lhsVal->type = ConstEvalValue::Type::ConstFloat;
-  } else if (lhsVal->type == ConstEvalValue::Type::ConstInt &&
+  } else if ((lhsVal->type == ConstEvalValue::Type::ConstUint ||
+              lhsVal->type == ConstEvalValue::Type::ConstInt) &&
              rhsVal->type == ConstEvalValue::Type::ConstFloat) {
     lhsVal->value = static_cast<double>(std::get<0>(lhsVal->value));
     lhsVal->type = ConstEvalValue::Type::ConstFloat;

--- a/test/algorithms/test_wstate.cpp
+++ b/test/algorithms/test_wstate.cpp
@@ -52,6 +52,7 @@ TEST_P(WState, RoutineFunctionTest) {
 
 TEST(WState, WStateEdgeCasesTest) {
   auto dd = std::make_unique<dd::Package<>>(101);
+  const auto tolerance = dd::RealNumber::eps;
   dd::ComplexNumbers::setTolerance(0.1);
 
   ASSERT_THROW(dd->makeWState(101), std::runtime_error);
@@ -59,4 +60,5 @@ TEST(WState, WStateEdgeCasesTest) {
   EXPECT_EQ(dd->makeWState(0), dd->makeBasisState(0, {dd::BasisStates::one}));
   EXPECT_EQ(dd->makeWState(1), dd->makeBasisState(1, {dd::BasisStates::one}));
   ASSERT_THROW(dd->makeWState(127), std::runtime_error);
+  dd::ComplexNumbers::setTolerance(tolerance);
 }


### PR DESCRIPTION
## Description

One of the recently introduced tests (in #445) adjusted the DD package tolerance to trigger a potential error.
However, that test did not restore the tolerance to its prior setting.
At least locally, this has led to quite some strange errors of subsequent tests failing.
I am kind of puzzled that this hasn't led to any CI failures.
Anyway, this PR fixes the underlying issue by properly resetting the tolerance to its original value.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
