### PR TITLE
⬆️ update cibuildwheel version on Cirrus-CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,7 +44,7 @@ macos_arm64_test_task:
 
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel~=2.15.0
+    - python -m pip install cibuildwheel~=2.16.2
   run_cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:


### PR DESCRIPTION
## Description

This small PR updates the `cibuildwheel` version used in Cirrus-CI to `2.16.2`.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
