### PR TITLE
For builtin gates, print `c` prefix instead of `ctrl @ `

### DIFF
--- a/include/operations/StandardOperation.hpp
+++ b/include/operations/StandardOperation.hpp
@@ -117,7 +117,6 @@ protected:
   void dumpGateType(std::ostream& of, std::ostringstream& op,
                     const RegisterNames& qreg) const;
 
-private:
   void dumpControls(std::ostringstream& op) const;
 };
 

--- a/include/operations/StandardOperation.hpp
+++ b/include/operations/StandardOperation.hpp
@@ -116,6 +116,9 @@ protected:
 
   void dumpGateType(std::ostream& of, std::ostringstream& op,
                     const RegisterNames& qreg) const;
+
+private:
+  void dumpControls(std::ostringstream& op) const;
 };
 
 } // namespace qc

--- a/src/operations/StandardOperation.cpp
+++ b/src/operations/StandardOperation.cpp
@@ -613,37 +613,33 @@ void StandardOperation::dumpControls(std::ostringstream& op) const {
     return;
   }
 
-  // if operation is in stdgates, we print a c prefix instead of ctrl @
-  size_t posControls = 0;
-  bool printBuiltin = true;
-  for (const auto& control : controls) {
-    if (control.type == Control::Type::Neg) {
-      printBuiltin = false;
+  // if operation is in stdgates.inc, we print a c prefix instead of ctrl @
+  if (bool printBuiltin = std::none_of(
+          controls.begin(), controls.end(),
+          [](const Control& c) { return c.type == Control::Type::Neg; });
+      printBuiltin) {
+    const auto numControls = controls.size();
+    switch (type) {
+    case P:
+    case RX:
+    case Y:
+    case RY:
+    case Z:
+    case RZ:
+    case H:
+    case SWAP:
+      printBuiltin = numControls == 1;
       break;
+    case X:
+      printBuiltin = numControls == 1 || numControls == 2;
+      break;
+    default:
+      printBuiltin = false;
     }
-    ++posControls;
-  }
-  switch (type) {
-  case P:
-  case RX:
-  case Y:
-  case RY:
-  case Z:
-  case RZ:
-  case H:
-  case SWAP:
-    printBuiltin &= posControls == 1;
-    break;
-  case X:
-    printBuiltin &= posControls == 1 || posControls == 2;
-    break;
-  default:
-    printBuiltin = false;
-  }
-
-  if (printBuiltin) {
-    op << std::string(posControls, 'c');
-    return;
+    if (printBuiltin) {
+      op << std::string(numControls, 'c');
+      return;
+    }
   }
 
   Control::Type currentType = controls.begin()->type;

--- a/src/operations/StandardOperation.cpp
+++ b/src/operations/StandardOperation.cpp
@@ -1,5 +1,6 @@
 #include "operations/StandardOperation.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <sstream>
 #include <variant>

--- a/src/operations/StandardOperation.cpp
+++ b/src/operations/StandardOperation.cpp
@@ -295,31 +295,7 @@ void StandardOperation::dumpOpenQASM2(std::ostream& of, std::ostringstream& op,
 
 void StandardOperation::dumpOpenQASM3(std::ostream& of, std::ostringstream& op,
                                       const RegisterNames& qreg) const {
-
-  if (!controls.empty()) {
-    Control::Type currentType = controls.begin()->type;
-    int count = 0;
-
-    for (const auto& control : controls) {
-      if (control.type == currentType) {
-        ++count;
-      } else {
-        op << (currentType == Control::Type::Neg ? "negctrl" : "ctrl");
-        if (count > 1) {
-          op << "(" << count << ")";
-        }
-        op << " @ ";
-        currentType = control.type;
-        count = 1;
-      }
-    }
-
-    op << (currentType == Control::Type::Neg ? "negctrl" : "ctrl");
-    if (count > 1) {
-      op << "(" << count << ")";
-    }
-    op << " @ ";
-  }
+  dumpControls(op);
 
   dumpGateType(of, op, qreg);
 }
@@ -630,5 +606,67 @@ void StandardOperation::invert() {
     throw QFRException("Inverting gate" + toString(type) +
                        " is not supported.");
   }
+}
+
+void StandardOperation::dumpControls(std::ostringstream& op) const {
+  if (controls.empty()) {
+    return;
+  }
+
+  // if operation is in stdgates, we print a c prefix instead of ctrl @
+  size_t posControls = 0;
+  bool printBuiltin = true;
+  for (const auto& control : controls) {
+    if (control.type == Control::Type::Neg) {
+      printBuiltin = false;
+      break;
+    }
+    ++posControls;
+  }
+  switch (type) {
+  case P:
+  case RX:
+  case Y:
+  case RY:
+  case Z:
+  case RZ:
+  case H:
+  case SWAP:
+    printBuiltin &= posControls == 1;
+    break;
+  case X:
+    printBuiltin &= posControls == 1 || posControls == 2;
+    break;
+  default:
+    printBuiltin = false;
+  }
+
+  if (printBuiltin) {
+    op << std::string(posControls, 'c');
+    return;
+  }
+
+  Control::Type currentType = controls.begin()->type;
+  int count = 0;
+
+  for (const auto& control : controls) {
+    if (control.type == currentType) {
+      ++count;
+    } else {
+      op << (currentType == Control::Type::Neg ? "negctrl" : "ctrl");
+      if (count > 1) {
+        op << "(" << count << ")";
+      }
+      op << " @ ";
+      currentType = control.type;
+      count = 1;
+    }
+  }
+
+  op << (currentType == Control::Type::Neg ? "negctrl" : "ctrl");
+  if (count > 1) {
+    op << "(" << count << ")";
+  }
+  op << " @ ";
 }
 } // namespace qc

--- a/test/unittests/test_qasm3_parser.cpp
+++ b/test/unittests/test_qasm3_parser.cpp
@@ -83,11 +83,26 @@ TEST_F(Qasm3ParserTest, ImportQasm3GateDecl) {
 
 TEST_F(Qasm3ParserTest, ImportQasm3CtrlModifier) {
   std::stringstream ss{};
-  const std::string testfile = "OPENQASM 3.0;\n"
-                               "include \"stdgates.inc\";\n"
-                               "qubit[3] q;\n"
-                               "ctrl @ x q[0], q[1];\n"
-                               "ctrl(2) @ x q[0], q[1], q[2];\n";
+  const std::string testfile =
+      "OPENQASM 3.0;\n"
+      "include \"stdgates.inc\";\n"
+      "qubit[5] q;\n"
+      "x q[0];\n"
+      "ctrl @ x q[0], q[1];\n"
+      "ctrl(2) @ x q[0], q[1], q[2];\n"
+      "ctrl(3) @ x q[0], q[1], q[2], q[3];\n"
+      "ctrl(3) @ negctrl @ x q[0], q[1], q[2], q[3], q[4];\n"
+      "ctrl @ p(0.5) q[0], q[1];\n"
+      "ctrl @ rx(pi) q[0], q[1];\n"
+      "ctrl @ y q[0], q[1];\n"
+      "ctrl @ ry(pi) q[0], q[1];\n"
+      "ctrl @ z q[0], q[1];\n"
+      "ctrl @ rz(pi) q[0], q[1];\n"
+      "ctrl @ h q[0], q[1];\n"
+      "ctrl @ swap q[0], q[1], q[2];\n"
+      "ctrl @ rxx(pi) q[0], q[1], q[2];\n"
+      "ctrl @ negctrl @ x q[0], q[1], q[2];\n"
+      "";
 
   ss << testfile;
   auto qc = QuantumComputation();
@@ -96,13 +111,28 @@ TEST_F(Qasm3ParserTest, ImportQasm3CtrlModifier) {
   std::stringstream out{};
   qc.dump(out, Format::OpenQASM3);
 
-  const std::string expected = "// i 0 1 2\n"
-                               "// o 0 1 2\n"
-                               "OPENQASM 3.0;\n"
-                               "include \"stdgates.inc\";\n"
-                               "qubit[3] q;\n"
-                               "ctrl @ x q[0], q[1];\n"
-                               "ctrl(2) @ x q[0], q[1], q[2];\n";
+  const std::string expected =
+      "// i 0 1 2 3 4\n"
+      "// o 0 1 2 3 4\n"
+      "OPENQASM 3.0;\n"
+      "include \"stdgates.inc\";\n"
+      "qubit[5] q;\n"
+      "x q[0];\n"
+      "cx q[0], q[1];\n"
+      "ccx q[0], q[1], q[2];\n"
+      "ctrl(3) @ x q[0], q[1], q[2], q[3];\n"
+      "ctrl(3) @ negctrl @ x q[0], q[1], q[2], q[3], q[4];\n"
+      "cp(0.5) q[0], q[1];\n"
+      "crx(3.14159265358979) q[0], q[1];\n"
+      "cy q[0], q[1];\n"
+      "cry(3.14159265358979) q[0], q[1];\n"
+      "cz q[0], q[1];\n"
+      "crz(3.14159265358979) q[0], q[1];\n"
+      "ch q[0], q[1];\n"
+      "cswap q[0], q[1], q[2];\n"
+      "ctrl @ rxx(3.14159265358979) q[0], q[1], q[2];\n"
+      "ctrl @ negctrl @ x q[0], q[1], q[2];\n"
+      "";
 
   EXPECT_EQ(out.str(), expected);
 }
@@ -183,7 +213,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3ControlledCompoundGate) {
                                "OPENQASM 3.0;\n"
                                "include \"stdgates.inc\";\n"
                                "qubit[2] q;\n"
-                               "ctrl @ x q[0], q[1];\n";
+                               "cx q[0], q[1];\n";
 
   EXPECT_EQ(out.str(), expected);
 }
@@ -301,7 +331,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3ConstEval) {
                                "include \"stdgates.inc\";\n"
                                "qubit[8] q;\n"
                                "bit[32] N;\n"
-                               "ctrl @ x q[0], q[7];\n"
+                               "cx q[0], q[7];\n"
                                "x q[0];\n"
                                "x q[1];\n"
                                "x q[2];\n"
@@ -746,8 +776,8 @@ TEST_F(Qasm3ParserTest, ImportQasmBroadcasting) {
                                "h q1[0];\n"
                                "h q1[1];\n"
                                "reset q2;\n"
-                               "ctrl @ x q1[0], q2[0];\n"
-                               "ctrl @ x q1[1], q2[1];\n"
+                               "cx q1[0], q2[0];\n"
+                               "cx q1[1], q2[1];\n"
                                "";
 
   EXPECT_EQ(out.str(), expected);


### PR DESCRIPTION
## Description

For builtin gates, print a `c` prefix instead of `ctrl @ gate`.

### Example

Before:
```qasm
ctrl @ x q0, q1;
ctrl(2) @ x q0, q1, q2;
ctrl(3) @ x q0, q1, q2, q3;
```

After:
```qasm
cx q0, q1;
ccx q0, q1, q2;
ctrl(3) @ x q0, q1, q2, q3;
```

Gates with negative controls, more controls than natively supported or non-supported gates are printed as before, with the `ctrl @ gate` notation.

Fixes #519 

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
