### PR TITLE
🐛 Fix and optimize reduction of ancillaries

### DIFF
--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -1973,3 +1973,18 @@ TEST(DDPackageTest, DDStatistics) {
   ASSERT_TRUE(uniqueTableStats["total"].contains("num_buckets"));
   EXPECT_GT(uniqueTableStats["total"]["num_buckets"], 0);
 }
+
+TEST(DDPackageTest, ReduceAncillaRegression) {
+  auto dd = std::make_unique<dd::Package<>>(2);
+  const auto inputMatrix =
+      dd::CMat{{1, 1, 1, 1}, {1, -1, 1, -1}, {1, 1, -1, -1}, {1, -1, -1, 1}};
+  auto inputDD = dd->makeDDFromMatrix(inputMatrix);
+  dd->incRef(inputDD);
+  const auto outputDD = dd->reduceAncillae(inputDD, {true, false});
+
+  const auto outputMatrix = outputDD.getMatrix();
+  const auto expected =
+      dd::CMat{{1, 0, 1, 0}, {1, 0, 1, 0}, {1, 0, -1, 0}, {1, 0, -1, 0}};
+
+  EXPECT_EQ(outputMatrix, expected);
+}


### PR DESCRIPTION
## Description

This PR fixes a bug in the ancillary reduction routine of the DD package where some edge weights were simply overwritten.
Additionally, it optimizes the implementation to rely on cached edge weights throughout the computation which should reduce the influence on the complex number table.

Fixes #505

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
