### PR TITLE
✨ New optimization pass: Backpropagate output permutation and better dynamic circuit support

### DIFF
--- a/include/CircuitOptimizer.hpp
+++ b/include/CircuitOptimizer.hpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <memory>
+#include <unordered_set>
 
 namespace qc {
 static constexpr std::array<qc::OpType, 10> DIAGONAL_GATES = {
@@ -61,6 +62,18 @@ public:
     replaceMCXWithMCZ(qc.ops);
   }
 
+  /**
+   * @brief Backpropagates the output permutation through the circuit.
+   * @details Starts at the end of the circuit with a potentially incomplete
+   * output permutation and backpropagates it through the circuit until the
+   * beginning of the circuit is reached. The tracked permutation is updated
+   * with every SWAP gate and, eventually, the initial layout of the circuit is
+   * set to the tracked permutation. Any unassigned qubit in the initial layout
+   * is assigned to the first available position (favoring an identity mapping).
+   * @param qc the quantum circuit
+   */
+  static void backpropagateOutputPermutation(QuantumComputation& qc);
+
 protected:
   static void removeDiagonalGatesBeforeMeasureRecursive(
       DAG& dag, DAGReverseIterators& dagIterators, Qubit idx,
@@ -88,5 +101,8 @@ protected:
                            Iterator it);
 
   static void replaceMCXWithMCZ(std::vector<std::unique_ptr<Operation>>& ops);
+  static void backpropagateOutputPermutation(
+      std::vector<std::unique_ptr<Operation>>& ops, Permutation& permutation,
+      std::unordered_set<Qubit>& missingLogicalQubits);
 };
 } // namespace qc

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1687,7 +1687,7 @@ public:
         for (const auto& [physical, logical] : permutation) {
           filteredString[logical] = binaryString[physical];
         }
-        idx = std::stoul(filteredString, nullptr, 2);
+        idx = std::stoull(filteredString, nullptr, 2);
       }
       if (auto it = probs.find(idx); it != probs.end()) {
         return top * std::sqrt(it->second);

--- a/include/dd/Package.hpp
+++ b/include/dd/Package.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Definitions.hpp"
+#include "Permutation.hpp"
 #include "dd/CachedEdge.hpp"
 #include "dd/Complex.hpp"
 #include "dd/ComplexNumbers.hpp"
@@ -1663,19 +1664,32 @@ public:
     return innerProduct(x, y).mag2();
   }
 
-  fp fidelityOfMeasurementOutcomes(const vEdge& e, const SparsePVec& probs) {
+  fp fidelityOfMeasurementOutcomes(const vEdge& e, const SparsePVec& probs,
+                                   const qc::Permutation& permutation = {}) {
     if (e.w.approximatelyZero()) {
       return 0.;
     }
-    return fidelityOfMeasurementOutcomesRecursive(e, probs, 0);
+    return fidelityOfMeasurementOutcomesRecursive(e, probs, 0, permutation,
+                                                  e.p->v + 1U);
   }
 
   fp fidelityOfMeasurementOutcomesRecursive(const vEdge& e,
                                             const SparsePVec& probs,
-                                            const std::size_t i) {
+                                            const std::size_t i,
+                                            const qc::Permutation& permutation,
+                                            const std::size_t nQubits) {
     const auto top = ComplexNumbers::mag(e.w);
     if (e.isTerminal()) {
-      if (auto it = probs.find(i); it != probs.end()) {
+      auto idx = i;
+      if (!permutation.empty()) {
+        const auto binaryString = intToBinaryString(i, nQubits);
+        std::string filteredString(permutation.size(), '0');
+        for (const auto& [physical, logical] : permutation) {
+          filteredString[logical] = binaryString[physical];
+        }
+        idx = std::stoul(filteredString, nullptr, 2);
+      }
+      if (auto it = probs.find(idx); it != probs.end()) {
         return top * std::sqrt(it->second);
       }
       return 0.;
@@ -1684,15 +1698,15 @@ public:
     std::size_t leftIdx = i;
     fp leftContribution = 0.;
     if (!e.p->e[0].w.approximatelyZero()) {
-      leftContribution =
-          fidelityOfMeasurementOutcomesRecursive(e.p->e[0], probs, leftIdx);
+      leftContribution = fidelityOfMeasurementOutcomesRecursive(
+          e.p->e[0], probs, leftIdx, permutation, nQubits);
     }
 
     std::size_t rightIdx = i | (1ULL << e.p->v);
     auto rightContribution = 0.;
     if (!e.p->e[1].w.approximatelyZero()) {
-      rightContribution =
-          fidelityOfMeasurementOutcomesRecursive(e.p->e[1], probs, rightIdx);
+      rightContribution = fidelityOfMeasurementOutcomesRecursive(
+          e.p->e[1], probs, rightIdx, permutation, nQubits);
     }
 
     return top * (leftContribution + rightContribution);

--- a/include/dd/Simulation.hpp
+++ b/include/dd/Simulation.hpp
@@ -45,9 +45,9 @@ void extractProbabilityVector(const QuantumComputation* qc, const VectorDD& in,
 template <class Config>
 void extractProbabilityVectorRecursive(
     const QuantumComputation* qc, const VectorDD& currentState,
-    decltype(qc->begin()) currentIt, std::map<std::size_t, char> measurements,
-    dd::fp commonFactor, dd::SparsePVec& probVector,
-    std::unique_ptr<dd::Package<Config>>& dd);
+    decltype(qc->begin()) currentIt, Permutation& permutation,
+    std::map<std::size_t, char> measurements, dd::fp commonFactor,
+    dd::SparsePVec& probVector, std::unique_ptr<dd::Package<Config>>& dd);
 
 template <class Config>
 VectorDD simulate(GoogleRandomCircuitSampling* qc, const VectorDD& in,

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -1398,4 +1398,114 @@ void CircuitOptimizer::replaceMCXWithMCZ(
     }
   }
 }
+
+void CircuitOptimizer::backpropagateOutputPermutation(QuantumComputation& qc) {
+  auto permutation = qc.outputPermutation;
+
+  // Collect all logical qubits missing from the output permutation
+  std::unordered_set<Qubit> logicalQubits{};
+  for (const auto& [physical, logical] : permutation) {
+    logicalQubits.insert(logical);
+  }
+  std::unordered_set<Qubit> missingLogicalQubits{};
+  for (Qubit i = 0; i < qc.getNqubits(); ++i) {
+    if (logicalQubits.find(i) == logicalQubits.end()) {
+      missingLogicalQubits.emplace(i);
+    }
+  }
+
+  backpropagateOutputPermutation(qc.ops, permutation, missingLogicalQubits);
+
+  // `permutation` now holds a potentially incomplete initial layout
+  // check whether the initial layout is complete and return if it is
+  if (permutation.size() == qc.getNqubits()) {
+    qc.initialLayout = permutation;
+    return;
+  }
+
+  // Otherwise, fill the initial layout with the missing logical qubits.
+  // Give preference to choosing the same logical qubit as the missing physical
+  // qubit (i.e., an identity mapping) to avoid unnecessary permutations.
+  for (Qubit i = 0; i < qc.getNqubits(); ++i) {
+    if (permutation.find(i) == permutation.end()) {
+      if (missingLogicalQubits.find(i) != missingLogicalQubits.end()) {
+        permutation.emplace(i, i);
+        missingLogicalQubits.erase(i);
+      } else {
+        permutation.emplace(i, *missingLogicalQubits.begin());
+        missingLogicalQubits.erase(missingLogicalQubits.begin());
+      }
+    }
+  }
+  assert(missingLogicalQubits.empty());
+  qc.initialLayout = permutation;
+}
+
+void CircuitOptimizer::backpropagateOutputPermutation(
+    std::vector<std::unique_ptr<Operation>>& ops, Permutation& permutation,
+    std::unordered_set<Qubit>& missingLogicalQubits) {
+  for (auto it = ops.rbegin(); it != ops.rend(); ++it) {
+    if ((*it)->isCompoundOperation()) {
+      auto& op = dynamic_cast<CompoundOperation&>(**it);
+      backpropagateOutputPermutation(op.getOps(), permutation,
+                                     missingLogicalQubits);
+      continue;
+    }
+
+    if ((*it)->getType() == qc::OpType::SWAP && !(*it)->isControlled() &&
+        (*it)->getTargets().size() == 2U) {
+      const auto& targets = (*it)->getTargets();
+      // four cases
+      // 1. both targets are in the permutation
+      // 2. only the first target is in the permutation
+      // 3. only the second target is in the permutation
+      // 4. neither target is in the permutation
+
+      const auto it0 = permutation.find(targets[0]);
+      const auto it1 = permutation.find(targets[1]);
+
+      if (it0 != permutation.end() && it1 != permutation.end()) {
+        // case 1: swap the entries
+        std::swap(it0->second, it1->second);
+        continue;
+      }
+
+      if (it0 != permutation.end()) {
+        // case 2: swap the value assign the other target from the list of
+        // missing logical qubits. Give preference to choosing the same logical
+        // qubit as the missing physical qubit
+        permutation[targets[1]] = it0->second;
+
+        if (missingLogicalQubits.find(targets[0]) !=
+            missingLogicalQubits.end()) {
+          missingLogicalQubits.erase(targets[0]);
+          it0->second = targets[0];
+        } else {
+          it0->second = *missingLogicalQubits.begin();
+          missingLogicalQubits.erase(missingLogicalQubits.begin());
+        }
+        continue;
+      }
+
+      if (it1 != permutation.end()) {
+        // case 3: swap the value assign the other target from the list of
+        // missing logical qubits. Give preference to choosing the same logical
+        // qubit as the missing physical qubit
+        permutation[targets[0]] = it1->second;
+
+        if (missingLogicalQubits.find(targets[1]) !=
+            missingLogicalQubits.end()) {
+          missingLogicalQubits.erase(targets[1]);
+          it1->second = targets[1];
+        } else {
+          it1->second = *missingLogicalQubits.begin();
+          missingLogicalQubits.erase(missingLogicalQubits.begin());
+        }
+        continue;
+      }
+
+      // case 4: nothing to do
+    }
+  }
+}
 } // namespace qc

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -950,9 +950,11 @@ void CircuitOptimizer::deferMeasurements(QuantumComputation& qc) {
     }
     ++it;
   }
+  qc.outputPermutation.clear();
   for (const auto& [qubit, clbit] : qubitsToAddMeasurements) {
     qc.measure(qubit, clbit);
   }
+  qc.initializeIOMapping();
 }
 
 bool CircuitOptimizer::isDynamicCircuit(QuantumComputation& qc) {

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -533,10 +533,7 @@ std::ostream& QuantumComputation::print(std::ostream& os) const {
   for (const auto& physicalQubit : initialLayout) {
     auto it = outputPermutation.find(physicalQubit.first);
     if (it == outputPermutation.end()) {
-      if (garbage[physicalQubit.second]) {
-        os << "\033[31m";
-      }
-      os << std::setw(4) << "|"
+      os << "\033[31m" << std::setw(4) << "|"
          << "\033[0m";
     } else {
       os << std::setw(4) << it->second;

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -198,6 +198,7 @@ void QuantumComputation::initializeIOMapping() {
   }
 
   const bool buildOutputPermutation = outputPermutation.empty();
+  garbage.assign(nqubits + nancillae, false);
   for (const auto& [physicalIn, logicalIn] : initialLayout) {
     const bool isIdle = isIdleQubit(physicalIn);
 

--- a/src/algorithms/BernsteinVazirani.cpp
+++ b/src/algorithms/BernsteinVazirani.cpp
@@ -65,6 +65,13 @@ void BernsteinVazirani::createCircuit() {
   x(0);
 
   if (dynamic) {
+    // set up initial layout
+    initialLayout[0] = 1;
+    initialLayout[1] = 0;
+    setLogicalQubitGarbage(1);
+    outputPermutation.erase(0);
+    outputPermutation[1] = 0;
+
     for (std::size_t i = 0; i < bitwidth; ++i) {
       // initial Hadamard
       h(1);
@@ -86,6 +93,14 @@ void BernsteinVazirani::createCircuit() {
       }
     }
   } else {
+    // set up initial layout
+    initialLayout[0] = static_cast<Qubit>(bitwidth);
+    for (std::size_t i = 1; i <= bitwidth; ++i) {
+      initialLayout[static_cast<Qubit>(i)] = static_cast<Qubit>(i - 1);
+    }
+    setLogicalQubitGarbage(static_cast<Qubit>(bitwidth));
+    outputPermutation.erase(0);
+
     // initial Hadamard transformation
     for (std::size_t i = 1; i <= bitwidth; ++i) {
       h(static_cast<Qubit>(i));
@@ -106,6 +121,7 @@ void BernsteinVazirani::createCircuit() {
     // measure results
     for (std::size_t i = 1; i <= bitwidth; i++) {
       measure(static_cast<Qubit>(i), i - 1);
+      outputPermutation[static_cast<Qubit>(i)] = static_cast<Qubit>(i - 1);
     }
   }
 }

--- a/src/algorithms/BernsteinVazirani.cpp
+++ b/src/algorithms/BernsteinVazirani.cpp
@@ -43,14 +43,13 @@ std::ostream& BernsteinVazirani::printStatistics(std::ostream& os) const {
 }
 
 void BernsteinVazirani::createCircuit() {
-  name = "bv_" + s.to_string();
-
   expected = s.to_string();
   std::reverse(expected.begin(), expected.end());
   while (expected.length() > bitwidth) {
     expected.pop_back();
   }
   std::reverse(expected.begin(), expected.end());
+  name = "bv_" + expected;
 
   addQubitRegister(1, "flag");
 

--- a/src/algorithms/QFT.cpp
+++ b/src/algorithms/QFT.cpp
@@ -81,6 +81,8 @@ void QFT::createCircuit() {
       // measure qubits in reverse order
       for (std::size_t i = 0; i < precision; ++i) {
         measure(static_cast<Qubit>(i), precision - 1 - i);
+        outputPermutation[static_cast<Qubit>(i)] =
+            static_cast<Qubit>(precision - 1 - i);
       }
     } else {
       for (Qubit i = 0; i < static_cast<Qubit>(precision / 2); ++i) {

--- a/src/algorithms/QPE.cpp
+++ b/src/algorithms/QPE.cpp
@@ -72,6 +72,13 @@ void QPE::createCircuit() {
   x(0);
 
   if (iterative) {
+    // set up initial layout
+    initialLayout[0] = 1;
+    initialLayout[1] = 0;
+    setLogicalQubitGarbage(1);
+    outputPermutation.erase(0);
+    outputPermutation[1] = 0;
+
     for (std::size_t i = 0; i < precision; i++) {
       // Hadamard
       h(1);
@@ -99,6 +106,14 @@ void QPE::createCircuit() {
       }
     }
   } else {
+    // set up initial layout
+    initialLayout[0] = static_cast<Qubit>(precision);
+    for (std::size_t i = 1; i <= precision; ++i) {
+      initialLayout[static_cast<Qubit>(i)] = static_cast<Qubit>(i - 1);
+    }
+    setLogicalQubitGarbage(static_cast<Qubit>(precision));
+    outputPermutation.erase(0);
+
     // Hadamard Layer
     for (std::size_t i = 1; i <= precision; i++) {
       h(static_cast<Qubit>(i));
@@ -129,6 +144,7 @@ void QPE::createCircuit() {
     // measure results
     for (std::size_t i = 0; i < nqubits - 1; i++) {
       measure(static_cast<Qubit>(i + 1), i);
+      outputPermutation[static_cast<Qubit>(i + 1)] = static_cast<Qubit>(i);
     }
   }
 }

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -107,13 +107,14 @@ simulate(const QuantumComputation* qc, const VectorDD& in,
           // measurement map specifies that the circuit `qubit` is measured into
           // a certain `bit`
           measurement[qc->getNcbits() - 1U - bit] =
-              bitstring[bitstring.size() - 1U - qubit];
+              bitstring[bitstring.size() - 1U -
+                        qc->outputPermutation.at(qubit)];
         }
       } else {
         // otherwise, we consider the output permutation for determining where
         // to measure the qubits to
         for (const auto& [qubit, bit] : qc->outputPermutation) {
-          measurement[qc->getNcbits() - 1 - bit] =
+          measurement[qc->getNcbits() - 1U - bit] =
               bitstring[bitstring.size() - 1U - qubit];
         }
       }
@@ -151,8 +152,8 @@ simulate(const QuantumComputation* qc, const VectorDD& in,
                 e, static_cast<Qubit>(permutation.at(qubit)), true, mt);
             // apply an X operation whenever the measured result is one
             if (bit == '1') {
-              const auto x =
-                  qc::StandardOperation(qc->getNqubits(), qubit, qc::X);
+              const auto x = qc::StandardOperation(
+                  qc->getNqubits(), permutation.at(qubit), qc::X);
               auto tmp = dd->multiply(getDD(&x, dd), e);
               dd->incRef(tmp);
               dd->decRef(e);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,9 @@ package_add_test(
   ${PROJECT_NAME}-test ${PROJECT_NAME} unittests/test_io.cpp unittests/test_qfr_functionality.cpp
   unittests/test_symbolic.cpp unittests/test_qasm3_parser.cpp)
 
+file(GLOB_RECURSE circuit_optimizer_tests "unittests/circuit_optimizer/*.cpp")
+package_add_test(${PROJECT_NAME}-test-circuit-optimizer ${PROJECT_NAME} ${circuit_optimizer_tests})
+
 package_add_test(
   ${PROJECT_NAME}-test-dd
   ${PROJECT_NAME}-dd

--- a/test/algorithms/eval_dynamic_circuits.cpp
+++ b/test/algorithms/eval_dynamic_circuits.cpp
@@ -180,15 +180,9 @@ TEST_P(DynamicCircuitEvalExactQPE, ProbabilityExtraction) {
                            probs, dd);
   const auto extractionEnd = std::chrono::steady_clock::now();
 
-  // extend to account for 0 qubit
-  auto stub = dd::SparsePVec{};
-  stub.reserve(probs.size());
-  for (const auto& [state, prob] : probs) {
-    stub[2ULL * state + 1] = prob;
-  }
-
   // compare outcomes
-  auto fidelity = dd->fidelityOfMeasurementOutcomes(e, stub);
+  auto fidelity =
+      dd->fidelityOfMeasurementOutcomes(e, probs, qpe->outputPermutation);
   const auto comparisonEnd = std::chrono::steady_clock::now();
 
   const auto simulation =
@@ -393,15 +387,9 @@ TEST_P(DynamicCircuitEvalInexactQPE, ProbabilityExtraction) {
   dd = std::move(exp->dd);
   std::cout << "---- sim done ----\n";
 
-  // extend to account for 0 qubit
-  auto stub = dd::SparsePVec{};
-  stub.reserve(probs.size());
-  for (const auto& [state, prob] : probs) {
-    stub[2 * state + 1] = prob;
-  }
-
   // compare outcomes
-  auto fidelity = dd->fidelityOfMeasurementOutcomes(e, stub);
+  auto fidelity =
+      dd->fidelityOfMeasurementOutcomes(e, probs, qpe->outputPermutation);
   const auto comparisonEnd = std::chrono::steady_clock::now();
 
   const auto extraction =
@@ -552,15 +540,9 @@ TEST_P(DynamicCircuitEvalBV, ProbabilityExtraction) {
                            probs, dd);
   const auto extractionEnd = std::chrono::steady_clock::now();
 
-  // extend to account for 0 qubit
-  auto stub = dd::SparsePVec{};
-  stub.reserve(probs.size());
-  for (const auto& [state, prob] : probs) {
-    stub[2ULL * state + 1] = prob;
-  }
-
   // compare outcomes
-  auto fidelity = dd->fidelityOfMeasurementOutcomes(e, stub);
+  auto fidelity =
+      dd->fidelityOfMeasurementOutcomes(e, probs, bv->outputPermutation);
   const auto comparisonEnd = std::chrono::steady_clock::now();
 
   const auto simulation =
@@ -710,7 +692,8 @@ TEST_P(DynamicCircuitEvalQFT, ProbabilityExtraction) {
     const auto extractionEnd = std::chrono::steady_clock::now();
 
     // compare outcomes
-    auto fidelity = dd->fidelityOfMeasurementOutcomes(e, probs);
+    auto fidelity =
+        dd->fidelityOfMeasurementOutcomes(e, probs, qft->outputPermutation);
     const auto comparisonEnd = std::chrono::steady_clock::now();
     const auto extraction =
         std::chrono::duration<double>(extractionEnd - simulationEnd).count();

--- a/test/algorithms/test_bernsteinvazirani.cpp
+++ b/test/algorithms/test_bernsteinvazirani.cpp
@@ -123,6 +123,7 @@ TEST_P(BernsteinVazirani, DynamicEquivalenceSimulation) {
   // afterwards deferring measurements
   qc::CircuitOptimizer::eliminateResets(dbv);
   qc::CircuitOptimizer::deferMeasurements(dbv);
+  qc::CircuitOptimizer::backpropagateOutputPermutation(dbv);
 
   // remove final measurements to obtain statevector
   qc::CircuitOptimizer::removeFinalMeasurements(dbv);

--- a/test/unittests/circuit_optimizer/test_backpropagate_output_permutation.cpp
+++ b/test/unittests/circuit_optimizer/test_backpropagate_output_permutation.cpp
@@ -1,0 +1,158 @@
+#include "CircuitOptimizer.hpp"
+#include "QuantumComputation.hpp"
+
+#include "gtest/gtest.h"
+#include <iostream>
+
+namespace qc {
+TEST(BackpropagateOutputPermutation, FullySpecified) {
+  // i *  *      i 1  0
+  //   |  |  ->    |  |
+  // o 1  0      o 1  0
+
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 1;
+  qc.outputPermutation[1] = 0;
+  CircuitOptimizer::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout, qc.outputPermutation);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedQubitAvailable) {
+  // i *  *      i 1  0
+  //   |  |  ->    |  |
+  // o 1  *      o 1  0
+
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 1;
+  CircuitOptimizer::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], qc.outputPermutation[0]);
+  EXPECT_EQ(qc.initialLayout[1], 0);
+}
+
+TEST(BackpropagateOutputPermutation, FullySpecifiedWithSWAP) {
+  // i *  *      i 1  0
+  //   x--x  ->    x--x
+  // o 0  1      o 0  1
+
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 0;
+  qc.outputPermutation[1] = 1;
+  qc.swap(0, 1);
+  CircuitOptimizer::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], qc.outputPermutation[1]);
+  EXPECT_EQ(qc.initialLayout[1], qc.outputPermutation[0]);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedWithSWAP) {
+  // i *  *      i 1  0
+  //   x--x  ->    x--x
+  // o 0  *      o 0  *
+
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 0;
+  qc.swap(0, 1);
+  CircuitOptimizer::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], 1);
+  EXPECT_EQ(qc.initialLayout[1], qc.outputPermutation[0]);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedWithSWAP2) {
+  // i *  *      i 1  0
+  //   x--x  ->    x--x
+  // o *  1      o *  1
+
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[1] = 1;
+  qc.swap(0, 1);
+  CircuitOptimizer::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], qc.outputPermutation[1]);
+  EXPECT_EQ(qc.initialLayout[1], 0);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedWithSWAP3) {
+  // i *  *      i 0  1
+  //   x--x  ->    x--x
+  // o *  *      o *  *
+
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.swap(0, 1);
+  CircuitOptimizer::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], 0);
+  EXPECT_EQ(qc.initialLayout[1], 1);
+}
+
+TEST(BackpropagateOutputPermutation, CompoundOperation) {
+  // i *  *      i 0  1
+  //   ----        ----
+  //   x--x  ->    x--x
+  //   ----        ----
+  // o 1  0      o 1  0
+  auto qc = QuantumComputation(2);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 1;
+  qc.outputPermutation[1] = 0;
+
+  auto qc2 = QuantumComputation(2);
+  qc2.swap(0, 1);
+  qc.emplace_back(qc2.asCompoundOperation());
+  CircuitOptimizer::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], qc.outputPermutation[1]);
+  EXPECT_EQ(qc.initialLayout[1], qc.outputPermutation[0]);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedNotAMissingQubit) {
+  // i *  *  *      i 2  0  1
+  //   x--x  |  ->    x--x  |
+  // o 0  *  1      o 0  *  1
+
+  auto qc = QuantumComputation(3);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[0] = 0;
+  qc.outputPermutation[2] = 1;
+  qc.swap(0, 1);
+  CircuitOptimizer::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], 2);
+  EXPECT_EQ(qc.initialLayout[1], 0);
+  EXPECT_EQ(qc.initialLayout[2], 1);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedNotAMissingQubit2) {
+  // i *  *  *      i 0  2  1
+  //   x--x  |  ->    x--x  |
+  // o *  0  1      o *  0  1
+
+  auto qc = QuantumComputation(3);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[1] = 0;
+  qc.outputPermutation[2] = 1;
+  qc.swap(0, 1);
+  CircuitOptimizer::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], 0);
+  EXPECT_EQ(qc.initialLayout[1], 2);
+  EXPECT_EQ(qc.initialLayout[2], 1);
+}
+
+TEST(BackpropagateOutputPermutation, PartiallySpecifiedNotAMissingQubit3) {
+  // i *  *  *  *      i 0  3  2  1
+  //   x-----x  |  ->    x-----x  |
+  // o *  *  0  1      o *  *  0  1
+
+  auto qc = QuantumComputation(4);
+  qc.outputPermutation.clear();
+  qc.outputPermutation[2] = 0;
+  qc.outputPermutation[3] = 1;
+  qc.swap(0, 2);
+  CircuitOptimizer::backpropagateOutputPermutation(qc);
+  EXPECT_EQ(qc.initialLayout[0], 0);
+  EXPECT_EQ(qc.initialLayout[1], 3);
+  EXPECT_EQ(qc.initialLayout[2], 2);
+  EXPECT_EQ(qc.initialLayout[3], 1);
+}
+
+} // namespace qc


### PR DESCRIPTION
## Description

This PR introduces a new optimization pass that allows one to backpropagate a given output permutation to the initial layout of a circuit.
This can be useful in situations where the initial qubit layout is not perfectly known or constructible (such as for dynamic quantum circuits that have been transformed by substituting resets and deferring measurements).
The pass tries to find the initial layout that best matches the given output permutation while considering any SWAPs in the circuit. Qubits that are not part of the output permutation (i.e., garbage qubits) are assigned via an identity mapping (if possible) or arbitrarily to the first available location.

This also fixes a small bug where the output permutation of a circuit was incorrectly set after deferring measurements.

In addition to the above, this PR improves the general support for dynamic quantum circuits by fixing a couple of bugs in the respective simulation routines and enriching the capabilities of some of the related functions.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
