### PR TITLE
🩹 guard install instruction

### DIFF
--- a/src/zx/CMakeLists.txt
+++ b/src/zx/CMakeLists.txt
@@ -21,9 +21,11 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME}-zx)
                                         $<INSTALL_INTERFACE:${MQT_CORE_INCLUDE_INSTALL_DIR}>)
       add_library(MQT::Multiprecision ALIAS multiprecision)
 
-      # finally, we create install instructions for the respective header files
-      install(DIRECTORY ${MULTIPRECISION_INCLUDE_DIR}/boost
-              DESTINATION ${MQT_CORE_INCLUDE_INSTALL_DIR})
+      if(MQT_CORE_INSTALL)
+        # finally, we create install instructions for the respective header files
+        install(DIRECTORY ${MULTIPRECISION_INCLUDE_DIR}/boost
+                DESTINATION ${MQT_CORE_INCLUDE_INSTALL_DIR})
+      endif()
     endif()
   endif()
 


### PR DESCRIPTION
## Description

This PR fixes a small oversight in #529 where one of the install instructions was not guarded properly. This should fix the issues observed in cda-tum/mqt-qcec#352.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
