### PR TITLE
🐛 avoid using system header includes for external dependencies

### DIFF
--- a/eval/eval_dd_package.cpp
+++ b/eval/eval_dd_package.cpp
@@ -9,8 +9,8 @@
 #include "dd/Benchmark.hpp"
 #include "dd/FunctionalityConstruction.hpp"
 #include "dd/statistics/PackageStatistics.hpp"
+#include "nlohmann/json.hpp"
 
-#include <nlohmann/json.hpp>
 #include <string>
 #include <utility>
 

--- a/include/dd/Benchmark.hpp
+++ b/include/dd/Benchmark.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "dd/Package.hpp"
+#include "nlohmann/json.hpp"
 
 #include <chrono>
-#include <nlohmann/json.hpp>
 
 namespace qc {
 class QuantumComputation;

--- a/include/dd/UniqueTable.hpp
+++ b/include/dd/UniqueTable.hpp
@@ -5,6 +5,7 @@
 #include "dd/MemoryManager.hpp"
 #include "dd/Node.hpp"
 #include "dd/statistics/UniqueTableStatistics.hpp"
+#include "nlohmann/json.hpp"
 
 #include <algorithm>
 #include <array>
@@ -12,7 +13,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
-#include <nlohmann/json.hpp>
 #include <type_traits>
 #include <vector>
 

--- a/include/dd/statistics/PackageStatistics.hpp
+++ b/include/dd/statistics/PackageStatistics.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "dd/Package.hpp"
-
-#include <nlohmann/json.hpp>
+#include "nlohmann/json.hpp"
 
 namespace dd {
 

--- a/include/dd/statistics/Statistics.hpp
+++ b/include/dd/statistics/Statistics.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <nlohmann/json_fwd.hpp>
+#include "nlohmann/json_fwd.hpp"
+
 #include <ostream>
 #include <string>
 

--- a/include/python/pybind11.hpp
+++ b/include/python/pybind11.hpp
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
 
 namespace mqt {
 namespace py = pybind11;

--- a/include/python/qiskit/QuantumCircuit.hpp
+++ b/include/python/qiskit/QuantumCircuit.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "pybind11/pybind11.h"
+#include "pybind11/pytypes.h"
 
-#include <pybind11/pytypes.h>
 #include <regex>
 #include <type_traits>
 #include <variant>

--- a/src/dd/statistics/MemoryManagerStatistics.cpp
+++ b/src/dd/statistics/MemoryManagerStatistics.cpp
@@ -2,9 +2,9 @@
 
 #include "dd/Node.hpp"
 #include "dd/RealNumber.hpp"
+#include "nlohmann/json.hpp"
 
 #include <algorithm>
-#include <nlohmann/json.hpp>
 
 namespace dd {
 

--- a/src/dd/statistics/Statistics.cpp
+++ b/src/dd/statistics/Statistics.cpp
@@ -1,6 +1,6 @@
 #include "dd/statistics/Statistics.hpp"
 
-#include <nlohmann/json.hpp>
+#include "nlohmann/json.hpp"
 
 namespace dd {
 

--- a/src/dd/statistics/TableStatistics.cpp
+++ b/src/dd/statistics/TableStatistics.cpp
@@ -1,6 +1,6 @@
 #include "dd/statistics/TableStatistics.hpp"
 
-#include <nlohmann/json.hpp>
+#include "nlohmann/json.hpp"
 
 namespace dd {
 

--- a/src/dd/statistics/UniqueTableStatistics.cpp
+++ b/src/dd/statistics/UniqueTableStatistics.cpp
@@ -1,7 +1,8 @@
 #include "dd/statistics/UniqueTableStatistics.hpp"
 
+#include "nlohmann/json.hpp"
+
 #include <algorithm>
-#include <nlohmann/json.hpp>
 
 namespace dd {
 

--- a/src/python/operations/register_operation.cpp
+++ b/src/python/operations/register_operation.cpp
@@ -1,7 +1,6 @@
 #include "operations/Operation.hpp"
+#include "pybind11/operators.h"
 #include "python/pybind11.hpp"
-
-#include <pybind11/operators.h>
 
 namespace mqt {
 

--- a/src/python/symbolic/register_expression.cpp
+++ b/src/python/symbolic/register_expression.cpp
@@ -1,7 +1,7 @@
 #include "operations/Expression.hpp"
+#include "pybind11/operators.h"
 #include "python/pybind11.hpp"
 
-#include <pybind11/operators.h>
 #include <sstream>
 
 namespace mqt {

--- a/test/algorithms/test_wstate.cpp
+++ b/test/algorithms/test_wstate.cpp
@@ -1,6 +1,5 @@
 #include "algorithms/WState.hpp"
 #include "dd/Benchmark.hpp"
-#include "dd/Simulation.hpp"
 
 #include "gtest/gtest.h"
 #include <iostream>

--- a/test/dd/test_complex.cpp
+++ b/test/dd/test_complex.cpp
@@ -3,8 +3,8 @@
 #include "dd/Export.hpp"
 
 #include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include <array>
-#include <gtest/gtest.h>
 #include <limits>
 #include <vector>
 

--- a/test/dd/test_dd_noise_functionality.cpp
+++ b/test/dd/test_dd_noise_functionality.cpp
@@ -3,7 +3,7 @@
 #include "dd/NoiseFunctionality.hpp"
 #include "dd/Operations.hpp"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 #include <random>
 
 using namespace qc;

--- a/test/dd/test_edge_functionality.cpp
+++ b/test/dd/test_edge_functionality.cpp
@@ -1,6 +1,6 @@
 #include "dd/Package.hpp"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 namespace dd {
 

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -5,8 +5,8 @@
 #include "dd/statistics/PackageStatistics.hpp"
 #include "operations/Control.hpp"
 
+#include "gtest/gtest.h"
 #include <filesystem>
-#include <gtest/gtest.h>
 #include <iomanip>
 #include <memory>
 #include <random>

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -1,8 +1,8 @@
 #include "QuantumComputation.hpp"
 #include "parsers/qasm3_parser/Exception.hpp"
 
+#include "gtest/gtest.h"
 #include <filesystem>
-#include <gtest/gtest.h>
 #include <iostream>
 #include <string>
 

--- a/test/zx/test_expression.cpp
+++ b/test/zx/test_expression.cpp
@@ -2,7 +2,7 @@
 #include "zx/Rational.hpp"
 #include "zx/Utils.hpp"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 #include <stdexcept>
 #include <variant>
 

--- a/test/zx/test_rational.cpp
+++ b/test/zx/test_rational.cpp
@@ -1,7 +1,7 @@
 #include "zx/Rational.hpp"
 #include "zx/ZXDefinitions.hpp"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 #include <iostream>
 
 class RationalTest : public ::testing::Test {};

--- a/test/zx/test_simplify.cpp
+++ b/test/zx/test_simplify.cpp
@@ -1,7 +1,7 @@
 #include "zx/Simplify.hpp"
 #include "zx/ZXDiagram.hpp"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 using zx::fullReduceApproximate;
 

--- a/test/zx/test_zx.cpp
+++ b/test/zx/test_zx.cpp
@@ -3,8 +3,8 @@
 #include "zx/ZXDefinitions.hpp"
 #include "zx/ZXDiagram.hpp"
 
+#include "gtest/gtest.h"
 #include <array>
-#include <gtest/gtest.h>
 
 class ZXDiagramTest : public ::testing::Test {
 public:

--- a/test/zx/test_zx_functionality.cpp
+++ b/test/zx/test_zx_functionality.cpp
@@ -4,8 +4,8 @@
 #include "zx/ZXDefinitions.hpp"
 #include "zx/ZXDiagram.hpp"
 
+#include "gtest/gtest.h"
 #include <array>
-#include <gtest/gtest.h>
 #include <iostream>
 #include <sstream>
 


### PR DESCRIPTION
## Description

This PR changes all includes of external dependencies that are shipped with the project to use double quotes instead of angle brackets. As a consequence, this should pick up the shipped versions first instead of the system ones.

Fixes #503 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
