### PR TITLE
🐛 Fix `PiExpression` division and multiplication arithmetic

### DIFF
--- a/include/mqt-core/operations/Expression.hpp
+++ b/include/mqt-core/operations/Expression.hpp
@@ -252,7 +252,7 @@ public:
       return *this;
     }
     std::for_each(terms.begin(), terms.end(), [&](auto& term) { term *= rhs; });
-    constant *= U{rhs};
+    constant = U{double{constant} * double{rhs}};
     return *this;
   }
 

--- a/include/mqt-core/operations/Expression.hpp
+++ b/include/mqt-core/operations/Expression.hpp
@@ -275,7 +275,7 @@ public:
       throw std::runtime_error("Trying to divide expression by 0!");
     }
     std::for_each(terms.begin(), terms.end(), [&](auto& term) { term /= rhs; });
-    constant /= U{rhs};
+    constant = U{double{constant} / double{rhs}};
     return *this;
   }
 

--- a/test/zx/test_expression.cpp
+++ b/test/zx/test_expression.cpp
@@ -196,3 +196,13 @@ TEST_F(ExpressionTest, Instantiation) {
   EXPECT_THROW([[maybe_unused]] const auto h = e.evaluate(assignment),
                sym::SymbolicException);
 }
+
+TEST_F(ExpressionTest, Arithmetic) {
+  const auto beta = zx::PiRational(1, 2);
+
+  EXPECT_EQ(beta * 2, zx::PiRational(1, 1));
+  EXPECT_EQ(beta * 2., zx::PiRational(1, 1));
+
+  const auto betaExpr = zx::PiExpression{beta};
+  EXPECT_EQ(betaExpr * 2., zx::PiExpression{zx::PiRational(1, 1)});
+}

--- a/test/zx/test_expression.cpp
+++ b/test/zx/test_expression.cpp
@@ -205,4 +205,6 @@ TEST_F(ExpressionTest, Arithmetic) {
 
   const auto betaExpr = zx::PiExpression{beta};
   EXPECT_EQ(betaExpr * 2., zx::PiExpression{zx::PiRational(1, 1)});
+
+  EXPECT_EQ(betaExpr / .5, zx::PiExpression{zx::PiRational(1, 1)});
 }


### PR DESCRIPTION
## Description

Fix Arithmetic Issues when dividing or multiplying a `PiExpression` by a `double`.

Partially solves #486

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
