### PR TITLE
✨ Allow project installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,21 +13,13 @@ include(cmake/PreventInSourceBuilds.cmake)
 include(cmake/PackageAddTest.cmake)
 include(cmake/Cache.cmake)
 
-option(BUILD_MQT_CORE_TESTS "Also build tests for the MQT Core project" ON)
-option(BUILD_MQT_CORE_BENCHMARKS "Also build benchmarks for the MQT Core project")
 option(BUILD_MQT_CORE_BINDINGS "Build the MQT Core Python bindings" OFF)
-
 if(BUILD_MQT_CORE_BINDINGS)
   # ensure that the BINDINGS option is set
   set(BINDINGS
       ON
-      CACHE BOOL "Enable settings related to Python bindings" FORCE)
-  set(Python_FIND_VIRTUALENV
-      FIRST
-      CACHE STRING "Give precedence to virtualenvs when searching for Python")
-  set(Python_ARTIFACTS_INTERACTIVE
-      ON
-      CACHE BOOL "Prevent multiple searches for Python and instead cache the results.")
+      CACHE INTERNAL "Enable settings related to Python bindings")
+
   # top-level call to find Python
   find_package(
     Python 3.8 REQUIRED
@@ -35,29 +27,31 @@ if(BUILD_MQT_CORE_BINDINGS)
     OPTIONAL_COMPONENTS Development.SABIModule)
 endif()
 
-if(NOT TARGET project_warnings)
-  # Use the warnings specified in CompilerWarnings.cmake
-  add_library(project_warnings INTERFACE)
+# try to determine the version from either git or the Python package
+include(cmake/GetVersion.cmake)
+get_version()
 
-  # Standard compiler warnings
-  include(cmake/CompilerWarnings.cmake)
-  set_project_warnings(project_warnings)
+project(
+  mqt-core
+  LANGUAGES CXX
+  VERSION ${MQT_CORE_VERSION}
+  DESCRIPTION "MQT Core - The Backbone of the Munich Quantum Toolkit")
+
+# check if this is the master project or used via add_subdirectory
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  set(MQT_CORE_MASTER_PROJECT ON)
+else()
+  set(MQT_CORE_MASTER_PROJECT OFF)
 endif()
 
-if(NOT TARGET project_options)
-  # Use the options specified in CompilerOptions.cmake
-  add_library(project_options INTERFACE)
-
-  # Standard compiler options
-  include(cmake/CompilerOptions.cmake)
-  enable_project_options(project_options)
-
-  # Sanitizer options if supported by compiler
-  include(cmake/Sanitizers.cmake)
-  enable_sanitizers(project_options)
-endif()
+option(MQT_CORE_INSTALL "Generate installation instructions for MQT Core"
+       ${MQT_CORE_MASTER_PROJECT})
+option(BUILD_MQT_CORE_TESTS "Also build tests for the MQT Core project" ${MQT_CORE_MASTER_PROJECT})
 
 include(cmake/ExternalDependencies.cmake)
+
+# set the include directory for the build tree
+set(MQT_CORE_INCLUDE_BUILD_DIR "${PROJECT_SOURCE_DIR}/include")
 
 # add main library code
 add_subdirectory(src)
@@ -69,6 +63,13 @@ if(BUILD_MQT_CORE_TESTS)
   add_subdirectory(test)
 endif()
 
+option(BUILD_MQT_CORE_BENCHMARKS "Also build benchmarks for the MQT Core project" OFF)
 if(BUILD_MQT_CORE_BENCHMARKS)
   add_subdirectory(eval)
+endif()
+
+if(NOT MQT_CORE_MASTER_PROJECT)
+  set(mqt-core_FOUND
+      TRUE
+      CACHE INTERNAL "True if mqt-core is found on the system")
 endif()

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -63,6 +63,11 @@ set(JSON_BuildTests
 set(JSON_MultipleHeaders
     OFF
     CACHE INTERNAL "")
+if(MQT_CORE_INSTALL)
+  set(JSON_Install
+      ON
+      CACHE INTERNAL "")
+endif()
 declare_dependency(
   NAME
   nlohmann_json
@@ -72,8 +77,7 @@ declare_dependency(
   c23a33f04786d85c29fda8d16b5f0efd
   MIN_VERSION
   3.11.3
-  SYSTEM
-  EXCLUDE_FROM_ALL)
+  SYSTEM)
 
 set(BOOST_MP_STANDALONE
     ON
@@ -133,8 +137,7 @@ if(BINDINGS)
     93ebbea2bb69f71febe0f83c8f88ced2
     MIN_VERSION
     0.2.13
-    SYSTEM
-    EXCLUDE_FROM_ALL)
+    SYSTEM)
 endif()
 
 # Make all declared dependencies available.

--- a/cmake/GetVersion.cmake
+++ b/cmake/GetVersion.cmake
@@ -1,0 +1,228 @@
+# A cmake script to determine the project version either
+#
+# * from the `SKBUILD_PROJECT_VERSION` variable (if available) or
+# * from the git repository (if available) or
+# * from the Python package version (if available).
+#
+# The following variables are set:
+#
+# * MQT_CORE_VERSION
+# * MQT_CORE_VERSION_STRING
+# * MQT_CORE_VERSION_FOUND (TRUE if version was found, FALSE otherwise)
+
+function(version_from_skbuild)
+  if(NOT DEFINED SKBUILD_PROJECT_VERSION)
+    message(
+      VERBOSE
+      "SKBUILD_PROJECT_VERSION not found. Cannot determine project version from scikit-build-core.")
+    return()
+  endif()
+  set(MQT_CORE_VERSION_STRING
+      "${SKBUILD_PROJECT_VERSION}"
+      CACHE INTERNAL "MQT_CORE_VERSION_STRING")
+
+  # Regex for package version: Major.Minor.Patch(.dev<commits>+g<sha1>.d<dirty>)
+  string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\.dev([0-9]+)\\+g([0-9a-f]+)(\\.d[0-9]+)?)?"
+               MQT_CORE_VERSION_STRING "${MQT_CORE_VERSION_STRING}")
+  set(MQT_CORE_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  set(MQT_CORE_VERSION_MINOR "${CMAKE_MATCH_2}")
+  set(MQT_CORE_VERSION_PATCH "${CMAKE_MATCH_3}")
+
+  if("${MQT_CORE_VERSION_MAJOR}" STREQUAL ""
+     OR "${MQT_CORE_VERSION_MINOR}" STREQUAL ""
+     OR "${MQT_CORE_VERSION_PATCH}" STREQUAL "")
+    message(
+      VERBOSE
+      "SKBUILD_PROJECT_VERSION invalid. Cannot determine project version from scikit-build-core.")
+    return()
+  endif()
+
+  set(MQT_CORE_VERSION_FOUND
+      TRUE
+      CACHE INTERNAL "MQT_CORE_VERSION_FOUND")
+  set(MQT_CORE_VERSION
+      "${MQT_CORE_VERSION_MAJOR}.${MQT_CORE_VERSION_MINOR}.${MQT_CORE_VERSION_PATCH}"
+      CACHE INTERNAL "MQT_CORE_VERSION")
+  return()
+
+endfunction()
+
+function(version_from_git)
+  find_package(Git QUIET)
+  if(NOT GIT_FOUND)
+    message(STATUS "Git not found. Cannot determine project version from Git.")
+    return()
+  endif()
+
+  set(GIT_DIR "${PROJECT_SOURCE_DIR}/.git")
+  message(VERBOSE "Looking for Git repository at ${GIT_DIR}")
+  if(NOT EXISTS "${GIT_DIR}")
+    message(VERBOSE "Git repository not found. Cannot determine project version from Git.")
+    return()
+  endif()
+
+  # Get the latest abbreviated commit hash of the working branch
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    OUTPUT_VARIABLE MQT_CORE_VERSION_SHA1
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(NOT "${MQT_CORE_VERSION_SHA1}" STREQUAL "")
+    message(VERBOSE "Git commit hash: ${MQT_CORE_VERSION_SHA1}")
+  else()
+    message(VERBOSE "Git commit hash not found. Cannot determine project version from Git.")
+    return()
+  endif()
+
+  # Get the latest tag name
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    OUTPUT_VARIABLE MQT_CORE_VERSION_TAG
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(NOT "${MQT_CORE_VERSION_TAG}" STREQUAL "")
+    message(VERBOSE "Git tag: ${MQT_CORE_VERSION_TAG}")
+  else()
+    message(VERBOSE "Git tag not found. Cannot determine project version from Git.")
+    return()
+  endif()
+
+  # Get the number of commits since the latest tag
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-list ${MQT_CORE_VERSION_TAG}..HEAD --count
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    OUTPUT_VARIABLE MQT_CORE_VERSION_COMMITS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(NOT "${MQT_CORE_VERSION_COMMITS}" STREQUAL "")
+    message(VERBOSE "Git commits since tag: ${MQT_CORE_VERSION_COMMITS}")
+  else()
+    message(VERBOSE "Git commits since tag not found. Cannot determine project version from Git.")
+    return()
+  endif()
+
+  # Parse the version number from the latest tag (v.MAJOR.MINOR.PATCH)
+  string(REGEX MATCH "v([0-9]+)\\.([0-9]+)\\.([0-9]+)" MQT_CORE_VERSION_TAG
+               "${MQT_CORE_VERSION_TAG}")
+  set(MQT_CORE_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  set(MQT_CORE_VERSION_MINOR "${CMAKE_MATCH_2}")
+  set(MQT_CORE_VERSION_PATCH "${CMAKE_MATCH_3}")
+
+  if(${MQT_CORE_VERSION_MAJOR} STREQUAL ""
+     OR ${MQT_CORE_VERSION_MINOR} STREQUAL ""
+     OR ${MQT_CORE_VERSION_PATCH} STREQUAL "")
+    message(VERBOSE
+            "Git version information incomplete. Cannot determine project version from Git.")
+    return()
+  endif()
+
+  # if commits since tag, increment patch version
+  if(NOT "${MQT_CORE_VERSION_COMMITS}" STREQUAL "0")
+    math(EXPR MQT_CORE_VERSION_PATCH "${MQT_CORE_VERSION_PATCH}+1")
+  endif()
+  set(MQT_CORE_VERSION
+      "${MQT_CORE_VERSION_MAJOR}.${MQT_CORE_VERSION_MINOR}.${MQT_CORE_VERSION_PATCH}"
+      CACHE INTERNAL "MQT_CORE_VERSION")
+  set(MQT_CORE_VERSION_STRING "${MQT_CORE_VERSION}")
+  # if commits since tag, append version info
+  if(NOT "${MQT_CORE_VERSION_COMMITS}" STREQUAL "0")
+    set(MQT_CORE_VERSION_STRING
+        "${MQT_CORE_VERSION}.dev${MQT_CORE_VERSION_COMMITS}+g${MQT_CORE_VERSION_SHA1}"
+        CACHE INTERNAL "MQT_CORE_VERSION_STRING")
+  endif()
+
+  set(MQT_CORE_VERSION_FOUND
+      TRUE
+      CACHE INTERNAL "MQT_CORE_VERSION_FOUND")
+endfunction()
+
+function(version_from_package)
+  if(NOT TARGET Python::Interpreter)
+    message(VERBOSE
+            "Python interpreter not found. Cannot determine project version from Python package.")
+    return()
+  endif()
+
+  execute_process(
+    COMMAND ${Python_EXECUTABLE} -m mqt.core --version
+    OUTPUT_VARIABLE MQT_CORE_VERSION_STRING
+    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+
+  if(${MQT_CORE_VERSION_STRING} STREQUAL "")
+    message(
+      VERBOSE
+      "Python package version not found. Cannot determine project version from Python package.")
+    return()
+  endif()
+  set(MQT_CORE_VERSION_STRING
+      "${MQT_CORE_VERSION_STRING}"
+      CACHE INTERNAL "MQT_CORE_VERSION_STRING")
+
+  # Regex for package version: Major.Minor.Patch(.dev<commits>+g<sha1>.d<dirty>)
+  string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\.dev([0-9]+)\\+g([0-9a-f]+)(\\.d[0-9]+)?)?"
+               MQT_CORE_VERSION_STRING "${MQT_CORE_VERSION_STRING}")
+  set(MQT_CORE_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  set(MQT_CORE_VERSION_MINOR "${CMAKE_MATCH_2}")
+  set(MQT_CORE_VERSION_PATCH "${CMAKE_MATCH_3}")
+
+  if(NOT MQT_CORE_VERSION_MAJOR
+     OR NOT MQT_CORE_VERSION_MINOR
+     OR NOT MQT_CORE_VERSION_PATCH)
+    message(
+      VERBOSE
+      "Python package version information incomplete. Cannot determine project version from Python package."
+    )
+    return()
+  endif()
+
+  set(MQT_CORE_VERSION
+      "${MQT_CORE_VERSION_MAJOR}.${MQT_CORE_VERSION_MINOR}.${MQT_CORE_VERSION_PATCH}"
+      CACHE INTERNAL "MQT_CORE_VERSION")
+  set(MQT_CORE_VERSION_FOUND
+      TRUE
+      CACHE INTERNAL "MQT_CORE_VERSION_FOUND")
+endfunction()
+
+function(get_version)
+  # Initialize as not found
+  set(MQT_CORE_VERSION_FOUND
+      FALSE
+      CACHE INTERNAL "MQT_CORE_VERSION_FOUND")
+
+  version_from_skbuild()
+  if(MQT_CORE_VERSION_FOUND)
+    message(
+      STATUS
+        "Found project version ${MQT_CORE_VERSION} from scikit-build-core (full version: ${MQT_CORE_VERSION_STRING})"
+    )
+    return()
+  endif()
+
+  version_from_git()
+  if(MQT_CORE_VERSION_FOUND)
+    message(
+      STATUS
+        "Found project version ${MQT_CORE_VERSION} from git (full version: ${MQT_CORE_VERSION_STRING})"
+    )
+    return()
+  endif()
+
+  version_from_package()
+  if(MQT_CORE_VERSION_FOUND)
+    message(
+      STATUS
+        "Found project version ${MQT_CORE_VERSION} from Python package (full version: ${MQT_CORE_VERSION_STRING})"
+    )
+    return()
+  endif()
+
+  message(WARNING "Could not determine project version. Setting to 0.0.0")
+  set(MQT_CORE_VERSION
+      "0.0.0"
+      CACHE INTERNAL "MQT_CORE_VERSION")
+  set(MQT_CORE_VERSION_STRING
+      "0.0.0"
+      CACHE INTERNAL "MQT_CORE_VERSION_STRING")
+endfunction()

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -63,3 +63,11 @@ if(DEPLOY)
       "10.15"
       CACHE STRING "" FORCE)
 endif()
+
+# Some common settings for finding Python
+set(Python_FIND_VIRTUALENV
+    FIRST
+    CACHE STRING "Give precedence to virtualenvs when searching for Python")
+set(Python_ARTIFACTS_INTERACTIVE
+    ON
+    CACHE BOOL "Prevent multiple searches for Python and instead cache the results.")

--- a/cmake/mqt-core-config.cmake.in
+++ b/cmake/mqt-core-config.cmake.in
@@ -1,0 +1,29 @@
+# A CMake config file for the library, to be used by external projects
+
+@PACKAGE_INIT@
+
+check_required_components(mqt-core)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+include(CMakeFindDependencyMacro)
+find_dependency(GMP)
+find_dependency(pybind11_json)
+
+if(TARGET MQT::Core)
+  return()
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/Cache.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/CompilerOptions.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/CompilerWarnings.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/GetVersion.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/PackageAddTest.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/PreventInSourceBuilds.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Sanitizers.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/StandardProjectSettings.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/mqt-core-targets.cmake")
+
+if(NOT mqt-core_FIND_QUIETLY)
+  message(STATUS "Found mqt-core version ${mqt-core_VERSION}")
+endif()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev = ["mqt.core[coverage, docs]",]
 
 [project.scripts]
 compare = "mqt.core.evaluation:main"
+mqt-core-cli = "mqt.core.__main__:main"
 
 [project.urls]
 Homepage = "https://github.com/cda-tum/mqt-core"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,8 @@ Discussions = "https://github.com/cda-tum/mqt-core/discussions"
 # Protect the configuration against future changes in scikit-build-core
 minimum-version = "0.6.1"
 
-# Set the target to build
-cmake.targets = ["_core"]
+# Set the wheel install directory
+wheel.install-dir = "mqt/core"
 
 # Set required CMake and Ninja versions
 cmake.minimum-version = "3.19"
@@ -253,6 +253,7 @@ isort.required-imports = ["from __future__ import annotations"]
 ]
 "src/mqt/core/_compat/**.py" = ["TID251"]
 "src/mqt/core/evaluation.py" = ["T201"]
+"src/mqt/core/__main__.py" = ["T201"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,40 +1,89 @@
-if(NOT TARGET ${PROJECT_NAME})
+set(MQT_CORE_TARGET_NAME "mqt-core")
+set(MQT_CORE_TARGETS "")
+
+if(MQT_CORE_INSTALL)
+  include(GNUInstallDirs)
+  if(NOT APPLE)
+    set(basePoint $ORIGIN)
+  endif()
+  set(MQT_CORE_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/cmake/mqt-core")
+  set(MQT_CORE_INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
+  set(MQT_CORE_TARGETS_EXPORT_NAME "mqt-core-targets")
+  set(MQT_CORE_CMAKE_CONFIG_TEMPLATE "${PROJECT_SOURCE_DIR}/cmake/mqt-core-config.cmake.in")
+  set(MQT_CORE_CMAKE_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+  set(MQT_CORE_CMAKE_VERSION_CONFIG_FILE
+      "${MQT_CORE_CMAKE_CONFIG_DIR}/mqt-core-config-version.cmake")
+  set(MQT_CORE_CMAKE_PROJECT_CONFIG_FILE "${MQT_CORE_CMAKE_CONFIG_DIR}/mqt-core-config.cmake")
+  set(MQT_CORE_CMAKE_PROJECT_TARGETS_FILE "${MQT_CORE_CMAKE_CONFIG_DIR}/mqt-core-targets.cmake")
+endif()
+
+if(NOT TARGET project_warnings)
+  # Use the warnings specified in CompilerWarnings.cmake
+  add_library(project_warnings INTERFACE)
+
+  # Standard compiler warnings
+  include(${PROJECT_SOURCE_DIR}/cmake/CompilerWarnings.cmake)
+  set_project_warnings(project_warnings)
+
+  # Add MQT alias
+  add_library(MQT::ProjectWarnings ALIAS project_warnings)
+  set_target_properties(project_warnings PROPERTIES EXPORT_NAME ProjectWarnings)
+endif()
+
+if(NOT TARGET project_options)
+  # Use the options specified in CompilerOptions.cmake
+  add_library(project_options INTERFACE)
+
+  # Standard compiler options
+  include(${PROJECT_SOURCE_DIR}/cmake/CompilerOptions.cmake)
+  enable_project_options(project_options)
+
+  # Sanitizer options if supported by compiler
+  include(${PROJECT_SOURCE_DIR}/cmake/Sanitizers.cmake)
+  enable_sanitizers(project_options)
+
+  # Add MQT alias
+  add_library(MQT::ProjectOptions ALIAS project_options)
+  set_target_properties(project_options PROPERTIES EXPORT_NAME ProjectOptions)
+endif()
+
+if(NOT TARGET ${MQT_CORE_TARGET_NAME})
   # main project library
   add_library(
-    ${PROJECT_NAME}
-    ${PROJECT_SOURCE_DIR}/include/algorithms/BernsteinVazirani.hpp
-    ${PROJECT_SOURCE_DIR}/include/algorithms/Entanglement.hpp
-    ${PROJECT_SOURCE_DIR}/include/algorithms/GoogleRandomCircuitSampling.hpp
-    ${PROJECT_SOURCE_DIR}/include/algorithms/Grover.hpp
-    ${PROJECT_SOURCE_DIR}/include/algorithms/QFT.hpp
-    ${PROJECT_SOURCE_DIR}/include/algorithms/QPE.hpp
-    ${PROJECT_SOURCE_DIR}/include/algorithms/RandomCliffordCircuit.hpp
-    ${PROJECT_SOURCE_DIR}/include/algorithms/WState.hpp
-    ${PROJECT_SOURCE_DIR}/include/CircuitOptimizer.hpp
-    ${PROJECT_SOURCE_DIR}/include/Definitions.hpp
-    ${PROJECT_SOURCE_DIR}/include/operations/Expression.hpp
-    ${PROJECT_SOURCE_DIR}/include/operations/ClassicControlledOperation.hpp
-    ${PROJECT_SOURCE_DIR}/include/operations/CompoundOperation.hpp
-    ${PROJECT_SOURCE_DIR}/include/operations/Control.hpp
-    ${PROJECT_SOURCE_DIR}/include/operations/NonUnitaryOperation.hpp
-    ${PROJECT_SOURCE_DIR}/include/operations/Operation.hpp
-    ${PROJECT_SOURCE_DIR}/include/operations/StandardOperation.hpp
-    ${PROJECT_SOURCE_DIR}/include/operations/SymbolicOperation.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/Scanner.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/Token.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/Parser.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/Statement.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/Types.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/InstVisitor.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/NestedEnvironment.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/Exception.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/Gate.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/StdGates.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/passes/CompilerPass.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/passes/ConstEvalPass.hpp
-    ${PROJECT_SOURCE_DIR}/include/parsers/qasm3_parser/passes/TypeCheckPass.hpp
-    ${PROJECT_SOURCE_DIR}/include/Permutation.hpp
-    ${PROJECT_SOURCE_DIR}/include/QuantumComputation.hpp
+    ${MQT_CORE_TARGET_NAME}
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/algorithms/BernsteinVazirani.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/algorithms/Entanglement.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/algorithms/GoogleRandomCircuitSampling.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/algorithms/Grover.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/algorithms/QFT.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/algorithms/QPE.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/algorithms/RandomCliffordCircuit.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/algorithms/WState.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/CircuitOptimizer.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/Definitions.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/operations/Expression.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/operations/ClassicControlledOperation.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/operations/CompoundOperation.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/operations/Control.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/operations/NonUnitaryOperation.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/operations/Operation.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/operations/StandardOperation.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/operations/SymbolicOperation.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/Scanner.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/Token.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/Parser.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/Statement.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/Types.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/InstVisitor.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/NestedEnvironment.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/Exception.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/Gate.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/StdGates.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/passes/CompilerPass.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/passes/ConstEvalPass.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/parsers/qasm3_parser/passes/TypeCheckPass.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/Permutation.hpp
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/QuantumComputation.hpp
     algorithms/BernsteinVazirani.cpp
     algorithms/Entanglement.cpp
     algorithms/GoogleRandomCircuitSampling.cpp
@@ -64,16 +113,19 @@ if(NOT TARGET ${PROJECT_NAME})
     QuantumComputation.cpp)
 
   # set include directories
-  target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include
-                                                    ${PROJECT_BINARY_DIR}/include)
+  target_include_directories(
+    ${MQT_CORE_TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${MQT_CORE_INCLUDE_BUILD_DIR}>
+                                   $<INSTALL_INTERFACE:${MQT_CORE_INCLUDE_INSTALL_DIR}>)
 
-  target_link_libraries(${PROJECT_NAME} PUBLIC nlohmann_json)
+  target_link_libraries(${MQT_CORE_TARGET_NAME} PUBLIC nlohmann_json)
 
   # add options and warnings to the library
-  target_link_libraries(${PROJECT_NAME} PUBLIC project_options project_warnings)
+  target_link_libraries(${MQT_CORE_TARGET_NAME} PUBLIC MQT::ProjectOptions MQT::ProjectWarnings)
 
   # add MQT alias
-  add_library(MQT::Core ALIAS ${PROJECT_NAME})
+  add_library(MQT::Core ALIAS ${MQT_CORE_TARGET_NAME})
+  set_target_properties(${MQT_CORE_TARGET_NAME} PROPERTIES EXPORT_NAME Core)
+  list(APPEND MQT_CORE_TARGETS ${MQT_CORE_TARGET_NAME})
 endif()
 
 # add DD package library
@@ -86,20 +138,64 @@ add_subdirectory(zx)
 add_subdirectory(ecc)
 
 # ** Note ** The following target will soon be removed from the project. All top-level projects
-# should switch to nanobind. After that, the pybind submodules will be removed.
-if(BINDINGS AND NOT TARGET ${PROJECT_NAME}-python)
+# should switch to using the mqt-core Python package.
+if(BINDINGS AND NOT TARGET mqt-core-python)
   # add Python interface library
-  add_library(${PROJECT_NAME}-python ${PROJECT_SOURCE_DIR}/include/python/qiskit/QuantumCircuit.hpp
-                                     python/qiskit/QuantumCircuit.cpp)
+  add_library(
+    ${MQT_CORE_TARGET_NAME}-python ${MQT_CORE_INCLUDE_BUILD_DIR}/python/qiskit/QuantumCircuit.hpp
+                                   python/qiskit/QuantumCircuit.cpp)
 
   # link with main project library and pybind11 libraries
-  target_link_libraries(${PROJECT_NAME}-python PUBLIC ${PROJECT_NAME} pybind11::pybind11
-                                                      pybind11_json)
+  target_link_libraries(${MQT_CORE_TARGET_NAME}-python PUBLIC MQT::Core pybind11::pybind11
+                                                              pybind11_json)
 
   # add MQT alias
-  add_library(MQT::CorePython ALIAS ${PROJECT_NAME}-python)
+  add_library(MQT::CorePython ALIAS ${MQT_CORE_TARGET_NAME}-python)
+  set_target_properties(${MQT_CORE_TARGET_NAME}-python PROPERTIES EXPORT_NAME CorePython)
+  list(APPEND MQT_CORE_TARGETS ${MQT_CORE_TARGET_NAME}-python)
 endif()
 
 if(BUILD_MQT_CORE_BINDINGS)
   add_subdirectory(python)
+endif()
+
+# Installation instructions for the main library
+if(MQT_CORE_INSTALL)
+  include(CMakePackageConfigHelpers)
+  configure_package_config_file(
+    ${MQT_CORE_CMAKE_CONFIG_TEMPLATE} ${MQT_CORE_CMAKE_PROJECT_CONFIG_FILE}
+    INSTALL_DESTINATION ${MQT_CORE_CONFIG_INSTALL_DIR})
+  write_basic_package_version_file(
+    ${MQT_CORE_CMAKE_VERSION_CONFIG_FILE}
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMinorVersion)
+
+  install(FILES ${MQT_CORE_CMAKE_PROJECT_CONFIG_FILE} ${MQT_CORE_CMAKE_VERSION_CONFIG_FILE}
+          DESTINATION ${MQT_CORE_CONFIG_INSTALL_DIR})
+
+  install(
+    TARGETS ${MQT_CORE_TARGETS} project_warnings project_options
+    EXPORT ${MQT_CORE_TARGETS_EXPORT_NAME}
+    INCLUDES
+    DESTINATION ${MQT_CORE_INCLUDE_INSTALL_DIR})
+
+  install(DIRECTORY ${MQT_CORE_INCLUDE_BUILD_DIR}/ DESTINATION ${MQT_CORE_INCLUDE_INSTALL_DIR})
+
+  install(
+    EXPORT ${MQT_CORE_TARGETS_EXPORT_NAME}
+    FILE ${MQT_CORE_PROJECT_TARGETS_FILE}
+    NAMESPACE MQT::
+    DESTINATION ${MQT_CORE_CONFIG_INSTALL_DIR})
+
+  install(
+    FILES ${PROJECT_SOURCE_DIR}/cmake/Cache.cmake
+          ${PROJECT_SOURCE_DIR}/cmake/CompilerOptions.cmake
+          ${PROJECT_SOURCE_DIR}/cmake/CompilerWarnings.cmake
+          ${PROJECT_SOURCE_DIR}/cmake/FindGMP.cmake
+          ${PROJECT_SOURCE_DIR}/cmake/GetVersion.cmake
+          ${PROJECT_SOURCE_DIR}/cmake/PackageAddTest.cmake
+          ${PROJECT_SOURCE_DIR}/cmake/PreventInSourceBuilds.cmake
+          ${PROJECT_SOURCE_DIR}/cmake/Sanitizers.cmake
+          ${PROJECT_SOURCE_DIR}/cmake/StandardProjectSettings.cmake
+    DESTINATION ${MQT_CORE_CONFIG_INSTALL_DIR})
 endif()

--- a/src/dd/CMakeLists.txt
+++ b/src/dd/CMakeLists.txt
@@ -1,9 +1,9 @@
-if(NOT TARGET ${PROJECT_NAME}-dd)
-  file(GLOB_RECURSE DD_HEADERS ${PROJECT_SOURCE_DIR}/include/dd/*.hpp)
+if(NOT TARGET ${MQT_CORE_TARGET_NAME}-dd)
+  file(GLOB_RECURSE DD_HEADERS ${MQT_CORE_INCLUDE_BUILD_DIR}/dd/*.hpp)
 
   # add DD Package library
   add_library(
-    ${PROJECT_NAME}-dd
+    ${MQT_CORE_TARGET_NAME}-dd
     ${DD_HEADERS}
     Benchmark.cpp
     CachedEdge.cpp
@@ -23,6 +23,10 @@ if(NOT TARGET ${PROJECT_NAME}-dd)
     statistics/Statistics.cpp
     statistics/TableStatistics.cpp
     statistics/UniqueTableStatistics.cpp)
-  target_link_libraries(${PROJECT_NAME}-dd PUBLIC ${PROJECT_NAME})
-  add_library(MQT::CoreDD ALIAS ${PROJECT_NAME}-dd)
+  target_link_libraries(${MQT_CORE_TARGET_NAME}-dd PUBLIC MQT::Core)
+  add_library(MQT::CoreDD ALIAS ${MQT_CORE_TARGET_NAME}-dd)
+  set_target_properties(mqt-core-dd PROPERTIES EXPORT_NAME CoreDD)
+  set(MQT_CORE_TARGETS
+      ${MQT_CORE_TARGETS} ${MQT_CORE_TARGET_NAME}-dd
+      PARENT_SCOPE)
 endif()

--- a/src/ecc/CMakeLists.txt
+++ b/src/ecc/CMakeLists.txt
@@ -1,9 +1,9 @@
-if(NOT TARGET ${PROJECT_NAME}-ecc)
-  file(GLOB_RECURSE ECC_HEADERS ${PROJECT_SOURCE_DIR}/include/ecc/*.hpp)
+if(NOT TARGET ${MQT_CORE_TARGET_NAME}-ecc)
+  file(GLOB_RECURSE ECC_HEADERS ${MQT_CORE_INCLUDE_BUILD_DIR}/ecc/*.hpp)
 
   # add ECC package library
   add_library(
-    ${PROJECT_NAME}-ecc
+    ${MQT_CORE_TARGET_NAME}-ecc
     ${ECC_HEADERS}
     Ecc.cpp
     Q3Shor.cpp
@@ -13,8 +13,12 @@ if(NOT TARGET ${PROJECT_NAME}-ecc)
     Q9Surface.cpp
     Q18Surface.cpp)
 
-  target_link_libraries(${PROJECT_NAME}-ecc PUBLIC ${PROJECT_NAME})
+  target_link_libraries(${MQT_CORE_TARGET_NAME}-ecc PUBLIC MQT::Core)
 
   # add MQT alias
-  add_library(MQT::CoreECC ALIAS ${PROJECT_NAME}-ecc)
+  add_library(MQT::CoreECC ALIAS ${MQT_CORE_TARGET_NAME}-ecc)
+  set_target_properties(${MQT_CORE_TARGET_NAME}-ecc PROPERTIES EXPORT_NAME CoreECC)
+  set(MQT_CORE_TARGETS
+      ${MQT_CORE_TARGETS} ${MQT_CORE_TARGET_NAME}-ecc
+      PARENT_SCOPE)
 endif()

--- a/src/mqt/core/__init__.py
+++ b/src/mqt/core/__init__.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 from ._core import Permutation, QuantumComputation
 from ._version import version as __version__
+from ._version import version_tuple as version_info
+from .commands import cmake_dir, include_dir
 
 __all__ = [
     "Permutation",
     "QuantumComputation",
     "__version__",
+    "version_info",
+    "cmake_dir",
+    "include_dir",
 ]
 
 for cls in (Permutation, QuantumComputation):

--- a/src/mqt/core/__main__.py
+++ b/src/mqt/core/__main__.py
@@ -1,0 +1,33 @@
+"""Command line interface for mqt-core."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from ._version import version as __version__
+from .commands import cmake_dir, include_dir
+
+
+def main() -> None:
+    """Entry point for the mqt-core command line interface."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", action="version", version=__version__, help="Print version and exit.")
+
+    parser.add_argument(
+        "--include_dir", action="store_true", help="Print the path to the mqt-core C++ include directory."
+    )
+    parser.add_argument(
+        "--cmake_dir", action="store_true", help="Print the path to the mqt-core CMake module directory."
+    )
+    args = parser.parse_args()
+    if not sys.argv[1:]:
+        parser.print_help()
+    if args.include_dir:
+        print(include_dir())
+    if args.cmake_dir:
+        print(cmake_dir())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mqt/core/commands.py
+++ b/src/mqt/core/commands.py
@@ -2,20 +2,33 @@
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
-
-DIR = Path(__file__).parent.absolute()
 
 
 def include_dir() -> Path:
     """Return the path to the mqt-core include directory."""
-    return DIR / "include"
+    try:
+        dist = distribution("mqt-core")
+        located_include_dir = Path(dist.locate_file("mqt/core/include"))
+        if located_include_dir.exists() and located_include_dir.is_dir():
+            return located_include_dir
+        msg = "mqt-core include files not found."
+        raise FileNotFoundError(msg)
+    except PackageNotFoundError:
+        msg = "mqt-core not installed, installation required to access the include files."
+        raise ImportError(msg) from None
 
 
 def cmake_dir() -> Path:
     """Return the path to the mqt-core CMake module directory."""
-    cmake_installed_path = DIR / "share" / "cmake"
-    if cmake_installed_path.exists():
-        return cmake_installed_path
-    msg = "mqt-core not installed, installation required to access the CMake files."
-    raise ImportError(msg)
+    try:
+        dist = distribution("mqt-core")
+        located_cmake_dir = Path(dist.locate_file("mqt/core/share/cmake"))
+        if located_cmake_dir.exists() and located_cmake_dir.is_dir():
+            return located_cmake_dir
+        msg = "mqt-core CMake files not found."
+        raise FileNotFoundError(msg)
+    except PackageNotFoundError:
+        msg = "mqt-core not installed, installation required to access the CMake files."
+        raise ImportError(msg) from None

--- a/src/mqt/core/commands.py
+++ b/src/mqt/core/commands.py
@@ -1,0 +1,21 @@
+"""Useful commands for obtaining information about mqt-core."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DIR = Path(__file__).parent.absolute()
+
+
+def include_dir() -> Path:
+    """Return the path to the mqt-core include directory."""
+    return DIR / "include"
+
+
+def cmake_dir() -> Path:
+    """Return the path to the mqt-core CMake module directory."""
+    cmake_installed_path = DIR / "share" / "cmake"
+    if cmake_installed_path.exists():
+        return cmake_installed_path
+    msg = "mqt-core not installed, installation required to access the CMake files."
+    raise ImportError(msg)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,29 +1,3 @@
-if(NOT SKBUILD)
-  message(
-    NOTICE
-    "\
-  This CMake file is meant to be executed using 'scikit-build'. Running
-  it directly will almost certainly not produce the desired result. If
-  you are a user trying to install this package, please use the command
-  below, which will install all necessary build dependencies, compile
-  the package in an isolated environment, and then install it.
-  =====================================================================
-   $ pip install .
-  =====================================================================
-  If you are a software developer, and this is your own package, then
-  it is usually much more efficient to install the build dependencies
-  in your environment once and use the following command that avoids
-  a costly creation of a new virtual environment at every compilation:
-  =====================================================================
-   $ pip install 'scikit-build-core[pyproject]' setuptools_scm pybind11
-   $ pip install --no-build-isolation -ve .
-  =====================================================================
-  You may optionally add -Ceditable.rebuild=true to auto-rebuild when
-  the package is imported. Otherwise, you need to re-run the above
-  after editing C++ files.")
-endif()
-
-# We are now ready to compile the actual extension module
 pybind11_add_module(
   # Name of the extension
   _core
@@ -31,7 +5,7 @@ pybind11_add_module(
   # built. This does nothing on older Python versions
   WITH_SOABI
   # Source code goes here
-  ${PROJECT_SOURCE_DIR}/include/python/pybind11.hpp
+  ${MQT_CORE_INCLUDE_BUILD_DIR}/python/pybind11.hpp
   module.cpp
   register_operations.cpp
   register_permutation.cpp
@@ -51,4 +25,7 @@ pybind11_add_module(
 target_link_libraries(_core PRIVATE MQT::Core)
 
 # Install directive for scikit-build-core
-install(TARGETS _core LIBRARY DESTINATION mqt/core)
+install(
+  TARGETS _core
+  DESTINATION .
+  COMPONENT MQTCorePythonModule)

--- a/src/zx/CMakeLists.txt
+++ b/src/zx/CMakeLists.txt
@@ -1,9 +1,37 @@
-if(NOT TARGET ${PROJECT_NAME}-zx)
-  file(GLOB_RECURSE ZX_HEADERS ${PROJECT_SOURCE_DIR}/include/zx/*.hpp)
+if(NOT TARGET ${MQT_CORE_TARGET_NAME}-zx)
+  # make sure the MQT::multiprecision target is available
+  if(NOT TARGET MQT::Multiprecision)
+    # handle the case for a complete Boost installation
+    if(NOT TARGET Boost::multiprecision)
+      add_library(multiprecision INTERFACE)
+      target_link_libraries(multiprecision INTERFACE Boost::headers)
+      add_library(MQT::Multiprecision ALIAS multiprecision)
+    else()
+      # Boost::multiprecision does not provide its own installation instructions. As a consequence,
+      # this needs a workaround.
+
+      # first, we get the include directory of the multiprecision library
+      get_target_property(MULTIPRECISION_INCLUDE_DIR Boost::multiprecision
+                          INTERFACE_INCLUDE_DIRECTORIES)
+
+      # then, we create a target that will be used to export the include directory
+      add_library(multiprecision INTERFACE)
+      target_include_directories(
+        multiprecision SYSTEM INTERFACE $<BUILD_INTERFACE:${MULTIPRECISION_INCLUDE_DIR}>
+                                        $<INSTALL_INTERFACE:${MQT_CORE_INCLUDE_INSTALL_DIR}>)
+      add_library(MQT::Multiprecision ALIAS multiprecision)
+
+      # finally, we create install instructions for the respective header files
+      install(DIRECTORY ${MULTIPRECISION_INCLUDE_DIR}/boost
+              DESTINATION ${MQT_CORE_INCLUDE_INSTALL_DIR})
+    endif()
+  endif()
+
+  file(GLOB_RECURSE ZX_HEADERS ${MQT_CORE_INCLUDE_BUILD_DIR}/zx/*.hpp)
 
   # add ZX package library
   add_library(
-    ${PROJECT_NAME}-zx
+    ${MQT_CORE_TARGET_NAME}-zx
     ${ZX_HEADERS}
     Rational.cpp
     ZXDiagram.cpp
@@ -11,12 +39,7 @@ if(NOT TARGET ${PROJECT_NAME}-zx)
     Simplify.cpp
     Utils.cpp
     FunctionalityConstruction.cpp)
-  target_link_libraries(${PROJECT_NAME}-zx PUBLIC ${PROJECT_NAME})
-  if(TARGET Boost::multiprecision)
-    target_link_libraries(${PROJECT_NAME}-zx PUBLIC Boost::multiprecision)
-  else()
-    target_link_libraries(${PROJECT_NAME}-zx PUBLIC Boost::headers)
-  endif()
+  target_link_libraries(${MQT_CORE_TARGET_NAME}-zx PUBLIC MQT::Core MQT::Multiprecision)
 
   find_package(GMP)
   if(NOT GMP_FOUND)
@@ -24,10 +47,14 @@ if(NOT TARGET ${PROJECT_NAME}-zx)
   endif()
   # # link to GMP libraries if present
   if(GMP_FOUND)
-    target_compile_definitions(${PROJECT_NAME}-zx PUBLIC GMP)
-    target_link_libraries(${PROJECT_NAME}-zx PUBLIC GMP::gmp GMP::gmpxx)
+    target_compile_definitions(${MQT_CORE_TARGET_NAME}-zx PUBLIC GMP)
+    target_link_libraries(${MQT_CORE_TARGET_NAME}-zx PUBLIC GMP::gmp GMP::gmpxx)
   endif()
 
   # add MQT alias
-  add_library(MQT::CoreZX ALIAS ${PROJECT_NAME}-zx)
+  add_library(MQT::CoreZX ALIAS ${MQT_CORE_TARGET_NAME}-zx)
+  set_target_properties(${MQT_CORE_TARGET_NAME}-zx PROPERTIES EXPORT_NAME CoreZX)
+  set(MQT_CORE_TARGETS
+      ${MQT_CORE_TARGETS} ${MQT_CORE_TARGET_NAME}-zx multiprecision
+      PARENT_SCOPE)
 endif()

--- a/test/python/test_cli.py
+++ b/test/python/test_cli.py
@@ -86,3 +86,11 @@ def test_cli_cmake_dir_not_found(script_runner: ScriptRunner) -> None:
         ret = script_runner.run(["mqt-core-cli", "--cmake_dir"])
         assert not ret.success
         assert "mqt-core CMake files not found." in ret.stderr
+
+
+def test_cli_execute_module() -> None:
+    """Test running the CLI by executing the mqt-core module."""
+    from subprocess import check_output
+
+    output = check_output(["python3", "-m", "mqt.core", "--version"])  # noqa: S603, S607
+    assert mqt_core_version in output.decode()

--- a/test/python/test_cli.py
+++ b/test/python/test_cli.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import sys
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
+
+import pytest
 
 from mqt.core import __version__ as mqt_core_version
 
@@ -88,6 +91,7 @@ def test_cli_cmake_dir_not_found(script_runner: ScriptRunner) -> None:
         assert "mqt-core CMake files not found." in ret.stderr
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="The subprocess calls do not work properly on Windows.")
 def test_cli_execute_module() -> None:
     """Test running the CLI by executing the mqt-core module."""
     from subprocess import check_output

--- a/test/python/test_cli.py
+++ b/test/python/test_cli.py
@@ -17,7 +17,6 @@ def test_cli_no_arguments(script_runner: ScriptRunner) -> None:
     ret = script_runner.run(["mqt-core-cli"])
     assert ret.success
     assert "usage: mqt-core-cli [-h] [--version] [--include_dir] [--cmake_dir]" in ret.stdout
-    assert "options:" in ret.stdout
 
 
 def test_cli_help(script_runner: ScriptRunner) -> None:
@@ -25,7 +24,6 @@ def test_cli_help(script_runner: ScriptRunner) -> None:
     ret = script_runner.run(["mqt-core-cli", "--help"])
     assert ret.success
     assert "usage: mqt-core-cli [-h] [--version] [--include_dir] [--cmake_dir]" in ret.stdout
-    assert "options:" in ret.stdout
 
 
 def test_cli_version(script_runner: ScriptRunner) -> None:

--- a/test/python/test_cli.py
+++ b/test/python/test_cli.py
@@ -1,0 +1,85 @@
+"""Test the mqt-core CLI."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from mqt.core import __version__ as mqt_core_version
+
+if TYPE_CHECKING:
+    from pytest_console_scripts import ScriptRunner
+
+
+def test_cli_no_arguments(script_runner: ScriptRunner) -> None:
+    """Test running the CLI with no arguments."""
+    ret = script_runner.run(["mqt-core-cli"])
+    assert ret.success
+    assert "usage: mqt-core-cli [-h] [--version] [--include_dir] [--cmake_dir]" in ret.stdout
+    assert "options:" in ret.stdout
+
+
+def test_cli_help(script_runner: ScriptRunner) -> None:
+    """Test running the CLI with the --help argument."""
+    ret = script_runner.run(["mqt-core-cli", "--help"])
+    assert ret.success
+    assert "usage: mqt-core-cli [-h] [--version] [--include_dir] [--cmake_dir]" in ret.stdout
+    assert "options:" in ret.stdout
+
+
+def test_cli_version(script_runner: ScriptRunner) -> None:
+    """Test running the CLI with the --version argument."""
+    ret = script_runner.run(["mqt-core-cli", "--version"])
+    assert ret.success
+    assert mqt_core_version in ret.stdout
+
+
+def test_cli_include_dir(script_runner: ScriptRunner) -> None:
+    """Test running the CLI with the --include_dir argument."""
+    ret = script_runner.run(["mqt-core-cli", "--include_dir"])
+    assert ret.success
+    assert "mqt/core/include" in ret.stdout
+
+
+def test_cli_cmake_dir(script_runner: ScriptRunner) -> None:
+    """Test running the CLI with the --cmake_dir argument."""
+    ret = script_runner.run(["mqt-core-cli", "--cmake_dir"])
+    assert ret.success
+    assert "mqt/core/share/cmake" in ret.stdout
+
+
+def test_cli_include_dir_not_installed(script_runner: ScriptRunner) -> None:
+    """Test running the CLI with the --include_dir argument, but mqt-core is not installed."""
+    with patch("importlib.metadata.Distribution.from_name") as mock:
+        mock.side_effect = PackageNotFoundError()
+        ret = script_runner.run(["mqt-core-cli", "--include_dir"])
+        assert not ret.success
+        assert "mqt-core not installed, installation required to access the include files." in ret.stderr
+
+
+def test_cli_cmake_dir_not_installed(script_runner: ScriptRunner) -> None:
+    """Test running the CLI with the --cmake_dir argument, but mqt-core is not installed."""
+    with patch("importlib.metadata.Distribution.from_name") as mock:
+        mock.side_effect = PackageNotFoundError()
+        ret = script_runner.run(["mqt-core-cli", "--cmake_dir"])
+        assert not ret.success
+        assert "mqt-core not installed, installation required to access the CMake files." in ret.stderr
+
+
+def test_cli_include_dir_not_found(script_runner: ScriptRunner) -> None:
+    """Test running the CLI with the --include_dir argument, but the include directory is not found."""
+    with patch("importlib.metadata.Distribution.from_name") as mock:
+        mock.return_value.locate_file.return_value = "dir-not-found"
+        ret = script_runner.run(["mqt-core-cli", "--include_dir"])
+        assert not ret.success
+        assert "mqt-core include files not found." in ret.stderr
+
+
+def test_cli_cmake_dir_not_found(script_runner: ScriptRunner) -> None:
+    """Test running the CLI with the --cmake_dir argument, but the CMake directory is not found."""
+    with patch("importlib.metadata.Distribution.from_name") as mock:
+        mock.return_value.locate_file.return_value = "dir-not-found"
+        ret = script_runner.run(["mqt-core-cli", "--cmake_dir"])
+        assert not ret.success
+        assert "mqt-core CMake files not found." in ret.stderr

--- a/test/python/test_cli.py
+++ b/test/python/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -37,14 +38,18 @@ def test_cli_include_dir(script_runner: ScriptRunner) -> None:
     """Test running the CLI with the --include_dir argument."""
     ret = script_runner.run(["mqt-core-cli", "--include_dir"])
     assert ret.success
-    assert "mqt/core/include" in ret.stdout
+    include_dir = Path(ret.stdout.strip())
+    assert include_dir.exists()
+    assert include_dir.is_dir()
 
 
 def test_cli_cmake_dir(script_runner: ScriptRunner) -> None:
     """Test running the CLI with the --cmake_dir argument."""
     ret = script_runner.run(["mqt-core-cli", "--cmake_dir"])
     assert ret.success
-    assert "mqt/core/share/cmake" in ret.stdout
+    cmake_dir = Path(ret.stdout.strip())
+    assert cmake_dir.exists()
+    assert cmake_dir.is_dir()
 
 
 def test_cli_include_dir_not_installed(script_runner: ScriptRunner) -> None:

--- a/test/python/test_cli.py
+++ b/test/python/test_cli.py
@@ -92,5 +92,5 @@ def test_cli_execute_module() -> None:
     """Test running the CLI by executing the mqt-core module."""
     from subprocess import check_output
 
-    output = check_output(["python3", "-m", "mqt.core", "--version"])  # noqa: S603, S607
+    output = check_output(["python", "-m", "mqt.core", "--version"])  # noqa: S603, S607
     assert mqt_core_version in output.decode()


### PR DESCRIPTION
## Description

This PR sets up the project so that it can be installed properly.
As it is configured right now, this allows to install the `mqt-core` Python package and make the C++ project available via `find_package(mqt-core)` as long as the proper cmake directory is added to the search path.
The right directory can easily be determined via `python -m mqt.core --cmake_dir` (or via `mqt-core-cli --cmake_dir`).
You might be wondering what this is useful for. It allows us to only require a single source copy of mqt-core in top-level projects once we switch them to using the `mqt-core` Python package. Otherwise, we would need to maintain the submodule and the Python package in parallel.

While I expect this to require some follow ups once used in practice, I believe this is a solid start.

Fixes #504 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
