### PR TITLE
Fix handling of output permutation and initial layout

### DIFF
--- a/test/unittests/test_qasm3_parser.cpp
+++ b/test/unittests/test_qasm3_parser.cpp
@@ -466,6 +466,47 @@ TEST_F(Qasm3ParserTest, ImportQasm3EmptyIfElse) {
   EXPECT_EQ(out.str(), expected);
 }
 
+TEST_F(Qasm3ParserTest, ImportQasm3OutputPerm) {
+  std::stringstream ss{};
+  const std::string testfile = "// i 0 2 1 3\n"
+                               "// o 3 0\n"
+                               "qubit[4] q;\n";
+
+  ss << testfile;
+  auto qc = QuantumComputation();
+  qc.import(ss, Format::OpenQASM3);
+
+  std::stringstream out{};
+  QuantumComputation::printPermutation(qc.outputPermutation, out);
+
+  const std::string expected = "\t0: 1\n"
+                               "\t3: 0\n"
+                               "";
+
+  EXPECT_EQ(out.str(), expected);
+}
+
+TEST_F(Qasm3ParserTest, ImportQasm3OutputPermDefault) {
+  std::stringstream ss{};
+  const std::string testfile = "// i 0 2 1 3\n"
+                               "qubit[4] q;\n";
+
+  ss << testfile;
+  auto qc = QuantumComputation();
+  qc.import(ss, Format::OpenQASM3);
+
+  std::stringstream out{};
+  QuantumComputation::printPermutation(qc.outputPermutation, out);
+
+  const std::string expected = "\t0: 0\n"
+                               "\t1: 1\n"
+                               "\t2: 2\n"
+                               "\t3: 3\n"
+                               "";
+
+  EXPECT_EQ(out.str(), expected);
+}
+
 TEST_F(Qasm3ParserTest, ImportQasm3IfElseNoBlock) {
   std::stringstream ss{};
   const std::string testfile = "OPENQASM 3.0;\n"


### PR DESCRIPTION
## Description

Output permutation and initial layout need to be applied after the circuit is parsed completely.

This fixes an issue where an output permutation is declared with less qubits than are used in the circuit.

```qasm
// i 0 2 1 3
// o 3 0
qubit[4] q;
```

Would result in an output permutation of
```
0: 1
1: 1
2: 2
3: 0
```

instead of

```
0: 1
3: 0
```

The issue is fixed by applying the output permutation after parsing the complete circuit.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
