### PR TITLE
🚨 fix warnings about exceptions that privately inherit from `std::exeption`

### DIFF
--- a/include/parsers/qasm3_parser/Exception.hpp
+++ b/include/parsers/qasm3_parser/Exception.hpp
@@ -3,7 +3,7 @@
 #include "Statement.hpp"
 
 namespace qasm3 {
-class CompilerError final : std::exception {
+class CompilerError final : public std::exception {
 public:
   std::string message{};
   std::shared_ptr<DebugInfo> debugInfo{};
@@ -28,7 +28,7 @@ public:
 };
 } // namespace qasm3
 
-class ConstEvalError final : std::exception {
+class ConstEvalError final : public std::exception {
 public:
   std::string message{};
 
@@ -39,7 +39,7 @@ public:
   }
 };
 
-class TypeCheckError final : std::exception {
+class TypeCheckError final : public std::exception {
 public:
   std::string message{};
 


### PR DESCRIPTION
## Description

This PR fixes a bunch of compiler warnings that MSVC reports for the newly introduced OpenQASM3 exception types.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
