### PR TITLE
⬆️ raise minimum required Boost version to 1.80

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -86,7 +86,7 @@ declare_dependency(
   MD5
   b829378c90f4b268c79a796025c43eee
   MIN_VERSION
-  1.74.0
+  1.80.0
   ALT_NAME
   Boost
   SYSTEM


### PR DESCRIPTION
## Description

This was triggered in QCEC as a random test failure and seems to be due to bugs in earlier versions of multiprecision. `1.80` was confirmed to work.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
