### PR TITLE
🎨 provide `operator<<` overloads for scoped enums in ZX package

### DIFF
--- a/include/zx/ZXDefinitions.hpp
+++ b/include/zx/ZXDefinitions.hpp
@@ -8,8 +8,36 @@
 #include <string>
 
 namespace zx {
-enum class EdgeType { Simple, Hadamard };
-enum class VertexType { Boundary, Z, X };
+
+enum class EdgeType : uint8_t { Simple, Hadamard };
+inline std::ostream& operator<<(std::ostream& os, const EdgeType& type) {
+  switch (type) {
+  case EdgeType::Simple:
+    os << "Simple";
+    break;
+  case EdgeType::Hadamard:
+    os << "Hadamard";
+    break;
+  }
+  return os;
+}
+
+enum class VertexType : uint8_t { Boundary, Z, X };
+inline std::ostream& operator<<(std::ostream& os, const VertexType& type) {
+  switch (type) {
+  case VertexType::Boundary:
+    os << "Boundary";
+    break;
+  case VertexType::Z:
+    os << "Z";
+    break;
+  case VertexType::X:
+    os << "X";
+    break;
+  }
+  return os;
+}
+
 using Vertex = std::size_t;
 using Col = std::int32_t;
 using Qubit = std::int32_t;

--- a/test/zx/test_zx.cpp
+++ b/test/zx/test_zx.cpp
@@ -259,3 +259,41 @@ TEST_F(ZXDiagramTest, ConnectedSet) {
   EXPECT_FALSE(diag.isIn(4, connected));
   EXPECT_TRUE(diag.isIn(5, connected));
 }
+
+TEST_F(ZXDiagramTest, EdgeTypePrinting) {
+  diag = zx::ZXDiagram(3);
+  diag.addEdge(0, 1, zx::EdgeType::Simple);
+
+  const auto& edge = diag.getEdge(0, 1);
+  ASSERT_NE(edge, std::nullopt);
+  std::stringstream ss;
+  ss << edge->type;
+  EXPECT_EQ(ss.str(), "Simple");
+
+  // Change the type to Hadamard
+  diag.addHadamardEdge(1, 2);
+  const auto& edge2 = diag.getEdge(1, 2);
+  ASSERT_NE(edge2, std::nullopt);
+  std::stringstream ss2;
+  ss2 << edge2->type;
+  EXPECT_EQ(ss2.str(), "Hadamard");
+}
+
+TEST_F(ZXDiagramTest, VertexTypePrinting) {
+  diag = zx::ZXDiagram(1);
+  const auto boundary = diag.getInput(0);
+  EXPECT_EQ(diag.getVData(boundary)->type, zx::VertexType::Boundary);
+  std::stringstream ss;
+  ss << diag.getVData(boundary)->type;
+  EXPECT_EQ(ss.str(), "Boundary");
+  const auto z = diag.addVertex(0, 0, zx::PiExpression(), zx::VertexType::Z);
+  EXPECT_EQ(diag.getVData(z)->type, zx::VertexType::Z);
+  ss.str("");
+  ss << diag.getVData(z)->type;
+  EXPECT_EQ(ss.str(), "Z");
+  const auto x = diag.addVertex(0, 0, zx::PiExpression(), zx::VertexType::X);
+  EXPECT_EQ(diag.getVData(x)->type, zx::VertexType::X);
+  ss.str("");
+  ss << diag.getVData(x)->type;
+  EXPECT_EQ(ss.str(), "X");
+}

--- a/test/zx/test_zx.cpp
+++ b/test/zx/test_zx.cpp
@@ -266,34 +266,50 @@ TEST_F(ZXDiagramTest, EdgeTypePrinting) {
 
   const auto& edge = diag.getEdge(0, 1);
   ASSERT_NE(edge, std::nullopt);
-  std::stringstream ss;
-  ss << edge->type;
-  EXPECT_EQ(ss.str(), "Simple");
+  if (edge) {
+    std::stringstream ss;
+    ss << edge->type;
+    EXPECT_EQ(ss.str(), "Simple");
+  }
 
   // Change the type to Hadamard
   diag.addHadamardEdge(1, 2);
   const auto& edge2 = diag.getEdge(1, 2);
   ASSERT_NE(edge2, std::nullopt);
-  std::stringstream ss2;
-  ss2 << edge2->type;
-  EXPECT_EQ(ss2.str(), "Hadamard");
+  if (edge2) {
+    std::stringstream ss2;
+    ss2 << edge2->type;
+    EXPECT_EQ(ss2.str(), "Hadamard");
+  }
 }
 
 TEST_F(ZXDiagramTest, VertexTypePrinting) {
   diag = zx::ZXDiagram(1);
   const auto boundary = diag.getInput(0);
-  EXPECT_EQ(diag.getVData(boundary)->type, zx::VertexType::Boundary);
-  std::stringstream ss;
-  ss << diag.getVData(boundary)->type;
-  EXPECT_EQ(ss.str(), "Boundary");
+  const auto boundaryData = diag.getVData(boundary);
+  ASSERT_NE(boundaryData, std::nullopt);
+  if (boundaryData) {
+    EXPECT_EQ(boundaryData->type, zx::VertexType::Boundary);
+    std::stringstream ss;
+    ss << boundaryData->type;
+    EXPECT_EQ(ss.str(), "Boundary");
+  }
   const auto z = diag.addVertex(0, 0, zx::PiExpression(), zx::VertexType::Z);
-  EXPECT_EQ(diag.getVData(z)->type, zx::VertexType::Z);
-  ss.str("");
-  ss << diag.getVData(z)->type;
-  EXPECT_EQ(ss.str(), "Z");
+  const auto zData = diag.getVData(z);
+  ASSERT_NE(zData, std::nullopt);
+  if (zData) {
+    EXPECT_EQ(zData->type, zx::VertexType::Z);
+    std::stringstream ss;
+    ss << zData->type;
+    EXPECT_EQ(ss.str(), "Z");
+  }
   const auto x = diag.addVertex(0, 0, zx::PiExpression(), zx::VertexType::X);
-  EXPECT_EQ(diag.getVData(x)->type, zx::VertexType::X);
-  ss.str("");
-  ss << diag.getVData(x)->type;
-  EXPECT_EQ(ss.str(), "X");
+  const auto xData = diag.getVData(x);
+  ASSERT_NE(xData, std::nullopt);
+  if (xData) {
+    EXPECT_EQ(xData->type, zx::VertexType::X);
+    std::stringstream ss;
+    ss << xData->type;
+    EXPECT_EQ(ss.str(), "X");
+  }
 }


### PR DESCRIPTION
## Description

While this may not solve the underlying issue in #503, it should at least resolve some part of it and maybe reveal further warnings. It also fixes one of the new clang-tidy warnings for reducing the size of the underlying data type of enums.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
