### PR TITLE
🚨 fix Qiskit 0.46.0 deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,9 @@ filterwarnings = [
     'ignore:.*Building a flow controller with keyword arguments is going to be deprecated*:PendingDeprecationWarning:qiskit',
     'ignore:\s.*Pyarrow.*:DeprecationWarning:',
     'ignore:.*datetime\.datetime\.utcfromtimestamp.*:DeprecationWarning:',
+    'ignore:.*qiskit.utils.parallel*:DeprecationWarning:qiskit',
+    'ignore:.*qiskit.tools.events*:DeprecationWarning:qiskit',
+    'ignore:.*qiskit.qasm*:DeprecationWarning:qiskit',
 ]
 log_cli_level = "info"
 testpaths = ["test/python"]

--- a/test/python/test_io.py
+++ b/test/python/test_io.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from qiskit import QuantumCircuit
+from qiskit import QuantumCircuit, qasm2
 
 from mqt.core import QuantumComputation
 from mqt.core.io import load
@@ -64,7 +64,7 @@ def test_loading_qiskit_circuit() -> None:
     qiskit_circuit.h(0)
     qiskit_circuit.cx(0, 1)
     qiskit_circuit.measure(range(2), range(2))
-    qasm = qiskit_circuit.qasm()
+    qasm = qasm2.dumps(qiskit_circuit)
 
     # load the circuit
     qc = load(qiskit_circuit)


### PR DESCRIPTION
## Description

This PR works around some newly introduced deprecation warnings in the latest Qiskit version.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
