### PR TITLE
🐛 Fix and optimize reduction of garbage

### DIFF
--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -561,6 +561,7 @@ TEST(DDPackageTest, GarbageVector) {
   auto cxGate = dd->makeGateDD(dd::X_MAT, 2, 0_pc, 1);
   auto zeroState = dd->makeZeroState(2);
   auto bellState = dd->multiply(dd->multiply(cxGate, hGate), zeroState);
+  std::cout << "Bell State:\n";
   bellState.printVector();
 
   dd->incRef(bellState);
@@ -574,12 +575,14 @@ TEST(DDPackageTest, GarbageVector) {
   dd->incRef(bellState);
   reducedBellState = dd->reduceGarbage(bellState, {false, true, false, false});
   auto vec = reducedBellState.getVector();
+  std::cout << "Reduced Bell State (q1 garbage):\n";
   reducedBellState.printVector();
   EXPECT_EQ(vec[2], 0.);
   EXPECT_EQ(vec[3], 0.);
 
   dd->incRef(bellState);
   reducedBellState = dd->reduceGarbage(bellState, {true, false, false, false});
+  std::cout << "Reduced Bell State (q0 garbage):\n";
   reducedBellState.printVector();
   vec = reducedBellState.getVector();
   EXPECT_EQ(vec[1], 0.);


### PR DESCRIPTION
## Description

This is a follow-up to #524 that applies similar fixes and optimizations to the reduction of garbage qubits.
As in the original PR this fixes an underlying issue where some edge weights were silently overwritten and increases the performance by making use of cached computations.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
