### PR TITLE
⚡ Improved accuracy in complex number arithmetic

### DIFF
--- a/include/dd/Complex.hpp
+++ b/include/dd/Complex.hpp
@@ -78,15 +78,6 @@ struct Complex {
   [[nodiscard]] bool approximatelyZero() const noexcept;
 
   /**
-   * @brief Check whether the complex number is approximately equal to one.
-   * @returns True if the complex number is approximately equal to one, false
-   * otherwise.
-   * @see RealNumber::approximatelyOne
-   * @see RealNumber::approximatelyZero
-   */
-  [[nodiscard]] bool approximatelyOne() const noexcept;
-
-  /**
    * @brief Convert the complex number to a string.
    * @param formatted Whether to apply special formatting to the numbers.
    * @param precision The precision to use for the numbers.

--- a/include/dd/ComplexNumbers.hpp
+++ b/include/dd/ComplexNumbers.hpp
@@ -2,6 +2,7 @@
 
 #include "dd/Complex.hpp"
 #include "dd/DDDefinitions.hpp"
+#include "dd/Node.hpp"
 #include "dd/RealNumberUniqueTable.hpp"
 
 namespace dd {
@@ -95,6 +96,22 @@ public:
    * @see ComplexTable::lookup
    */
   [[nodiscard]] Complex lookup(fp r, fp i);
+
+  /**
+   * @brief Turn CachedEdge into Edge via lookup.
+   * @tparam Node The type of the node.
+   * @param ce The cached edge.
+   * @return The edge with looked-up weight. The zero terminal if the new weight
+   * is exactly zero.
+   */
+  template <class Node>
+  [[nodiscard]] Edge<Node> lookup(const CachedEdge<Node>& ce) {
+    auto e = Edge<Node>{ce.p, lookup(ce.w)};
+    if (e.w.exactlyZero()) {
+      e.p = Node::getTerminal();
+    }
+    return e;
+  }
 
   /**
    * @brief Increment the reference count of a complex number.

--- a/include/dd/ComplexValue.hpp
+++ b/include/dd/ComplexValue.hpp
@@ -60,15 +60,6 @@ struct ComplexValue {
   [[nodiscard]] bool approximatelyZero() const noexcept;
 
   /**
-   * @brief Check whether the complex number is approximately equal to one.
-   * @returns True if the complex number is approximately equal to one, false
-   * otherwise.
-   * @see RealNumber::approximatelyOne
-   * @see RealNumber::approximatelyZero
-   */
-  [[nodiscard]] bool approximatelyOne() const noexcept;
-
-  /**
    * @brief Write a binary representation of the complex number to the given
    * output stream.
    * @param os The output stream to write to.

--- a/include/dd/ComputeTable.hpp
+++ b/include/dd/ComputeTable.hpp
@@ -36,8 +36,20 @@ public:
 
   static std::size_t hash(const LeftOperandType& leftOperand,
                           const RightOperandType& rightOperand) {
-    const auto h1 = std::hash<LeftOperandType>{}(leftOperand);
-    const auto h2 = std::hash<RightOperandType>{}(rightOperand);
+    auto h1 = std::hash<LeftOperandType>{}(leftOperand);
+    if constexpr (std::is_same_v<LeftOperandType, dNode*>) {
+      if (!dNode::isTerminal(leftOperand)) {
+        h1 = qc::combineHash(
+            h1, dd::dNode::getDensityMatrixTempFlags(leftOperand->flags));
+      }
+    }
+    auto h2 = std::hash<RightOperandType>{}(rightOperand);
+    if constexpr (std::is_same_v<RightOperandType, dNode*>) {
+      if (!dNode::isTerminal(rightOperand)) {
+        h2 = qc::combineHash(
+            h2, dd::dNode::getDensityMatrixTempFlags(rightOperand->flags));
+      }
+    }
     const auto hash = qc::combineHash(h1, h2);
     return hash & MASK;
   }

--- a/include/dd/Export.hpp
+++ b/include/dd/Export.hpp
@@ -122,7 +122,7 @@ inline std::string conditionalFormat(const Complex& a,
 
   std::ostringstream ss{};
   // magnitude is (almost) 1
-  if (RealNumber::approximatelyOne(mag)) {
+  if (RealNumber::approximatelyEquals(mag, 1.)) {
     if (RealNumber::approximatelyZero(phase)) {
       return "1";
     }
@@ -173,7 +173,7 @@ static std::ostream& header(const Edge<Node>& e, std::ostream& os,
   }
   os << "[penwidth=\"" << thicknessFromMagnitude(e.w) << "\",tooltip=\""
      << conditionalFormat(e.w, formatAsPolar) << "\"";
-  if (!e.w.approximatelyOne()) {
+  if (!e.w.exactlyOne()) {
     os << ",style=dashed";
   }
   if (edgeLabels) {
@@ -479,7 +479,7 @@ bwEdge(const mEdge& from, const mEdge& to, std::uint16_t idx, std::ostream& os,
   auto mag = thicknessFromMagnitude(to.w);
   os << "[penwidth=\"" << mag << "\",tooltip=\""
      << conditionalFormat(to.w, formatAsPolar) << "\"";
-  if (!to.w.approximatelyOne()) {
+  if (!to.w.exactlyOne()) {
     os << ",style=dashed";
   }
   if (edgeLabels) {
@@ -509,7 +509,7 @@ bwEdge(const vEdge& from, const vEdge& to, std::uint16_t idx, std::ostream& os,
   auto mag = thicknessFromMagnitude(to.w);
   os << "[penwidth=\"" << mag << "\",tooltip=\""
      << conditionalFormat(to.w, formatAsPolar) << "\"";
-  if (!to.w.approximatelyOne()) {
+  if (!to.w.exactlyOne()) {
     os << ",style=dashed";
   }
   if (edgeLabels) {

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1337,7 +1337,7 @@ public:
     }
 
     const auto result = add2(CachedEdge{x.p, x.w}, {y.p, y.w}, var);
-    return {result.p, cn.lookup(result.w)};
+    return cn.lookup(result);
   }
 
   template <class Node>
@@ -1515,7 +1515,7 @@ public:
 
       const auto e = multiply2(xCopy, yCopy, var, start, generateDensityMatrix);
       dEdge::revertDmChangesToEdges(xCopy, yCopy);
-      return {e.p, cn.lookup(e.w)};
+      return cn.lookup(e);
     } else {
       if (!x.isTerminal()) {
         var = x.p->v;
@@ -1524,7 +1524,7 @@ public:
         var = y.p->v;
       }
       const auto e = multiply2(x, y, var, start);
-      return {e.p, cn.lookup(e.w)};
+      return cn.lookup(e);
     }
   }
 
@@ -1833,8 +1833,8 @@ public:
           "Kronecker is currently not supported for density matrices");
     }
 
-    auto e = kronecker2(x, y, incIdx);
-    return {e.p, cn.lookup(e.w)};
+    const auto e = kronecker2(x, y, incIdx);
+    return cn.lookup(e);
   }
 
   // extent the DD pointed to by `e` with `h` identities on top and `l`
@@ -1910,7 +1910,7 @@ private:
 public:
   mEdge partialTrace(const mEdge& a, const std::vector<bool>& eliminate) {
     auto r = trace(a, eliminate);
-    return {r.p, cn.lookup(r.w)};
+    return cn.lookup(r);
   }
   ComplexValue trace(const mEdge& a) {
     const auto eliminate = std::vector<bool>(nqubits, true);

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1354,17 +1354,11 @@ public:
     }
     if (x.p == y.p) {
       const auto rWeight = x.w + y.w;
-      if (rWeight.approximatelyZero()) {
-        return CachedEdge<Node>::zero();
-      }
       return {x.p, rWeight};
     }
 
     auto& computeTable = getAddComputeTable<Node>();
     if (const auto* r = computeTable.lookup(x, y); r != nullptr) {
-      if (r->w.approximatelyZero()) {
-        return CachedEdge<Node>::zero();
-      }
       return *r;
     }
 
@@ -1561,14 +1555,7 @@ private:
     auto& computeTable = getMultiplicationComputeTable<RightOperandNode>();
     if (const auto* r = computeTable.lookup(x.p, y.p, generateDensityMatrix);
         r != nullptr) {
-      if (r->w.approximatelyZero()) {
-        return ResultEdge::zero();
-      }
-      const auto w = r->w * rWeight;
-      if (w.approximatelyZero()) {
-        return ResultEdge::zero();
-      }
-      return {r->p, w};
+      return {r->p, r->w * rWeight};
     }
 
     constexpr std::size_t n = std::tuple_size_v<decltype(y.p->e)>;
@@ -1639,13 +1626,7 @@ private:
     auto e = makeDDNode(var, edge, generateDensityMatrix);
     computeTable.insert(x.p, y.p, e);
 
-    if (e.w.approximatelyZero()) {
-      return ResultEdge::zero();
-    }
     e.w = e.w * rWeight;
-    if (e.w.approximatelyZero()) {
-      return ResultEdge::zero();
-    }
     return e;
   }
 

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1568,9 +1568,7 @@ private:
       if (r->w.approximatelyZero()) {
         return ResultEdge::zero();
       }
-      auto w = r->w;
-      w = w * xWeight;
-      w = w * yWeight;
+      const auto w = r->w * rWeight;
       if (w.approximatelyZero()) {
         return ResultEdge::zero();
       }
@@ -1648,8 +1646,7 @@ private:
     if (e.w.approximatelyZero()) {
       return ResultEdge::zero();
     }
-    e.w = e.w * xWeight;
-    e.w = e.w * yWeight;
+    e.w = e.w * rWeight;
     if (e.w.approximatelyZero()) {
       return ResultEdge::zero();
     }

--- a/include/dd/RealNumber.hpp
+++ b/include/dd/RealNumber.hpp
@@ -99,21 +99,6 @@ struct RealNumber {
   [[nodiscard]] static bool approximatelyZero(const RealNumber* e) noexcept;
 
   /**
-   * @brief Check whether a floating point number is approximately one.
-   * @param e The floating point number to check.
-   * @returns Whether the floating point number is approximately one.
-   */
-  [[nodiscard]] static bool approximatelyOne(fp e) noexcept;
-
-  /**
-   * @brief Check whether a number is approximately one.
-   * @param e The number to check.
-   * @returns Whether the number is approximately one.
-   * @see approximatelyOne(fp)
-   */
-  [[nodiscard]] static bool approximatelyOne(const RealNumber* e) noexcept;
-
-  /**
    * @brief Indicates whether a given number needs reference count updates.
    * @details This function checks whether a given number needs reference count
    * updates. A number needs reference count updates if the pointer to it is

--- a/src/dd/Complex.cpp
+++ b/src/dd/Complex.cpp
@@ -18,10 +18,6 @@ bool Complex::approximatelyZero() const noexcept {
   return RealNumber::approximatelyZero(r) && RealNumber::approximatelyZero(i);
 }
 
-bool Complex::approximatelyOne() const noexcept {
-  return RealNumber::approximatelyOne(r) && RealNumber::approximatelyZero(i);
-}
-
 std::string Complex::toString(bool formatted, int precision) const {
   return ComplexValue::toString(RealNumber::val(r), RealNumber::val(i),
                                 formatted, precision);

--- a/src/dd/ComplexValue.cpp
+++ b/src/dd/ComplexValue.cpp
@@ -239,15 +239,6 @@ ComplexValue operator*(fp r, const ComplexValue& c1) {
 }
 
 ComplexValue operator*(const ComplexValue& c1, const ComplexValue& c2) {
-  if (c1.approximatelyOne()) {
-    return c2;
-  }
-  if (c2.approximatelyOne()) {
-    return c1;
-  }
-  if (c1.approximatelyZero() || c2.approximatelyZero()) {
-    return {0., 0.};
-  }
   return {c1.r * c2.r - c1.i * c2.i, c1.r * c2.i + c1.i * c2.r};
 }
 
@@ -256,12 +247,6 @@ ComplexValue operator/(const ComplexValue& c1, fp r) {
 }
 
 ComplexValue operator/(const ComplexValue& c1, const ComplexValue& c2) {
-  if (c2.approximatelyOne()) {
-    return c1;
-  }
-  if (c1.approximatelyEquals(c2)) {
-    return {1., 0.};
-  }
   const auto denom = c2.r * c2.r + c2.i * c2.i;
   return {(c1.r * c2.r + c1.i * c2.i) / denom,
           (c1.i * c2.r - c1.r * c2.i) / denom};

--- a/src/dd/ComplexValue.cpp
+++ b/src/dd/ComplexValue.cpp
@@ -31,10 +31,6 @@ bool ComplexValue::approximatelyZero() const noexcept {
   return RealNumber::approximatelyZero(r) && RealNumber::approximatelyZero(i);
 }
 
-bool ComplexValue::approximatelyOne() const noexcept {
-  return RealNumber::approximatelyOne(r) && RealNumber::approximatelyZero(i);
-}
-
 void ComplexValue::writeBinary(std::ostream& os) const {
   RealNumber::writeBinary(r, os);
   RealNumber::writeBinary(i, os);

--- a/src/dd/RealNumber.cpp
+++ b/src/dd/RealNumber.cpp
@@ -61,14 +61,6 @@ bool RealNumber::approximatelyZero(const RealNumber* e) noexcept {
   return e == &constants::zero || approximatelyZero(val(e));
 }
 
-bool RealNumber::approximatelyOne(const fp e) noexcept {
-  return approximatelyEquals(e, 1.0);
-}
-
-bool RealNumber::approximatelyOne(const RealNumber* e) noexcept {
-  return e == &constants::one || approximatelyOne(val(e));
-}
-
 bool RealNumber::noRefCountingNeeded(const RealNumber* const num) noexcept {
   assert(!isNegativePointer(num));
   return num == nullptr || constants::isStaticNumber(num) ||

--- a/src/dd/RealNumberUniqueTable.cpp
+++ b/src/dd/RealNumberUniqueTable.cpp
@@ -56,7 +56,7 @@ RealNumber* RealNumberUniqueTable::lookupNonNegative(const fp val) {
   assert(!std::isnan(val));
   assert(val > 0);
 
-  if (RealNumber::approximatelyOne(val)) {
+  if (RealNumber::approximatelyEquals(val, 1.0)) {
     return &constants::one;
   }
 

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -268,7 +268,7 @@ void extractProbabilityVectorRecursive(const QuantumComputation* qc,
       pzero /= norm;
       pone /= norm;
 
-      if (RealNumber::approximatelyOne(pone)) {
+      if (RealNumber::approximatelyEquals(pone, 1.)) {
         const qc::MatrixDD xGate =
             dd->makeGateDD(X_MAT, static_cast<std::size_t>(state.p->v) + 1U,
                            static_cast<Qubit>(targets[0U]));
@@ -279,7 +279,7 @@ void extractProbabilityVectorRecursive(const QuantumComputation* qc,
         continue;
       }
 
-      if (!RealNumber::approximatelyOne(pzero)) {
+      if (!RealNumber::approximatelyEquals(pzero, 1.)) {
         throw qc::QFRException("Reset on non basis state encountered. This is "
                                "not supported in this method.");
       }

--- a/test/dd/test_dd_functionality.cpp
+++ b/test/dd/test_dd_functionality.cpp
@@ -249,18 +249,18 @@ TEST_F(DDFunctionality, changePermutation) {
   qc.import(ss, qc::Format::OpenQASM);
   auto sim = simulate(&qc, dd->makeZeroState(qc.getNqubits()), dd);
   EXPECT_TRUE(sim.p->e[0].isZeroTerminal());
-  EXPECT_TRUE(sim.p->e[1].w.approximatelyOne());
+  EXPECT_TRUE(sim.p->e[1].w.exactlyOne());
   EXPECT_TRUE(sim.p->e[1].p->e[1].isZeroTerminal());
-  EXPECT_TRUE(sim.p->e[1].p->e[0].w.approximatelyOne());
+  EXPECT_TRUE(sim.p->e[1].p->e[0].w.exactlyOne());
   auto func = buildFunctionality(&qc, dd);
   EXPECT_FALSE(func.p->e[0].isZeroTerminal());
   EXPECT_FALSE(func.p->e[1].isZeroTerminal());
   EXPECT_FALSE(func.p->e[2].isZeroTerminal());
   EXPECT_FALSE(func.p->e[3].isZeroTerminal());
-  EXPECT_TRUE(func.p->e[0].p->e[1].w.approximatelyOne());
-  EXPECT_TRUE(func.p->e[1].p->e[3].w.approximatelyOne());
-  EXPECT_TRUE(func.p->e[2].p->e[0].w.approximatelyOne());
-  EXPECT_TRUE(func.p->e[3].p->e[2].w.approximatelyOne());
+  EXPECT_TRUE(func.p->e[0].p->e[1].w.exactlyOne());
+  EXPECT_TRUE(func.p->e[1].p->e[3].w.exactlyOne());
+  EXPECT_TRUE(func.p->e[2].p->e[0].w.exactlyOne());
+  EXPECT_TRUE(func.p->e[3].p->e[2].w.exactlyOne());
 }
 
 TEST_F(DDFunctionality, basicTensorDumpTest) {

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -1270,9 +1270,8 @@ TEST(DDPackageTest, dNodeMulCache1) {
   const auto& densityMatrix0 =
       dd::densityFromMatrixEdge(dd->conjugateTranspose(operation));
 
-  const auto xCopy = dd::dEdge{state.p, dd::Complex::one()};
-  const auto yCopy = dd::dEdge{densityMatrix0.p, dd::Complex::one()};
-  const auto* cachedResult = computeTable.lookup(xCopy, yCopy, false);
+  const auto* cachedResult =
+      computeTable.lookup(state.p, densityMatrix0.p, false);
   ASSERT_NE(cachedResult, nullptr);
   ASSERT_NE(cachedResult->p, nullptr);
   state = dd->multiply(state, densityMatrix0, 0, false);
@@ -1280,23 +1279,24 @@ TEST(DDPackageTest, dNodeMulCache1) {
   ASSERT_EQ(state.p, cachedResult->p);
 
   const auto densityMatrix1 = dd::densityFromMatrixEdge(operation);
-  const auto xCopy1 = dd::dEdge{densityMatrix1.p, dd::Complex::one()};
-  const auto yCopy1 = dd::dEdge{state.p, dd::Complex::one()};
-  const auto* cachedResult1 = computeTable.lookup(xCopy1, yCopy1, true);
+  const auto* cachedResult1 =
+      computeTable.lookup(densityMatrix1.p, state.p, true);
   ASSERT_NE(cachedResult1, nullptr);
   ASSERT_NE(cachedResult1->p, nullptr);
-  state = dd->multiply(densityMatrix1, state, 0, true);
-  ASSERT_NE(state.p, nullptr);
-  ASSERT_EQ(state.p, cachedResult1->p);
+  const auto state2 = dd->multiply(densityMatrix1, state, 0, true);
+  ASSERT_NE(state2.p, nullptr);
+  ASSERT_EQ(state2.p, cachedResult1->p);
 
   // try a repeated lookup
-  const auto* cachedResult2 = computeTable.lookup(xCopy1, yCopy1, true);
+  const auto* cachedResult2 =
+      computeTable.lookup(densityMatrix1.p, state.p, true);
   ASSERT_NE(cachedResult2, nullptr);
   ASSERT_NE(cachedResult2->p, nullptr);
   ASSERT_EQ(cachedResult2->p, cachedResult1->p);
 
   computeTable.clear();
-  const auto* cachedResult3 = computeTable.lookup(xCopy1, yCopy1, true);
+  const auto* cachedResult3 =
+      computeTable.lookup(densityMatrix1.p, state.p, true);
   ASSERT_EQ(cachedResult3, nullptr);
 }
 


### PR DESCRIPTION
## Description

This is a follow-up PR to #444. That PR has shown that the approximation conducted as part of complex number arithmetic (multiplication and division) can lead to quite some unexpected results.
Whenever we compute something on complex numbers, the respective computation should be as accurate as possible and rounding should happen as late as possible to maintain maximum accuracy.
This PR completely removes the approximate special casing in the complex number arithmetic. Correspondingly, it adjusts the computation of the top edge weight in the multiplication routine to reuse the already computed `rWeight`.
Furthermore, it optimizes out some of the approximation calls throughout the package and provides more accurate complex number arithmetic.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
