### PR TITLE
🚸♻️ Improve the high-level DD package interfaces

### DIFF
--- a/eval/eval_dd_package.cpp
+++ b/eval/eval_dd_package.cpp
@@ -134,7 +134,7 @@ protected:
       // apply state preparation setup
       qc::QuantumComputation statePrep(qc->getNqubits());
       qc->setup(statePrep);
-      auto s = buildFunctionality(&statePrep, dd);
+      auto s = buildFunctionality(&statePrep, *dd);
       auto e = dd->multiply(s, dd->makeZeroState(qc->getNqubits()));
       dd->incRef(e);
       dd->decRef(s);
@@ -143,7 +143,7 @@ protected:
       qc->oracle(groverIteration);
       qc->diffusion(groverIteration);
 
-      auto iter = buildFunctionalityRecursive(&groverIteration, dd);
+      auto iter = buildFunctionalityRecursive(&groverIteration, *dd);
       std::bitset<128U> iterBits(qc->iterations);
       auto msb =
           static_cast<std::size_t>(std::floor(std::log2(qc->iterations)));

--- a/include/dd/FunctionalityConstruction.hpp
+++ b/include/dd/FunctionalityConstruction.hpp
@@ -8,27 +8,23 @@ namespace dd {
 using namespace qc;
 
 template <class Config>
-MatrixDD buildFunctionality(const QuantumComputation* qc,
-                            std::unique_ptr<dd::Package<Config>>& dd);
+MatrixDD buildFunctionality(const QuantumComputation* qc, Package<Config>& dd);
 
 template <class Config>
 MatrixDD buildFunctionalityRecursive(const QuantumComputation* qc,
-                                     std::unique_ptr<dd::Package<Config>>& dd);
+                                     Package<Config>& dd);
 
 template <class Config>
 bool buildFunctionalityRecursive(const QuantumComputation* qc,
                                  std::size_t depth, std::size_t opIdx,
                                  std::stack<MatrixDD>& s,
-                                 Permutation& permutation,
-                                 std::unique_ptr<dd::Package<Config>>& dd);
+                                 Permutation& permutation, Package<Config>& dd);
 
 template <class Config>
-MatrixDD buildFunctionality(const qc::Grover* qc,
-                            std::unique_ptr<dd::Package<Config>>& dd);
+MatrixDD buildFunctionality(const qc::Grover* qc, Package<Config>& dd);
 
 template <class Config>
-MatrixDD buildFunctionalityRecursive(const qc::Grover* qc,
-                                     std::unique_ptr<dd::Package<Config>>& dd);
+MatrixDD buildFunctionalityRecursive(const qc::Grover* qc, Package<Config>& dd);
 
 inline void dumpTensorNetwork(std::ostream& of, const QuantumComputation& qc) {
   of << "{\"tensors\": [\n";
@@ -42,7 +38,7 @@ inline void dumpTensorNetwork(std::ostream& of, const QuantumComputation& qc) {
     if (op != qc.front() && (type != Measure && type != Barrier)) {
       of << ",\n";
     }
-    dumpTensor(op.get(), of, inds, gateIdx, dd);
+    dumpTensor(op.get(), of, inds, gateIdx, *dd);
   }
   of << "\n]}\n";
 }

--- a/include/dd/Operations.hpp
+++ b/include/dd/Operations.hpp
@@ -12,11 +12,10 @@
 namespace dd {
 // single-target Operations
 template <class Config>
-qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op,
-                                    std::unique_ptr<Package<Config>>& dd,
-                                    const qc::Controls& controls,
-                                    const qc::Qubit target,
-                                    const bool inverse) {
+qc::MatrixDD
+getStandardOperationDD(const qc::StandardOperation* op, Package<Config>& dd,
+                       const qc::Controls& controls, const qc::Qubit target,
+                       const bool inverse) {
   GateMatrix gm;
 
   const auto type = op->getType();
@@ -89,16 +88,15 @@ qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op,
     oss << "DD for gate" << op->getName() << " not available!";
     throw qc::QFRException(oss.str());
   }
-  return dd->makeGateDD(gm, nqubits, controls, target, startQubit);
+  return dd.makeGateDD(gm, nqubits, controls, target, startQubit);
 }
 
 // two-target Operations
 template <class Config>
-qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op,
-                                    std::unique_ptr<Package<Config>>& dd,
-                                    const qc::Controls& controls,
-                                    qc::Qubit target0, qc::Qubit target1,
-                                    const bool inverse) {
+qc::MatrixDD
+getStandardOperationDD(const qc::StandardOperation* op, Package<Config>& dd,
+                       const qc::Controls& controls, qc::Qubit target0,
+                       qc::Qubit target1, const bool inverse) {
   const auto type = op->getType();
   const auto nqubits = op->getNqubits();
   const auto startQubit = op->getStartingQubit();
@@ -154,88 +152,86 @@ qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op,
       definitionFound = false;
     }
     if (definitionFound) {
-      return dd->makeTwoQubitGateDD(gm, nqubits, target0, target1, startQubit);
+      return dd.makeTwoQubitGateDD(gm, nqubits, target0, target1, startQubit);
     }
   }
 
   switch (type) {
   case qc::SWAP:
     // SWAP is self-inverse
-    return dd->makeSWAPDD(nqubits, controls, target0, target1, startQubit);
+    return dd.makeSWAPDD(nqubits, controls, target0, target1, startQubit);
   case qc::iSWAP:
     if (inverse) {
-      return dd->makeiSWAPinvDD(nqubits, controls, target0, target1,
-                                startQubit);
+      return dd.makeiSWAPinvDD(nqubits, controls, target0, target1, startQubit);
     }
-    return dd->makeiSWAPDD(nqubits, controls, target0, target1, startQubit);
+    return dd.makeiSWAPDD(nqubits, controls, target0, target1, startQubit);
   case qc::iSWAPdg:
     if (inverse) {
-      return dd->makeiSWAPDD(nqubits, controls, target0, target1, startQubit);
+      return dd.makeiSWAPDD(nqubits, controls, target0, target1, startQubit);
     }
-    return dd->makeiSWAPinvDD(nqubits, controls, target0, target1, startQubit);
+    return dd.makeiSWAPinvDD(nqubits, controls, target0, target1, startQubit);
   case qc::Peres:
     if (inverse) {
-      return dd->makePeresdagDD(nqubits, controls, target0, target1,
-                                startQubit);
+      return dd.makePeresdagDD(nqubits, controls, target0, target1, startQubit);
     }
-    return dd->makePeresDD(nqubits, controls, target0, target1, startQubit);
+    return dd.makePeresDD(nqubits, controls, target0, target1, startQubit);
   case qc::Peresdg:
     if (inverse) {
-      return dd->makePeresDD(nqubits, controls, target0, target1, startQubit);
+      return dd.makePeresDD(nqubits, controls, target0, target1, startQubit);
     }
-    return dd->makePeresdagDD(nqubits, controls, target0, target1, startQubit);
+    return dd.makePeresdagDD(nqubits, controls, target0, target1, startQubit);
   case qc::DCX:
-    return dd->makeDCXDD(nqubits, controls, target0, target1, startQubit);
+    return dd.makeDCXDD(nqubits, controls, target0, target1, startQubit);
   case qc::ECR:
     // ECR is self-inverse
-    return dd->makeECRDD(nqubits, controls, target0, target1, startQubit);
+    return dd.makeECRDD(nqubits, controls, target0, target1, startQubit);
   case qc::RXX: {
     if (inverse) {
-      return dd->makeRXXDD(nqubits, controls, target0, target1, -parameter[0U],
-                           startQubit);
+      return dd.makeRXXDD(nqubits, controls, target0, target1, -parameter[0U],
+                          startQubit);
     }
-    return dd->makeRXXDD(nqubits, controls, target0, target1, parameter[0U],
-                         startQubit);
+    return dd.makeRXXDD(nqubits, controls, target0, target1, parameter[0U],
+                        startQubit);
   }
   case qc::RYY: {
     if (inverse) {
-      return dd->makeRYYDD(nqubits, controls, target0, target1, -parameter[0U],
-                           startQubit);
+      return dd.makeRYYDD(nqubits, controls, target0, target1, -parameter[0U],
+                          startQubit);
     }
-    return dd->makeRYYDD(nqubits, controls, target0, target1, parameter[0U],
-                         startQubit);
+    return dd.makeRYYDD(nqubits, controls, target0, target1, parameter[0U],
+                        startQubit);
   }
   case qc::RZZ: {
     if (inverse) {
-      return dd->makeRZZDD(nqubits, controls, target0, target1, -parameter[0U],
-                           startQubit);
+      return dd.makeRZZDD(nqubits, controls, target0, target1, -parameter[0U],
+                          startQubit);
     }
-    return dd->makeRZZDD(nqubits, controls, target0, target1, parameter[0U],
-                         startQubit);
+    return dd.makeRZZDD(nqubits, controls, target0, target1, parameter[0U],
+                        startQubit);
   }
   case qc::RZX: {
     if (inverse) {
-      return dd->makeRZXDD(nqubits, controls, target0, target1, -parameter[0U],
-                           startQubit);
+      return dd.makeRZXDD(nqubits, controls, target0, target1, -parameter[0U],
+                          startQubit);
     }
-    return dd->makeRZXDD(nqubits, controls, target0, target1, parameter[0U],
-                         startQubit);
+    return dd.makeRZXDD(nqubits, controls, target0, target1, parameter[0U],
+                        startQubit);
   }
   case qc::XXminusYY: {
     if (inverse) {
-      return dd->makeXXMinusYYDD(nqubits, controls, target0, target1,
-                                 -parameter[0U], parameter[1U], startQubit);
+      return dd.makeXXMinusYYDD(nqubits, controls, target0, target1,
+                                -parameter[0U], parameter[1U], startQubit);
     }
-    return dd->makeXXMinusYYDD(nqubits, controls, target0, target1,
-                               parameter[0U], parameter[1U], startQubit);
+    return dd.makeXXMinusYYDD(nqubits, controls, target0, target1,
+                              parameter[0U], parameter[1U], startQubit);
   }
   case qc::XXplusYY: {
     if (inverse) {
-      return dd->makeXXPlusYYDD(nqubits, controls, target0, target1,
-                                -parameter[0U], parameter[1U], startQubit);
+      return dd.makeXXPlusYYDD(nqubits, controls, target0, target1,
+                               -parameter[0U], parameter[1U], startQubit);
     }
-    return dd->makeXXPlusYYDD(nqubits, controls, target0, target1,
-                              parameter[0U], parameter[1U], startQubit);
+    return dd.makeXXPlusYYDD(nqubits, controls, target0, target1, parameter[0U],
+                             parameter[1U], startQubit);
   }
   default:
     std::ostringstream oss{};
@@ -250,8 +246,7 @@ qc::MatrixDD getStandardOperationDD(const qc::StandardOperation* op,
 //      then cx 0 1 will be translated to cx perm[0] perm[1] == cx 1 0
 
 template <class Config>
-qc::MatrixDD getDD(const qc::Operation* op,
-                   std::unique_ptr<Package<Config>>& dd,
+qc::MatrixDD getDD(const qc::Operation* op, Package<Config>& dd,
                    qc::Permutation& permutation, const bool inverse = false) {
   const auto type = op->getType();
   const auto nqubits = op->getNqubits();
@@ -278,11 +273,11 @@ qc::MatrixDD getDD(const qc::Operation* op,
     const auto target1 = targets[1U];
     // update permutation
     std::swap(permutation.at(target0), permutation.at(target1));
-    return dd->makeIdent(nqubits);
+    return dd.makeIdent(nqubits);
   }
 
   if (type == qc::Barrier) {
-    return dd->makeIdent(nqubits);
+    return dd.makeIdent(nqubits);
   }
 
   if (type == qc::GPhase) {
@@ -290,8 +285,8 @@ qc::MatrixDD getDD(const qc::Operation* op,
     if (inverse) {
       phase = -phase;
     }
-    auto id = dd->makeIdent(nqubits);
-    id.w = dd->cn.lookup(std::cos(phase), std::sin(phase));
+    auto id = dd.makeIdent(nqubits);
+    id.w = dd.cn.lookup(std::cos(phase), std::sin(phase));
     return id;
   }
 
@@ -314,14 +309,14 @@ qc::MatrixDD getDD(const qc::Operation* op,
   }
 
   if (const auto* compoundOp = dynamic_cast<const qc::CompoundOperation*>(op)) {
-    auto e = dd->makeIdent(op->getNqubits());
+    auto e = dd.makeIdent(op->getNqubits());
     if (inverse) {
       for (const auto& operation : *compoundOp) {
-        e = dd->multiply(e, getInverseDD(operation.get(), dd, permutation));
+        e = dd.multiply(e, getInverseDD(operation.get(), dd, permutation));
       }
     } else {
       for (const auto& operation : *compoundOp) {
-        e = dd->multiply(getDD(operation.get(), dd, permutation), e);
+        e = dd.multiply(getDD(operation.get(), dd, permutation), e);
       }
     }
     return e;
@@ -337,22 +332,19 @@ qc::MatrixDD getDD(const qc::Operation* op,
 }
 
 template <class Config>
-qc::MatrixDD getDD(const qc::Operation* op,
-                   std::unique_ptr<Package<Config>>& dd,
+qc::MatrixDD getDD(const qc::Operation* op, Package<Config>& dd,
                    const bool inverse = false) {
   qc::Permutation perm{};
   return getDD(op, dd, perm, inverse);
 }
 
 template <class Config>
-qc::MatrixDD getInverseDD(const qc::Operation* op,
-                          std::unique_ptr<Package<Config>>& dd) {
+qc::MatrixDD getInverseDD(const qc::Operation* op, Package<Config>& dd) {
   return getDD(op, dd, true);
 }
 
 template <class Config>
-qc::MatrixDD getInverseDD(const qc::Operation* op,
-                          std::unique_ptr<Package<Config>>& dd,
+qc::MatrixDD getInverseDD(const qc::Operation* op, Package<Config>& dd,
                           qc::Permutation& permutation) {
   return getDD(op, dd, permutation, true);
 }
@@ -360,14 +352,13 @@ qc::MatrixDD getInverseDD(const qc::Operation* op,
 template <class Config>
 void dumpTensor(qc::Operation* op, std::ostream& of,
                 std::vector<std::size_t>& inds, std::size_t& gateIdx,
-                std::unique_ptr<Package<Config>>& dd);
+                Package<Config>& dd);
 
 // apply swaps 'on' DD in order to change 'from' to 'to'
 // where |from| >= |to|
 template <class DDType, class Config>
 void changePermutation(DDType& on, qc::Permutation& from,
-                       const qc::Permutation& to,
-                       std::unique_ptr<Package<Config>>& dd,
+                       const qc::Permutation& to, Package<Config>& dd,
                        const bool regular = true) {
   assert(from.size() >= to.size());
   if (on.isTerminal()) {
@@ -403,21 +394,21 @@ void changePermutation(DDType& on, qc::Permutation& from,
     // swap i and j
     auto saved = on;
     const auto swapDD =
-        dd->makeTwoQubitGateDD(SWAP_MAT, on.p->v + 1U, from.at(i), from.at(j));
+        dd.makeTwoQubitGateDD(SWAP_MAT, on.p->v + 1U, from.at(i), from.at(j));
     if constexpr (std::is_same_v<DDType, qc::VectorDD>) {
-      on = dd->multiply(swapDD, on);
+      on = dd.multiply(swapDD, on);
     } else {
       // the regular flag only has an effect on matrix DDs
       if (regular) {
-        on = dd->multiply(swapDD, on);
+        on = dd.multiply(swapDD, on);
       } else {
-        on = dd->multiply(on, swapDD);
+        on = dd.multiply(on, swapDD);
       }
     }
 
-    dd->incRef(on);
-    dd->decRef(saved);
-    dd->garbageCollect();
+    dd.incRef(on);
+    dd.decRef(saved);
+    dd.garbageCollect();
 
     // update permutation
     from.at(i) = goal;

--- a/include/dd/Simulation.hpp
+++ b/include/dd/Simulation.hpp
@@ -9,48 +9,46 @@ using namespace qc;
 
 template <class Config>
 VectorDD simulate(const QuantumComputation* qc, const VectorDD& in,
-                  std::unique_ptr<dd::Package<Config>>& dd) {
+                  Package<Config>& dd) {
   // measurements are currently not supported here
   auto permutation = qc->initialLayout;
   auto e = in;
-  dd->incRef(e);
+  dd.incRef(e);
 
   for (const auto& op : *qc) {
-    auto tmp = dd->multiply(getDD(op.get(), dd, permutation), e);
-    dd->incRef(tmp);
-    dd->decRef(e);
+    auto tmp = dd.multiply(getDD(op.get(), dd, permutation), e);
+    dd.incRef(tmp);
+    dd.decRef(e);
     e = tmp;
 
-    dd->garbageCollect();
+    dd.garbageCollect();
   }
 
   // correct permutation if necessary
   changePermutation(e, permutation, qc->outputPermutation, dd);
-  e = dd->reduceGarbage(e, qc->garbage);
+  e = dd.reduceGarbage(e, qc->garbage);
 
   return e;
 }
 
 template <class Config>
 std::map<std::string, std::size_t>
-simulate(const QuantumComputation* qc, const VectorDD& in,
-         std::unique_ptr<dd::Package<Config>>& dd, std::size_t shots,
-         std::size_t seed = 0U);
+simulate(const QuantumComputation* qc, const VectorDD& in, Package<Config>& dd,
+         std::size_t shots, std::size_t seed = 0U);
 
 template <class Config>
 void extractProbabilityVector(const QuantumComputation* qc, const VectorDD& in,
-                              dd::SparsePVec& probVector,
-                              std::unique_ptr<dd::Package<Config>>& dd);
+                              dd::SparsePVec& probVector, Package<Config>& dd);
 
 template <class Config>
 void extractProbabilityVectorRecursive(
     const QuantumComputation* qc, const VectorDD& currentState,
     decltype(qc->begin()) currentIt, Permutation& permutation,
     std::map<std::size_t, char> measurements, dd::fp commonFactor,
-    dd::SparsePVec& probVector, std::unique_ptr<dd::Package<Config>>& dd);
+    dd::SparsePVec& probVector, Package<Config>& dd);
 
 template <class Config>
 VectorDD simulate(GoogleRandomCircuitSampling* qc, const VectorDD& in,
-                  std::unique_ptr<dd::Package<Config>>& dd,
+                  Package<Config>& dd,
                   std::optional<std::size_t> ncycles = std::nullopt);
 } // namespace dd

--- a/src/dd/Benchmark.cpp
+++ b/src/dd/Benchmark.cpp
@@ -16,7 +16,7 @@ benchmarkSimulate(const QuantumComputation& qc) {
   exp->dd = std::make_unique<Package<>>(nq);
   const auto start = std::chrono::high_resolution_clock::now();
   const auto in = exp->dd->makeZeroState(nq);
-  exp->sim = simulate(&qc, in, exp->dd);
+  exp->sim = simulate(&qc, in, *(exp->dd));
   const auto end = std::chrono::high_resolution_clock::now();
   exp->runtime =
       std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
@@ -33,9 +33,9 @@ benchmarkFunctionalityConstruction(const QuantumComputation& qc,
   exp->dd = std::make_unique<Package<>>(nq);
   const auto start = std::chrono::high_resolution_clock::now();
   if (recursive) {
-    exp->func = buildFunctionalityRecursive(&qc, exp->dd);
+    exp->func = buildFunctionalityRecursive(&qc, *(exp->dd));
   } else {
-    exp->func = buildFunctionality(&qc, exp->dd);
+    exp->func = buildFunctionality(&qc, *(exp->dd));
   }
   const auto end = std::chrono::high_resolution_clock::now();
   exp->runtime =
@@ -50,7 +50,7 @@ benchmarkSimulateWithShots(const qc::QuantumComputation& qc,
   auto nq = qc.getNqubits();
   auto dd = std::make_unique<dd::Package<>>(nq);
   auto in = dd->makeZeroState(nq);
-  auto measurements = simulate(&qc, in, dd, shots);
+  auto measurements = simulate(&qc, in, *dd, shots);
   return measurements;
 }
 

--- a/src/dd/FunctionalityConstruction.cpp
+++ b/src/dd/FunctionalityConstruction.cpp
@@ -2,8 +2,7 @@
 
 namespace dd {
 template <class Config>
-MatrixDD buildFunctionality(const QuantumComputation* qc,
-                            std::unique_ptr<Package<Config>>& dd) {
+MatrixDD buildFunctionality(const QuantumComputation* qc, Package<Config>& dd) {
   const auto nq = qc->getNqubits();
   if (nq == 0U) {
     return MatrixDD::one();
@@ -14,28 +13,28 @@ MatrixDD buildFunctionality(const QuantumComputation* qc,
   }
 
   auto permutation = qc->initialLayout;
-  auto e = dd->createInitialMatrix(nq, qc->ancillary);
+  auto e = dd.createInitialMatrix(nq, qc->ancillary);
 
   for (const auto& op : *qc) {
-    auto tmp = dd->multiply(getDD(op.get(), dd, permutation), e);
+    auto tmp = dd.multiply(getDD(op.get(), dd, permutation), e);
 
-    dd->incRef(tmp);
-    dd->decRef(e);
+    dd.incRef(tmp);
+    dd.decRef(e);
     e = tmp;
 
-    dd->garbageCollect();
+    dd.garbageCollect();
   }
   // correct permutation if necessary
   changePermutation(e, permutation, qc->outputPermutation, dd);
-  e = dd->reduceAncillae(e, qc->ancillary);
-  e = dd->reduceGarbage(e, qc->garbage);
+  e = dd.reduceAncillae(e, qc->ancillary);
+  e = dd.reduceGarbage(e, qc->garbage);
 
   return e;
 }
 
 template <class Config>
 MatrixDD buildFunctionalityRecursive(const QuantumComputation* qc,
-                                     std::unique_ptr<Package<Config>>& dd) {
+                                     Package<Config>& dd) {
   if (qc->getNqubits() == 0U) {
     return MatrixDD::one();
   }
@@ -48,7 +47,7 @@ MatrixDD buildFunctionalityRecursive(const QuantumComputation* qc,
 
   if (qc->size() == 1U) {
     auto e = getDD(qc->front().get(), dd, permutation);
-    dd->incRef(e);
+    dd.incRef(e);
     return e;
   }
 
@@ -60,8 +59,8 @@ MatrixDD buildFunctionalityRecursive(const QuantumComputation* qc,
 
   // correct permutation if necessary
   changePermutation(e, permutation, qc->outputPermutation, dd);
-  e = dd->reduceAncillae(e, qc->ancillary);
-  e = dd->reduceGarbage(e, qc->garbage);
+  e = dd.reduceAncillae(e, qc->ancillary);
+  e = dd.reduceGarbage(e, qc->garbage);
 
   return e;
 }
@@ -71,19 +70,19 @@ bool buildFunctionalityRecursive(const QuantumComputation* qc,
                                  std::size_t depth, std::size_t opIdx,
                                  std::stack<MatrixDD>& s,
                                  Permutation& permutation,
-                                 std::unique_ptr<Package<Config>>& dd) {
+                                 Package<Config>& dd) {
   // base case
   if (depth == 1U) {
     auto e = getDD(qc->at(opIdx).get(), dd, permutation);
     ++opIdx;
     if (opIdx == qc->size()) { // only one element was left
       s.push(e);
-      dd->incRef(e);
+      dd.incRef(e);
       return false;
     }
     auto f = getDD(qc->at(opIdx).get(), dd, permutation);
-    s.push(dd->multiply(f, e)); // ! reverse multiplication
-    dd->incRef(s.top());
+    s.push(dd.multiply(f, e)); // ! reverse multiplication
+    dd.incRef(s.top());
     return (opIdx != qc->size() - 1U);
   }
 
@@ -106,20 +105,19 @@ bool buildFunctionalityRecursive(const QuantumComputation* qc,
   s.pop();
   auto f = s.top();
   s.pop();
-  s.push(dd->multiply(e, f)); // ordering because of stack structure
+  s.push(dd.multiply(e, f)); // ordering because of stack structure
 
   // reference counting
-  dd->decRef(e);
-  dd->decRef(f);
-  dd->incRef(s.top());
-  dd->garbageCollect();
+  dd.decRef(e);
+  dd.decRef(f);
+  dd.incRef(s.top());
+  dd.garbageCollect();
 
   return success;
 }
 
 template <class Config>
-MatrixDD buildFunctionality(const qc::Grover* qc,
-                            std::unique_ptr<Package<Config>>& dd) {
+MatrixDD buildFunctionality(const qc::Grover* qc, Package<Config>& dd) {
   QuantumComputation groverIteration(qc->getNqubits());
   qc->oracle(groverIteration);
   qc->diffusion(groverIteration);
@@ -127,32 +125,32 @@ MatrixDD buildFunctionality(const qc::Grover* qc,
   auto iteration = buildFunctionality(&groverIteration, dd);
 
   auto e = iteration;
-  dd->incRef(e);
+  dd.incRef(e);
 
   for (std::size_t i = 0U; i < qc->iterations - 1U; ++i) {
-    auto f = dd->multiply(iteration, e);
-    dd->incRef(f);
-    dd->decRef(e);
+    auto f = dd.multiply(iteration, e);
+    dd.incRef(f);
+    dd.decRef(e);
     e = f;
-    dd->garbageCollect();
+    dd.garbageCollect();
   }
 
   QuantumComputation setup(qc->getNqubits());
   qc->setup(setup);
   auto g = buildFunctionality(&setup, dd);
-  auto f = dd->multiply(e, g);
-  dd->incRef(f);
-  dd->decRef(e);
-  dd->decRef(g);
+  auto f = dd.multiply(e, g);
+  dd.incRef(f);
+  dd.decRef(e);
+  dd.decRef(g);
   e = f;
 
-  dd->decRef(iteration);
+  dd.decRef(iteration);
   return e;
 }
 
 template <class Config>
 MatrixDD buildFunctionalityRecursive(const qc::Grover* qc,
-                                     std::unique_ptr<Package<Config>>& dd) {
+                                     Package<Config>& dd) {
   QuantumComputation groverIteration(qc->getNqubits());
   qc->oracle(groverIteration);
   qc->diffusion(groverIteration);
@@ -162,59 +160,55 @@ MatrixDD buildFunctionalityRecursive(const qc::Grover* qc,
   std::bitset<128U> iterBits(qc->iterations);
   auto msb = static_cast<std::size_t>(std::floor(std::log2(qc->iterations)));
   auto f = iter;
-  dd->incRef(f);
+  dd.incRef(f);
   bool zero = !iterBits[0U];
   for (std::size_t j = 1U; j <= msb; ++j) {
-    auto tmp = dd->multiply(f, f);
-    dd->incRef(tmp);
-    dd->decRef(f);
+    auto tmp = dd.multiply(f, f);
+    dd.incRef(tmp);
+    dd.decRef(f);
     f = tmp;
     if (iterBits[j]) {
       if (zero) {
-        dd->incRef(f);
-        dd->decRef(e);
+        dd.incRef(f);
+        dd.decRef(e);
         e = f;
         zero = false;
       } else {
-        auto g = dd->multiply(e, f);
-        dd->incRef(g);
-        dd->decRef(e);
+        auto g = dd.multiply(e, f);
+        dd.incRef(g);
+        dd.decRef(e);
         e = g;
-        dd->garbageCollect();
+        dd.garbageCollect();
       }
     }
   }
-  dd->decRef(f);
+  dd.decRef(f);
 
   // apply state preparation setup
   qc::QuantumComputation statePrep(qc->getNqubits());
   qc->setup(statePrep);
   auto s = buildFunctionality(&statePrep, dd);
-  auto tmp = dd->multiply(e, s);
-  dd->incRef(tmp);
-  dd->decRef(s);
-  dd->decRef(e);
+  auto tmp = dd.multiply(e, s);
+  dd.incRef(tmp);
+  dd.decRef(s);
+  dd.decRef(e);
   e = tmp;
 
   return e;
 }
 
-template MatrixDD
-buildFunctionality(const qc::QuantumComputation* qc,
-                   std::unique_ptr<Package<DDPackageConfig>>& dd);
-template MatrixDD
-buildFunctionalityRecursive(const qc::QuantumComputation* qc,
-                            std::unique_ptr<Package<DDPackageConfig>>& dd);
-template bool
-buildFunctionalityRecursive(const qc::QuantumComputation* qc,
-                            const std::size_t depth, const std::size_t opIdx,
-                            std::stack<MatrixDD>& s,
-                            qc::Permutation& permutation,
-                            std::unique_ptr<Package<DDPackageConfig>>& dd);
-template MatrixDD
-buildFunctionality(const qc::Grover* qc,
-                   std::unique_ptr<Package<DDPackageConfig>>& dd);
-template MatrixDD
-buildFunctionalityRecursive(const qc::Grover* qc,
-                            std::unique_ptr<Package<DDPackageConfig>>& dd);
+template MatrixDD buildFunctionality(const qc::QuantumComputation* qc,
+                                     Package<DDPackageConfig>& dd);
+template MatrixDD buildFunctionalityRecursive(const qc::QuantumComputation* qc,
+                                              Package<DDPackageConfig>& dd);
+template bool buildFunctionalityRecursive(const qc::QuantumComputation* qc,
+                                          const std::size_t depth,
+                                          const std::size_t opIdx,
+                                          std::stack<MatrixDD>& s,
+                                          qc::Permutation& permutation,
+                                          Package<DDPackageConfig>& dd);
+template MatrixDD buildFunctionality(const qc::Grover* qc,
+                                     Package<DDPackageConfig>& dd);
+template MatrixDD buildFunctionalityRecursive(const qc::Grover* qc,
+                                              Package<DDPackageConfig>& dd);
 } // namespace dd

--- a/src/dd/Operations.cpp
+++ b/src/dd/Operations.cpp
@@ -4,7 +4,7 @@ namespace dd {
 template <class Config>
 void dumpTensor(qc::Operation* op, std::ostream& of,
                 std::vector<std::size_t>& inds, size_t& gateIdx,
-                std::unique_ptr<dd::Package<Config>>& dd) {
+                Package<Config>& dd) {
   const auto type = op->getType();
   if (op->isStandardOperation()) {
     auto nqubits = op->getNqubits();
@@ -74,7 +74,7 @@ void dumpTensor(qc::Operation* op, std::ostream& of,
         localTargets.emplace_back(localIdx);
       } else {
         const auto* control = std::get_if<qc::Control>(&var);
-        localControls.emplace(qc::Control{localIdx, control->type});
+        localControls.emplace(localIdx, control->type);
       }
       ++localIdx;
     }
@@ -134,8 +134,8 @@ void dumpTensor(qc::Operation* op, std::ostream& of,
   }
 }
 
-template void
-dumpTensor<DDPackageConfig>(qc::Operation* op, std::ostream& of,
-                            std::vector<std::size_t>& inds, size_t& gateIdx,
-                            std::unique_ptr<dd::Package<DDPackageConfig>>& dd);
+template void dumpTensor<DDPackageConfig>(qc::Operation* op, std::ostream& of,
+                                          std::vector<std::size_t>& inds,
+                                          size_t& gateIdx,
+                                          Package<DDPackageConfig>& dd);
 } // namespace dd

--- a/test/algorithms/eval_dynamic_circuits.cpp
+++ b/test/algorithms/eval_dynamic_circuits.cpp
@@ -117,8 +117,9 @@ TEST_P(DynamicCircuitEvalExactQPE, UnitaryTransformation) {
   auto rightIt = iqpe->begin();
 
   while (leftIt != qpe->end() && rightIt != iqpe->end()) {
-    auto multLeft = dd->multiply(getDD((*leftIt).get(), dd), e);
-    auto multRight = dd->multiply(multLeft, getInverseDD((*rightIt).get(), dd));
+    auto multLeft = dd->multiply(getDD((*leftIt).get(), *dd), e);
+    auto multRight =
+        dd->multiply(multLeft, getInverseDD((*rightIt).get(), *dd));
     dd->incRef(multRight);
     dd->decRef(e);
     e = multRight;
@@ -130,7 +131,7 @@ TEST_P(DynamicCircuitEvalExactQPE, UnitaryTransformation) {
   }
 
   while (leftIt != qpe->end()) {
-    auto multLeft = dd->multiply(getDD((*leftIt).get(), dd), e);
+    auto multLeft = dd->multiply(getDD((*leftIt).get(), *dd), e);
     dd->incRef(multLeft);
     dd->decRef(e);
     e = multLeft;
@@ -141,7 +142,7 @@ TEST_P(DynamicCircuitEvalExactQPE, UnitaryTransformation) {
   }
 
   while (rightIt != iqpe->end()) {
-    auto multRight = dd->multiply(e, getInverseDD((*rightIt).get(), dd));
+    auto multRight = dd->multiply(e, getInverseDD((*rightIt).get(), *dd));
     dd->incRef(multRight);
     dd->decRef(e);
     e = multRight;
@@ -177,7 +178,7 @@ TEST_P(DynamicCircuitEvalExactQPE, ProbabilityExtraction) {
   // extract measurement probabilities from IQPE simulations
   dd::SparsePVec probs{};
   extractProbabilityVector(iqpe.get(), dd->makeZeroState(iqpe->getNqubits()),
-                           probs, dd);
+                           probs, *dd);
   const auto extractionEnd = std::chrono::steady_clock::now();
 
   // compare outcomes
@@ -322,8 +323,9 @@ TEST_P(DynamicCircuitEvalInexactQPE, UnitaryTransformation) {
   auto rightIt = iqpe->begin();
 
   while (leftIt != qpe->end() && rightIt != iqpe->end()) {
-    auto multLeft = dd->multiply(getDD((*leftIt).get(), dd), e);
-    auto multRight = dd->multiply(multLeft, getInverseDD((*rightIt).get(), dd));
+    auto multLeft = dd->multiply(getDD((*leftIt).get(), *dd), e);
+    auto multRight =
+        dd->multiply(multLeft, getInverseDD((*rightIt).get(), *dd));
     dd->incRef(multRight);
     dd->decRef(e);
     e = multRight;
@@ -335,7 +337,7 @@ TEST_P(DynamicCircuitEvalInexactQPE, UnitaryTransformation) {
   }
 
   while (leftIt != qpe->end()) {
-    auto multLeft = dd->multiply(getDD((*leftIt).get(), dd), e);
+    auto multLeft = dd->multiply(getDD((*leftIt).get(), *dd), e);
     dd->incRef(multLeft);
     dd->decRef(e);
     e = multLeft;
@@ -346,7 +348,7 @@ TEST_P(DynamicCircuitEvalInexactQPE, UnitaryTransformation) {
   }
 
   while (rightIt != iqpe->end()) {
-    auto multRight = dd->multiply(e, getInverseDD((*rightIt).get(), dd));
+    auto multRight = dd->multiply(e, getInverseDD((*rightIt).get(), *dd));
     dd->incRef(multRight);
     dd->decRef(e);
     e = multRight;
@@ -376,7 +378,7 @@ TEST_P(DynamicCircuitEvalInexactQPE, ProbabilityExtraction) {
   // extract measurement probabilities from IQPE simulations
   dd::SparsePVec probs{};
   extractProbabilityVector(iqpe.get(), dd->makeZeroState(iqpe->getNqubits()),
-                           probs, dd);
+                           probs, *dd);
   const auto extractionEnd = std::chrono::steady_clock::now();
   std::cout << "---- extraction done ----\n";
 
@@ -477,8 +479,9 @@ TEST_P(DynamicCircuitEvalBV, UnitaryTransformation) {
   auto rightIt = dbv->begin();
 
   while (leftIt != bv->end() && rightIt != dbv->end()) {
-    auto multLeft = dd->multiply(getDD((*leftIt).get(), dd), e);
-    auto multRight = dd->multiply(multLeft, getInverseDD((*rightIt).get(), dd));
+    auto multLeft = dd->multiply(getDD((*leftIt).get(), *dd), e);
+    auto multRight =
+        dd->multiply(multLeft, getInverseDD((*rightIt).get(), *dd));
     dd->incRef(multRight);
     dd->decRef(e);
     e = multRight;
@@ -490,7 +493,7 @@ TEST_P(DynamicCircuitEvalBV, UnitaryTransformation) {
   }
 
   while (leftIt != bv->end()) {
-    auto multLeft = dd->multiply(getDD((*leftIt).get(), dd), e);
+    auto multLeft = dd->multiply(getDD((*leftIt).get(), *dd), e);
     dd->incRef(multLeft);
     dd->decRef(e);
     e = multLeft;
@@ -501,7 +504,7 @@ TEST_P(DynamicCircuitEvalBV, UnitaryTransformation) {
   }
 
   while (rightIt != dbv->end()) {
-    auto multRight = dd->multiply(e, getInverseDD((*rightIt).get(), dd));
+    auto multRight = dd->multiply(e, getInverseDD((*rightIt).get(), *dd));
     dd->incRef(multRight);
     dd->decRef(e);
     e = multRight;
@@ -537,7 +540,7 @@ TEST_P(DynamicCircuitEvalBV, ProbabilityExtraction) {
   // extract measurement probabilities from IQPE simulations
   dd::SparsePVec probs{};
   extractProbabilityVector(dbv.get(), dd->makeZeroState(dbv->getNqubits()),
-                           probs, dd);
+                           probs, *dd);
   const auto extractionEnd = std::chrono::steady_clock::now();
 
   // compare outcomes
@@ -624,8 +627,9 @@ TEST_P(DynamicCircuitEvalQFT, UnitaryTransformation) {
   auto rightIt = dqft->begin();
 
   while (leftIt != qft->end() && rightIt != dqft->end()) {
-    auto multLeft = dd->multiply(getDD((*leftIt).get(), dd), e);
-    auto multRight = dd->multiply(multLeft, getInverseDD((*rightIt).get(), dd));
+    auto multLeft = dd->multiply(getDD((*leftIt).get(), *dd), e);
+    auto multRight =
+        dd->multiply(multLeft, getInverseDD((*rightIt).get(), *dd));
     dd->incRef(multRight);
     dd->decRef(e);
     e = multRight;
@@ -637,7 +641,7 @@ TEST_P(DynamicCircuitEvalQFT, UnitaryTransformation) {
   }
 
   while (leftIt != qft->end()) {
-    auto multLeft = dd->multiply(getDD((*leftIt).get(), dd), e);
+    auto multLeft = dd->multiply(getDD((*leftIt).get(), *dd), e);
     dd->incRef(multLeft);
     dd->decRef(e);
     e = multLeft;
@@ -648,7 +652,7 @@ TEST_P(DynamicCircuitEvalQFT, UnitaryTransformation) {
   }
 
   while (rightIt != dqft->end()) {
-    auto multRight = dd->multiply(e, getInverseDD((*rightIt).get(), dd));
+    auto multRight = dd->multiply(e, getInverseDD((*rightIt).get(), *dd));
     dd->incRef(multRight);
     dd->decRef(e);
     e = multRight;
@@ -688,7 +692,7 @@ TEST_P(DynamicCircuitEvalQFT, ProbabilityExtraction) {
   if (qft->getNqubits() <= 15) {
     dd::SparsePVec probs{};
     extractProbabilityVector(dqft.get(), dd->makeZeroState(dqft->getNqubits()),
-                             probs, dd);
+                             probs, *dd);
     const auto extractionEnd = std::chrono::steady_clock::now();
 
     // compare outcomes

--- a/test/algorithms/test_bernsteinvazirani.cpp
+++ b/test/algorithms/test_bernsteinvazirani.cpp
@@ -114,7 +114,7 @@ TEST_P(BernsteinVazirani, DynamicEquivalenceSimulation) {
   qc::CircuitOptimizer::removeFinalMeasurements(bv);
 
   // simulate circuit
-  auto e = simulate(&bv, dd->makeZeroState(bv.getNqubits()), dd);
+  auto e = simulate(&bv, dd->makeZeroState(bv.getNqubits()), *dd);
 
   // create dynamic BV circuit
   auto dbv = qc::BernsteinVazirani(s, true);
@@ -129,7 +129,7 @@ TEST_P(BernsteinVazirani, DynamicEquivalenceSimulation) {
   qc::CircuitOptimizer::removeFinalMeasurements(dbv);
 
   // simulate circuit
-  auto f = simulate(&dbv, dd->makeZeroState(dbv.getNqubits()), dd);
+  auto f = simulate(&dbv, dd->makeZeroState(dbv.getNqubits()), *dd);
 
   // calculate fidelity between both results
   auto fidelity = dd->fidelity(e, f);

--- a/test/algorithms/test_grcs.cpp
+++ b/test/algorithms/test_grcs.cpp
@@ -28,7 +28,7 @@ TEST_F(GRCS, simulate) {
   auto dd = std::make_unique<dd::Package<>>(qcBris.getNqubits());
   auto in = dd->makeZeroState(qcBris.getNqubits());
   const std::optional<std::size_t> ncycles = 4;
-  ASSERT_NO_THROW({ simulate(&qcBris, in, dd, ncycles); });
+  ASSERT_NO_THROW({ simulate(&qcBris, in, *dd, ncycles); });
   std::cout << qcBris << "\n";
   qcBris.printStatistics(std::cout);
 }

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -198,7 +198,7 @@ TEST_P(QFT, FunctionalityRecursiveEquality) {
   auto dd = std::move(exp->dd);
 
   // there should be no error building the functionality regularly
-  auto funcRec = buildFunctionalityRecursive(qc.get(), dd);
+  auto funcRec = buildFunctionalityRecursive(qc.get(), *dd);
 
   ASSERT_EQ(func, funcRec);
   dd->decRef(funcRec);

--- a/test/algorithms/test_qpe.cpp
+++ b/test/algorithms/test_qpe.cpp
@@ -196,7 +196,7 @@ TEST_P(QPE, DynamicEquivalenceSimulation) {
   qc::CircuitOptimizer::removeFinalMeasurements(qpe);
 
   // simulate circuit
-  auto e = simulate(&qpe, dd->makeZeroState(qpe.getNqubits()), dd);
+  auto e = simulate(&qpe, dd->makeZeroState(qpe.getNqubits()), *dd);
 
   // create standard IQPE circuit
   auto iqpe = qc::QPE(lambda, precision, true);
@@ -210,7 +210,7 @@ TEST_P(QPE, DynamicEquivalenceSimulation) {
   qc::CircuitOptimizer::removeFinalMeasurements(iqpe);
 
   // simulate circuit
-  auto f = simulate(&iqpe, dd->makeZeroState(iqpe.getNqubits()), dd);
+  auto f = simulate(&iqpe, dd->makeZeroState(iqpe.getNqubits()), *dd);
 
   // calculate fidelity between both results
   auto fidelity = dd->fidelity(e, f);
@@ -245,7 +245,7 @@ TEST_P(QPE, DynamicEquivalenceFunctionality) {
   qc::CircuitOptimizer::removeFinalMeasurements(iqpe);
 
   // simulate circuit
-  auto f = buildFunctionality(&iqpe, exp->dd);
+  auto f = buildFunctionality(&iqpe, *(exp->dd));
 
   EXPECT_EQ(e, f);
 }
@@ -259,7 +259,7 @@ TEST_P(QPE, ProbabilityExtraction) {
   std::cout << iqpe << "\n";
   dd::SparsePVec probs{};
   extractProbabilityVector(&iqpe, dd->makeZeroState(iqpe.getNqubits()), probs,
-                           dd);
+                           *dd);
 
   for (const auto& [state, prob] : probs) {
     std::stringstream ss{};
@@ -286,7 +286,7 @@ TEST_P(QPE, DynamicEquivalenceSimulationProbabilityExtraction) {
   qc::CircuitOptimizer::removeFinalMeasurements(qpe);
 
   // simulate circuit
-  auto e = simulate(&qpe, dd->makeZeroState(qpe.getNqubits()), dd);
+  auto e = simulate(&qpe, dd->makeZeroState(qpe.getNqubits()), *dd);
   const auto vec = e.getVector();
   std::cout << "QPE:\n";
   for (const auto& amp : vec) {
@@ -299,7 +299,7 @@ TEST_P(QPE, DynamicEquivalenceSimulationProbabilityExtraction) {
   // extract measurement probabilities from IQPE simulations
   dd::SparsePVec probs{};
   extractProbabilityVector(&iqpe, dd->makeZeroState(iqpe.getNqubits()), probs,
-                           dd);
+                           *dd);
 
   std::cout << "IQPE:\n";
   for (const auto& [state, prob] : probs) {

--- a/test/dd/test_dd_functionality.cpp
+++ b/test/dd/test_dd_functionality.cpp
@@ -90,11 +90,9 @@ TEST_P(DDFunctionality, standardOpBuildInverseBuild) {
   case qc::iSWAPdg:
   case qc::DCX:
   case qc::ECR:
-    op = qc::StandardOperation(nqubits, Controls{}, 0, 1, gate);
-    break;
   case qc::Peres:
   case qc::Peresdg:
-    op = qc::StandardOperation(nqubits, {0_pc}, 1, 2, gate);
+    op = qc::StandardOperation(nqubits, {}, 0, 1, gate);
     break;
   case qc::RXX:
   case qc::RYY:
@@ -110,6 +108,63 @@ TEST_P(DDFunctionality, standardOpBuildInverseBuild) {
     break;
   default:
     op = qc::StandardOperation(nqubits, 0, gate);
+  }
+
+  ASSERT_NO_THROW(
+      { e = dd->multiply(getDD(&op, *dd), getInverseDD(&op, *dd)); });
+  dd->incRef(e);
+
+  EXPECT_EQ(ident, e);
+}
+
+TEST_P(DDFunctionality, controlledStandardOpBuildInverseBuild) {
+  using namespace qc::literals;
+  auto gate = static_cast<qc::OpType>(GetParam());
+
+  qc::StandardOperation op;
+  switch (gate) {
+  case qc::GPhase:
+    op = qc::StandardOperation(nqubits, Controls{0}, Targets{}, gate,
+                               std::vector{dist(mt)});
+    break;
+  case qc::U:
+    op = qc::StandardOperation(nqubits, 0, 1, gate,
+                               std::vector{dist(mt), dist(mt), dist(mt)});
+    break;
+  case qc::U2:
+    op = qc::StandardOperation(nqubits, 0, 1, gate,
+                               std::vector{dist(mt), dist(mt)});
+    break;
+  case qc::RX:
+  case qc::RY:
+  case qc::RZ:
+  case qc::P:
+    op = qc::StandardOperation(nqubits, 0, 1, gate, std::vector{dist(mt)});
+    break;
+
+  case qc::SWAP:
+  case qc::iSWAP:
+  case qc::iSWAPdg:
+  case qc::DCX:
+  case qc::ECR:
+  case qc::Peres:
+  case qc::Peresdg:
+    op = qc::StandardOperation(nqubits, Controls{0}, 1, 2, gate);
+    break;
+  case qc::RXX:
+  case qc::RYY:
+  case qc::RZZ:
+  case qc::RZX:
+    op = qc::StandardOperation(nqubits, Controls{0}, 1, 2, gate,
+                               std::vector{dist(mt)});
+    break;
+  case qc::XXminusYY:
+  case qc::XXplusYY:
+    op = qc::StandardOperation(nqubits, Controls{0}, 1, 2, gate,
+                               std::vector{dist(mt), dist(mt)});
+    break;
+  default:
+    op = qc::StandardOperation(nqubits, 0, 1, gate);
   }
 
   ASSERT_NO_THROW(

--- a/test/dd/test_dd_functionality.cpp
+++ b/test/dd/test_dd_functionality.cpp
@@ -112,7 +112,8 @@ TEST_P(DDFunctionality, standardOpBuildInverseBuild) {
     op = qc::StandardOperation(nqubits, 0, gate);
   }
 
-  ASSERT_NO_THROW({ e = dd->multiply(getDD(&op, dd), getInverseDD(&op, dd)); });
+  ASSERT_NO_THROW(
+      { e = dd->multiply(getDD(&op, *dd), getInverseDD(&op, *dd)); });
   dd->incRef(e);
 
   EXPECT_EQ(ident, e);
@@ -188,11 +189,11 @@ TEST_F(DDFunctionality, buildCircuit) {
   qc.swap(0, 1);
   qc.x(0);
 
-  e = buildFunctionality(&qc, dd);
+  e = buildFunctionality(&qc, *dd);
   EXPECT_EQ(ident, e);
 
   qc.x(0);
-  e = buildFunctionality(&qc, dd);
+  e = buildFunctionality(&qc, *dd);
   dd->incRef(e);
   EXPECT_NE(ident, e);
 }
@@ -202,10 +203,10 @@ TEST_F(DDFunctionality, nonUnitary) {
   auto dummyMap = Permutation{};
   auto op = qc::NonUnitaryOperation(nqubits, {0, 1, 2, 3}, {0, 1, 2, 3});
   EXPECT_FALSE(op.isUnitary());
-  EXPECT_THROW(getDD(&op, dd), qc::QFRException);
-  EXPECT_THROW(getInverseDD(&op, dd), qc::QFRException);
-  EXPECT_THROW(getDD(&op, dd, dummyMap), qc::QFRException);
-  EXPECT_THROW(getInverseDD(&op, dd, dummyMap), qc::QFRException);
+  EXPECT_THROW(getDD(&op, *dd), qc::QFRException);
+  EXPECT_THROW(getInverseDD(&op, *dd), qc::QFRException);
+  EXPECT_THROW(getDD(&op, *dd, dummyMap), qc::QFRException);
+  EXPECT_THROW(getInverseDD(&op, *dd, dummyMap), qc::QFRException);
   for (Qubit i = 0; i < nqubits; ++i) {
     EXPECT_TRUE(op.actsOn(i));
   }
@@ -215,10 +216,10 @@ TEST_F(DDFunctionality, nonUnitary) {
   }
   auto barrier =
       qc::StandardOperation(nqubits, {0, 1, 2, 3}, qc::OpType::Barrier);
-  EXPECT_EQ(getDD(&barrier, dd), dd->makeIdent(nqubits));
-  EXPECT_EQ(getInverseDD(&barrier, dd), dd->makeIdent(nqubits));
-  EXPECT_EQ(getDD(&barrier, dd, dummyMap), dd->makeIdent(nqubits));
-  EXPECT_EQ(getInverseDD(&barrier, dd, dummyMap), dd->makeIdent(nqubits));
+  EXPECT_EQ(getDD(&barrier, *dd), dd->makeIdent(nqubits));
+  EXPECT_EQ(getInverseDD(&barrier, *dd), dd->makeIdent(nqubits));
+  EXPECT_EQ(getDD(&barrier, *dd, dummyMap), dd->makeIdent(nqubits));
+  EXPECT_EQ(getInverseDD(&barrier, *dd, dummyMap), dd->makeIdent(nqubits));
 }
 
 TEST_F(DDFunctionality, CircuitEquivalence) {
@@ -232,8 +233,8 @@ TEST_F(DDFunctionality, CircuitEquivalence) {
   qc2.sx(0);
   qc2.rz(PI_2, 0);
 
-  const qc::MatrixDD dd1 = buildFunctionality(&qc1, dd);
-  const qc::MatrixDD dd2 = buildFunctionality(&qc2, dd);
+  const qc::MatrixDD dd1 = buildFunctionality(&qc1, *dd);
+  const qc::MatrixDD dd2 = buildFunctionality(&qc2, *dd);
 
   EXPECT_EQ(dd1.p, dd2.p);
 }
@@ -245,12 +246,12 @@ TEST_F(DDFunctionality, changePermutation) {
                                "qreg q[2];"
                                "x q[0];\n";
   const auto qc = QuantumComputation::fromQASM(testfile);
-  auto sim = simulate(&qc, dd->makeZeroState(qc.getNqubits()), dd);
+  auto sim = simulate(&qc, dd->makeZeroState(qc.getNqubits()), *dd);
   EXPECT_TRUE(sim.p->e[0].isZeroTerminal());
   EXPECT_TRUE(sim.p->e[1].w.exactlyOne());
   EXPECT_TRUE(sim.p->e[1].p->e[1].isZeroTerminal());
   EXPECT_TRUE(sim.p->e[1].p->e[0].w.exactlyOne());
-  auto func = buildFunctionality(&qc, dd);
+  auto func = buildFunctionality(&qc, *dd);
   EXPECT_FALSE(func.p->e[0].isZeroTerminal());
   EXPECT_FALSE(func.p->e[1].isZeroTerminal());
   EXPECT_FALSE(func.p->e[2].isZeroTerminal());
@@ -330,9 +331,9 @@ TEST_F(DDFunctionality, FuseTwoSingleQubitGates) {
   qc.h(0);
 
   qc.print(std::cout);
-  e = buildFunctionality(&qc, dd);
+  e = buildFunctionality(&qc, *dd);
   CircuitOptimizer::singleQubitGateFusion(qc);
-  const auto f = buildFunctionality(&qc, dd);
+  const auto f = buildFunctionality(&qc, *dd);
   std::cout << "-----------------------------\n";
   qc.print(std::cout);
   EXPECT_EQ(qc.getNops(), 1);
@@ -346,11 +347,11 @@ TEST_F(DDFunctionality, FuseThreeSingleQubitGates) {
   qc.h(0);
   qc.y(0);
 
-  e = buildFunctionality(&qc, dd);
+  e = buildFunctionality(&qc, *dd);
   std::cout << "-----------------------------\n";
   qc.print(std::cout);
   CircuitOptimizer::singleQubitGateFusion(qc);
-  const auto f = buildFunctionality(&qc, dd);
+  const auto f = buildFunctionality(&qc, *dd);
   std::cout << "-----------------------------\n";
   qc.print(std::cout);
   EXPECT_EQ(qc.getNops(), 1);
@@ -363,11 +364,11 @@ TEST_F(DDFunctionality, FuseNoSingleQubitGates) {
   qc.h(0);
   qc.cx(0, 1);
   qc.y(0);
-  e = buildFunctionality(&qc, dd);
+  e = buildFunctionality(&qc, *dd);
   std::cout << "-----------------------------\n";
   qc.print(std::cout);
   CircuitOptimizer::singleQubitGateFusion(qc);
-  const auto f = buildFunctionality(&qc, dd);
+  const auto f = buildFunctionality(&qc, *dd);
   std::cout << "-----------------------------\n";
   qc.print(std::cout);
   EXPECT_EQ(qc.getNops(), 3);
@@ -380,11 +381,11 @@ TEST_F(DDFunctionality, FuseSingleQubitGatesAcrossOtherGates) {
   qc.h(0);
   qc.z(1);
   qc.y(0);
-  e = buildFunctionality(&qc, dd);
+  e = buildFunctionality(&qc, *dd);
   std::cout << "-----------------------------\n";
   qc.print(std::cout);
   CircuitOptimizer::singleQubitGateFusion(qc);
-  const auto f = buildFunctionality(&qc, dd);
+  const auto f = buildFunctionality(&qc, *dd);
   std::cout << "-----------------------------\n";
   qc.print(std::cout);
   EXPECT_EQ(qc.getNops(), 2);

--- a/test/dd/test_dd_noise_functionality.cpp
+++ b/test/dd/test_dd_noise_functionality.cpp
@@ -107,7 +107,7 @@ TEST_F(DDNoiseFunctionalityTest, DetSimulateAdder4TrackAPD) {
               useDensityMatrixType, applyNoiseSequentially);
 
       for (auto const& op : qc) {
-        dd->applyOperationToDensity(rootEdge, dd::getDD(op.get(), dd),
+        dd->applyOperationToDensity(rootEdge, dd::getDD(op.get(), *dd),
                                     useDensityMatrixType);
         deterministicNoiseFunctionality.applyNoiseEffects(rootEdge, op);
       }
@@ -147,7 +147,7 @@ TEST_F(DDNoiseFunctionalityTest, StochSimulateAdder4TrackAPD) {
     dd->incRef(rootEdge);
 
     for (auto const& op : qc) {
-      auto operation = dd::getDD(op.get(), dd);
+      auto operation = dd::getDD(op.get(), *dd);
       auto usedQubits = op->getUsedQubits();
       stochasticNoiseFunctionality.applyNoiseOperation(
           usedQubits, operation, rootEdge, qc.getGenerator());
@@ -199,7 +199,7 @@ TEST_F(DDNoiseFunctionalityTest, StochSimulateAdder4IdentiyError) {
     dd->incRef(rootEdge);
 
     for (auto const& op : qc) {
-      auto operation = dd::getDD(op.get(), dd);
+      auto operation = dd::getDD(op.get(), *dd);
       auto usedQubits = op->getUsedQubits();
       stochasticNoiseFunctionality.applyNoiseOperation(
           op->getUsedQubits(), operation, rootEdge, qc.getGenerator());

--- a/test/unittests/test_ecc_functionality.cpp
+++ b/test/unittests/test_ecc_functionality.cpp
@@ -199,14 +199,14 @@ protected:
     ddOriginal->incRef(originalRootEdge);
 
     auto measurementsOriginal =
-        simulate(qcOriginal.get(), originalRootEdge, ddOriginal, shots);
+        simulate(qcOriginal.get(), originalRootEdge, *ddOriginal, shots);
 
     auto ddEcc = std::make_unique<dd::Package<>>(qcMapped->getNqubits());
     auto eccRootEdge = ddEcc->makeZeroState(qcMapped->getNqubits());
     ddEcc->incRef(eccRootEdge);
 
     auto measurementsProtected =
-        simulate(qcMapped.get(), eccRootEdge, ddEcc, shots, seed);
+        simulate(qcMapped.get(), eccRootEdge, *ddEcc, shots, seed);
     for (auto const& [classicalBit, hits] : measurementsOriginal) {
       // Since the result is stored as one bit string. I have to count the
       // relevant classical bits.


### PR DESCRIPTION
## Description

High-level functions such as `simulate` should not assume anything about the ownership of the DD package instance they are using. They now work on a reference to a package instance instead of a unique pointer.
This makes the interfaces more generic and usable in more scenarios.
It's quite possible that I missed some places and there will be a follow-up to this.
However, the changes here are enough to make everything work upstream for a new feature in QCEC.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
