### PR TITLE
🐛 Further installation fixes

### DIFF
--- a/include/mqt-core/dd/statistics/MemoryManagerStatistics.hpp
+++ b/include/mqt-core/dd/statistics/MemoryManagerStatistics.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dd/statistics/Statistics.hpp"
+#include "nlohmann/json_fwd.hpp"
 
 #include <cstddef>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,4 +275,4 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel"
 repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
-environment = { CMAKE_GENERATOR = "Ninja" }
+environment = { CMAKE_ARGS = "-T ClangCL" }


### PR DESCRIPTION
## Description

The goal of this PR is to identify and fix why
- cda-tum/mqt-qcec#355
- cda-tum/mqt-qmap#418
- cda-tum/mqt-ddsim#336

are all having problems with the static libraries deployed with v2.2.2. of mqt-core.

Currently known issues:
- Due to some unknown reason, some of the symbols are undefined and cannot be found in the shared Python module library.
- Due to some also unknown reason, the Windows wheels are installed in a Debug configuration which causes incompatibilities when trying to compile them together with Release build libraries.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
