### PR TITLE
🐛 fix missing `mcx` gate support in OpenQASM3 parser

### DIFF
--- a/src/parsers/QASM3Parser.cpp
+++ b/src/parsers/QASM3Parser.cpp
@@ -359,8 +359,9 @@ public:
     size_t implicitControls{0};
 
     if (iter == gates.end()) {
-      if (identifier == "mcx_gray" || identifier == "mcx_vchain" ||
-          identifier == "mcx_recursive" || identifier == "mcphase") {
+      if (identifier == "mcx" || identifier == "mcx_gray" ||
+          identifier == "mcx_vchain" || identifier == "mcx_recursive" ||
+          identifier == "mcphase") {
         // we create a temp gate definition for these gates
         gate =
             getMcGateDefinition(identifier, gateCallStatement->operands.size(),

--- a/test/unittests/test_qasm3_parser.cpp
+++ b/test/unittests/test_qasm3_parser.cpp
@@ -692,6 +692,22 @@ TEST_F(Qasm3ParserTest, ImportQasm2CPrefix) {
   EXPECT_EQ(out, expected);
 }
 
+TEST_F(Qasm3ParserTest, ImportMCXGate) {
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "qubit[4] q;\n"
+                               "mcx q[0], q[1], q[2], q[3];\n";
+  auto qc = QuantumComputation::fromQASM(testfile);
+
+  const std::string out = qc.toQASM();
+  const std::string expected = "// i 0 1 2 3\n"
+                               "// o 0 1 2 3\n"
+                               "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[4] q;\n"
+                               "ctrl(3) @ x q[0], q[1], q[2], q[3];\n";
+  EXPECT_EQ(out, expected);
+}
+
 TEST_F(Qasm3ParserTest, ImportQasm2CPrefixInvalidGate) {
   const std::string testfile = "OPENQASM 2.0;\n"
                                "qubit[5] q;\n"


### PR DESCRIPTION
## Description

This fixes a small regression in the new QASM parser where plain `mcx` statements were no longer accepted.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
