### PR TITLE
🩹 fixes for noise-aware simulation in DDSIM

### DIFF
--- a/include/mqt-core/dd/DDpackageConfig.hpp
+++ b/include/mqt-core/dd/DDpackageConfig.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "operations/OpType.hpp"
+
 #include <cstddef>
 
 namespace dd {
@@ -25,8 +27,36 @@ struct DDPackageConfig {
   static constexpr std::size_t CT_DM_ADD_NBUCKET = 1U;
 
   // The number of different quantum operations. I.e., the number of operations
-  // defined in the QFR OpType.hpp This parameter is required to initialize the
+  // defined in OpType.hpp. This parameter is required to initialize the
   // StochasticNoiseOperationTable.hpp
   static constexpr std::size_t STOCHASTIC_CACHE_OPS = 1;
+};
+
+struct StochasticNoiseSimulatorDDPackageConfig : public dd::DDPackageConfig {
+  static constexpr std::size_t STOCHASTIC_CACHE_OPS = qc::OpType::OpCount;
+};
+
+struct DensityMatrixSimulatorDDPackageConfig : public dd::DDPackageConfig {
+  static constexpr std::size_t UT_DM_NBUCKET = 65536U;
+  static constexpr std::size_t UT_DM_INITIAL_ALLOCATION_SIZE = 4096U;
+
+  static constexpr std::size_t CT_DM_DM_MULT_NBUCKET = 16384U;
+  static constexpr std::size_t CT_DM_ADD_NBUCKET = 16384U;
+  static constexpr std::size_t CT_DM_NOISE_NBUCKET = 4096U;
+
+  static constexpr std::size_t UT_MAT_NBUCKET = 16384U;
+  static constexpr std::size_t CT_MAT_ADD_NBUCKET = 4096U;
+  static constexpr std::size_t CT_VEC_ADD_NBUCKET = 4096U;
+  static constexpr std::size_t CT_MAT_CONJ_TRANS_NBUCKET = 4096U;
+
+  static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET = 1U;
+  static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET = 1U;
+  static constexpr std::size_t UT_VEC_NBUCKET = 1U;
+  static constexpr std::size_t UT_VEC_INITIAL_ALLOCATION_SIZE = 1U;
+  static constexpr std::size_t UT_MAT_INITIAL_ALLOCATION_SIZE = 1U;
+  static constexpr std::size_t CT_VEC_KRON_NBUCKET = 1U;
+  static constexpr std::size_t CT_MAT_KRON_NBUCKET = 1U;
+  static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 1U;
+  static constexpr std::size_t STOCHASTIC_CACHE_OPS = 1U;
 };
 } // namespace dd

--- a/include/mqt-core/dd/NoiseFunctionality.hpp
+++ b/include/mqt-core/dd/NoiseFunctionality.hpp
@@ -31,84 +31,22 @@ enum NoiseOperations : std::uint8_t {
   Identity
 };
 
-static void sanityCheckOfNoiseProbabilities(const double noiseProbability,
-                                            const double amplitudeDampingProb,
-                                            const double multiQubitGateFactor) {
-  if (noiseProbability < 0 || amplitudeDampingProb < 0 ||
-      noiseProbability * multiQubitGateFactor > 1 ||
-      amplitudeDampingProb * multiQubitGateFactor > 1) {
-    throw std::runtime_error(
-        "Error probabilities are faulty!"
-        "\n single qubit error probability: " +
-        std::to_string(noiseProbability) + " multi qubit error probability: " +
-        std::to_string(noiseProbability * multiQubitGateFactor) +
-        "\n single qubit amplitude damping  probability: " +
-        std::to_string(amplitudeDampingProb) +
-        " multi qubit amplitude damping  probability: " +
-        std::to_string(amplitudeDampingProb * multiQubitGateFactor));
-  }
-}
+void sanityCheckOfNoiseProbabilities(double noiseProbability,
+                                     double amplitudeDampingProb,
+                                     double multiQubitGateFactor);
 
-static std::vector<dd::NoiseOperations>
-initializeNoiseEffects(const std::string& cNoiseEffects) {
-  std::vector<dd::NoiseOperations> noiseOperationVector{};
-  for (const auto noise : cNoiseEffects) {
-    switch (noise) {
-    case 'A':
-      noiseOperationVector.push_back(dd::AmplitudeDamping);
-      break;
-    case 'P':
-      noiseOperationVector.push_back(dd::PhaseFlip);
-      break;
-    case 'D':
-      noiseOperationVector.push_back(dd::Depolarization);
-      break;
-    case 'I':
-      noiseOperationVector.push_back(dd::Identity);
-      break;
-    default:
-      throw std::runtime_error("Unknown noise operation '" + cNoiseEffects +
-                               "'\n");
-    }
-  }
-  return noiseOperationVector;
-}
-
-template <class Config> class StochasticNoiseFunctionality {
+class StochasticNoiseFunctionality {
 public:
-  StochasticNoiseFunctionality(const std::unique_ptr<Package<Config>>& dd,
-                               const std::size_t nq,
-                               double gateNoiseProbability,
-                               double amplitudeDampingProb,
-                               double multiQubitGateFactor,
-                               const std::string& cNoiseEffects)
-      : package(dd), nQubits(nq), dist(0.0, 1.0L),
-        noiseProbability(gateNoiseProbability),
-        noiseProbabilityMulti(gateNoiseProbability * multiQubitGateFactor),
-        sqrtAmplitudeDampingProbability(std::sqrt(amplitudeDampingProb)),
-        oneMinusSqrtAmplitudeDampingProbability(
-            std::sqrt(1 - amplitudeDampingProb)),
-        sqrtAmplitudeDampingProbabilityMulti(std::sqrt(gateNoiseProbability) *
-                                             multiQubitGateFactor),
-        oneMinusSqrtAmplitudeDampingProbabilityMulti(
-            std::sqrt(1 - multiQubitGateFactor * amplitudeDampingProb)),
-        ampDampingTrue({0, sqrtAmplitudeDampingProbability, 0, 0}),
-        ampDampingTrueMulti({0, sqrtAmplitudeDampingProbabilityMulti, 0, 0}),
-        ampDampingFalse({1, 0, 0, oneMinusSqrtAmplitudeDampingProbability}),
-        ampDampingFalseMulti(
-            {1, 0, 0, oneMinusSqrtAmplitudeDampingProbabilityMulti}),
-        noiseEffects(initializeNoiseEffects(cNoiseEffects)),
-        identityDD(package->makeIdent(nQubits)) {
-    sanityCheckOfNoiseProbabilities(gateNoiseProbability, amplitudeDampingProb,
-                                    multiQubitGateFactor);
-    package->incRef(identityDD);
-  }
+  StochasticNoiseFunctionality(
+      const std::unique_ptr<Package<StochasticNoiseSimulatorDDPackageConfig>>&
+          dd,
+      std::size_t nq, double gateNoiseProbability, double amplitudeDampingProb,
+      double multiQubitGateFactor, const std::string& cNoiseEffects);
 
   ~StochasticNoiseFunctionality() { package->decRef(identityDD); }
 
 protected:
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
-  const std::unique_ptr<Package<Config>>& package;
+  Package<StochasticNoiseSimulatorDDPackageConfig>* package;
   std::size_t nQubits;
   std::uniform_real_distribution<fp> dist;
 
@@ -126,195 +64,49 @@ protected:
   mEdge identityDD;
 
   [[nodiscard]] std::size_t getNumberOfQubits() const { return nQubits; }
-  [[nodiscard]] double getNoiseProbability(bool multiQubitNoiseFlag) const {
-    return multiQubitNoiseFlag ? noiseProbabilityMulti : noiseProbability;
-  }
+  [[nodiscard]] double getNoiseProbability(bool multiQubitNoiseFlag) const;
 
-  [[nodiscard]] qc::OpType
+  [[nodiscard]] static qc::OpType
   getAmplitudeDampingOperationType(bool multiQubitNoiseFlag,
-                                   bool amplitudeDampingFlag) const {
-    if (amplitudeDampingFlag) {
-      return multiQubitNoiseFlag ? qc::MultiATrue : qc::ATrue;
-    }
-    return multiQubitNoiseFlag ? qc::MultiAFalse : qc::AFalse;
-  }
+                                   bool amplitudeDampingFlag);
 
   [[nodiscard]] GateMatrix
   getAmplitudeDampingOperationMatrix(bool multiQubitNoiseFlag,
-                                     bool amplitudeDampingFlag) const {
-    if (amplitudeDampingFlag) {
-      return multiQubitNoiseFlag ? ampDampingTrueMulti : ampDampingTrue;
-    }
-    return multiQubitNoiseFlag ? ampDampingFalseMulti : ampDampingFalse;
-  }
+                                     bool amplitudeDampingFlag) const;
 
 public:
-  [[nodiscard]] mEdge getIdentityDD() const { return identityDD; }
-  void setNoiseEffects(std::vector<NoiseOperations> newNoiseEffects) {
-    noiseEffects = std::move(newNoiseEffects);
-  }
+  //  [[nodiscard]] mEdge getIdentityDD() const { return identityDD; }
+  //  void setNoiseEffects(std::vector<NoiseOperations> newNoiseEffects) {
+  //    noiseEffects = std::move(newNoiseEffects);
+  //  }
 
   void applyNoiseOperation(const std::set<qc::Qubit>& targets, mEdge operation,
-                           vEdge& state, std::mt19937_64& generator) {
-    const bool multiQubitOperation = targets.size() > 1;
-
-    for (const auto& target : targets) {
-      auto stackedOperation = generateNoiseOperation(
-          operation, target, generator, false, multiQubitOperation);
-      auto tmp = package->multiply(stackedOperation, state);
-
-      if (ComplexNumbers::mag2(tmp.w) < dist(generator)) {
-        // The probability of amplitude damping does not only depend on the
-        // noise probability, but also the quantum state. Due to the
-        // normalization constraint of decision diagrams the probability for
-        // applying amplitude damping stands in the root edge weight, of the dd
-        // after the noise has been applied
-        stackedOperation = generateNoiseOperation(operation, target, generator,
-                                                  true, multiQubitOperation);
-        tmp = package->multiply(stackedOperation, state);
-      }
-      tmp.w = Complex::one();
-
-      package->incRef(tmp);
-      package->decRef(state);
-      state = tmp;
-
-      // I only need to apply the operations once
-      operation = identityDD;
-    }
-  }
+                           vEdge& state, std::mt19937_64& generator);
 
 protected:
-  [[nodiscard]] mEdge stackOperation(mEdge operation, const qc::Qubit target,
-                                     const qc::OpType noiseOperation,
-                                     const GateMatrix matrix) {
-    if (const auto* op = package->stochasticNoiseOperationCache.lookup(
-            noiseOperation, target);
-        op != nullptr) {
-      return package->multiply(*op, operation);
-    }
-    const auto gateDD =
-        package->makeGateDD(matrix, getNumberOfQubits(), target);
-    package->stochasticNoiseOperationCache.insert(noiseOperation, target,
-                                                  gateDD);
-    return package->multiply(gateDD, operation);
-  }
+  [[nodiscard]] mEdge stackOperation(mEdge operation, qc::Qubit target,
+                                     qc::OpType noiseOperation,
+                                     GateMatrix matrix);
 
   mEdge generateNoiseOperation(mEdge operation, qc::Qubit target,
                                std::mt19937_64& generator,
-                               bool amplitudeDamping,
-                               bool multiQubitOperation) {
-    for (const auto& noiseType : noiseEffects) {
-      const auto effect = noiseType == AmplitudeDamping
-                              ? getAmplitudeDampingOperationType(
-                                    multiQubitOperation, amplitudeDamping)
-                              : returnNoiseOperation(noiseType, dist(generator),
-                                                     multiQubitOperation);
-      switch (effect) {
-      case (qc::I): {
-        continue;
-      }
-      case (qc::MultiATrue):
-      case (qc::ATrue): {
-        const GateMatrix amplitudeDampingMatrix =
-            getAmplitudeDampingOperationMatrix(multiQubitOperation, true);
-        operation =
-            stackOperation(operation, target, effect, amplitudeDampingMatrix);
-        break;
-      }
-      case (qc::MultiAFalse):
-      case (qc::AFalse): {
-        const GateMatrix amplitudeDampingMatrix =
-            getAmplitudeDampingOperationMatrix(multiQubitOperation, false);
-        operation =
-            stackOperation(operation, target, effect, amplitudeDampingMatrix);
-        break;
-      }
-      case (qc::X): {
-        operation = stackOperation(operation, target, effect, X_MAT);
-        break;
-      }
-      case (qc::Y): {
-        operation = stackOperation(operation, target, effect, Y_MAT);
-        break;
-      }
-      case (qc::Z): {
-        operation = stackOperation(operation, target, effect, Z_MAT);
-        break;
-      }
-      default: {
-        throw std::runtime_error("Unknown noise operation '" +
-                                 std::to_string(effect) + "'\n");
-      }
-      }
-    }
-    return operation;
-  }
+                               bool amplitudeDamping, bool multiQubitOperation);
 
-  [[nodiscard]] qc::OpType
-  returnNoiseOperation(NoiseOperations noiseOperation, double prob,
-                       bool multiQubitNoiseFlag) const {
-    switch (noiseOperation) {
-    case NoiseOperations::Depolarization: {
-      if (prob >= (getNoiseProbability(multiQubitNoiseFlag) * 0.75)) {
-        // prob > prob apply qc::I, also 25 % of the time when depolarization is
-        // applied nothing happens
-        return qc::I;
-      }
-      if (prob < (getNoiseProbability(multiQubitNoiseFlag) * 0.25)) {
-        // if 0 < prob < 0.25 (25 % of the time when applying depolarization)
-        // apply qc::X
-        return qc::X;
-      }
-      if (prob < (getNoiseProbability(multiQubitNoiseFlag) * 0.5)) {
-        // if 0.25 < prob < 0.5 (25 % of the time when applying depolarization)
-        // apply qc::Y
-        return qc::Y;
-      }
-      // if 0.5 < prob < 0.75 (25 % of the time when applying depolarization)
-      // apply qc::Z
-      return qc::Z;
-    }
-    case NoiseOperations::PhaseFlip: {
-      if (prob > getNoiseProbability(multiQubitNoiseFlag)) {
-        return qc::I;
-      }
-      return qc::Z;
-    }
-    case NoiseOperations::Identity: {
-      return qc::I;
-    }
-    default:
-      throw std::runtime_error(std::string{"Unknown noise effect '"} +
-                               std::to_string(noiseOperation) + "'");
-    }
-  }
+  [[nodiscard]] qc::OpType returnNoiseOperation(NoiseOperations noiseOperation,
+                                                double prob,
+                                                bool multiQubitNoiseFlag) const;
 };
 
-template <class Config> class DeterministicNoiseFunctionality {
+class DeterministicNoiseFunctionality {
 public:
-  DeterministicNoiseFunctionality(const std::unique_ptr<Package<Config>>& dd,
-                                  const std::size_t nq,
-                                  double noiseProbabilitySingleQubit,
-                                  double noiseProbabilityMultiQubit,
-                                  double ampDampProbSingleQubit,
-                                  double ampDampProbMultiQubit,
-                                  const std::string& cNoiseEffects)
-      : package(dd), nQubits(nq),
-        noiseProbSingleQubit(noiseProbabilitySingleQubit),
-        noiseProbMultiQubit(noiseProbabilityMultiQubit),
-        ampDampingProbSingleQubit(ampDampProbSingleQubit),
-        ampDampingProbMultiQubit(ampDampProbMultiQubit),
-        noiseEffects(initializeNoiseEffects(cNoiseEffects)) {
-    sanityCheckOfNoiseProbabilities(noiseProbabilitySingleQubit,
-                                    ampDampProbSingleQubit, 1);
-    sanityCheckOfNoiseProbabilities(noiseProbabilityMultiQubit,
-                                    ampDampProbMultiQubit, 1);
-  }
+  DeterministicNoiseFunctionality(
+      const std::unique_ptr<Package<DensityMatrixSimulatorDDPackageConfig>>& dd,
+      std::size_t nq, double noiseProbabilitySingleQubit,
+      double noiseProbabilityMultiQubit, double ampDampProbSingleQubit,
+      double ampDampProbMultiQubit, const std::string& cNoiseEffects);
 
 protected:
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
-  const std::unique_ptr<Package<Config>>& package;
+  Package<DensityMatrixSimulatorDDPackageConfig>* package;
   std::size_t nQubits;
 
   double noiseProbSingleQubit;
@@ -328,191 +120,18 @@ protected:
 
 public:
   void applyNoiseEffects(dEdge& originalEdge,
-                         const std::unique_ptr<qc::Operation>& qcOperation) {
-    auto usedQubits = qcOperation->getUsedQubits();
-    dCachedEdge nodeAfterNoise = {};
-    dEdge::applyDmChangesToEdge(originalEdge);
-    nodeAfterNoise = applyNoiseEffects(originalEdge, usedQubits, false);
-    dEdge::revertDmChangesToEdge(originalEdge);
-    auto r = dEdge{nodeAfterNoise.p, package->cn.lookup(nodeAfterNoise.w)};
-    package->incRef(r);
-    dEdge::alignDensityEdge(originalEdge);
-    package->decRef(originalEdge);
-    originalEdge = r;
-    dEdge::setDensityMatrixTrue(originalEdge);
-  }
+                         const std::unique_ptr<qc::Operation>& qcOperation);
 
 private:
   dCachedEdge applyNoiseEffects(dEdge& originalEdge,
                                 const std::set<qc::Qubit>& usedQubits,
-                                bool firstPathEdge) {
-    const auto originalWeight = static_cast<ComplexValue>(originalEdge.w);
-    if (originalEdge.isTerminal() || originalEdge.p->v < *usedQubits.begin()) {
-      return {originalEdge.p, originalWeight};
-    }
+                                bool firstPathEdge);
 
-    auto originalCopy = dEdge{originalEdge.p, Complex::one()};
-    ArrayOfEdges newEdges{};
-    for (std::size_t i = 0; i < newEdges.size(); i++) {
-      auto& successor = originalCopy.p->e[i];
-      if (firstPathEdge || i == 1) {
-        // If I am to the firstPathEdge I cannot minimize the necessary
-        // operations anymore
-        dEdge::applyDmChangesToEdge(successor);
-        newEdges[i] = applyNoiseEffects(successor, usedQubits, true);
-        dEdge::revertDmChangesToEdge(successor);
-      } else if (i == 2) {
-        // Since e[1] == e[2] (due to density matrix representation), I can skip
-        // calculating e[2]
-        newEdges[2] = newEdges[1];
-      } else {
-        dEdge::applyDmChangesToEdge(successor);
-        newEdges[i] = applyNoiseEffects(successor, usedQubits, false);
-        dEdge::revertDmChangesToEdge(successor);
-      }
-    }
-    if (std::any_of(usedQubits.begin(), usedQubits.end(),
-                    [originalEdge](const qc::Qubit qubit) {
-                      return originalEdge.p->v == qubit;
-                    })) {
-      for (auto const& type : noiseEffects) {
-        switch (type) {
-        case AmplitudeDamping:
-          applyAmplitudeDampingToEdges(
-              newEdges, (usedQubits.size() == 1) ? ampDampingProbSingleQubit
-                                                 : ampDampingProbMultiQubit);
-          break;
-        case PhaseFlip:
-          applyPhaseFlipToEdges(newEdges, (usedQubits.size() == 1)
-                                              ? noiseProbSingleQubit
-                                              : noiseProbMultiQubit);
-          break;
-        case Depolarization:
-          applyDepolarisationToEdges(newEdges, (usedQubits.size() == 1)
-                                                   ? noiseProbSingleQubit
-                                                   : noiseProbMultiQubit);
-          break;
-        case Identity:
-          continue;
-        }
-      }
-    }
+  static void applyPhaseFlipToEdges(ArrayOfEdges& e, double probability);
 
-    auto e = package->makeDDNode(originalCopy.p->v, newEdges, firstPathEdge);
-    if (e.w.exactlyZero()) {
-      return e;
-    }
-    e.w = e.w * originalWeight;
-    return e;
-  }
+  void applyAmplitudeDampingToEdges(ArrayOfEdges& e, double probability);
 
-  void applyPhaseFlipToEdges(ArrayOfEdges& e, double probability) {
-    const auto complexProb = 1. - 2. * probability;
-
-    // e[0] = e[0]
-    // e[1] = (1-2p)*e[1]
-    if (!e[1].w.exactlyZero()) {
-      e[1].w *= complexProb;
-    }
-    // e[2] = (1-2p)*e[2]
-    if (!e[2].w.exactlyZero()) {
-      e[2].w *= complexProb;
-    }
-    // e[3] = e[3]
-  }
-
-  void applyAmplitudeDampingToEdges(ArrayOfEdges& e, double probability) {
-    // e[0] = e[0] + p*e[3]
-    if (!e[3].w.exactlyZero()) {
-      if (!e[0].w.exactlyZero()) {
-        const auto var =
-            static_cast<Qubit>(std::max({e[0].p != nullptr ? e[0].p->v : 0,
-                                         e[1].p != nullptr ? e[1].p->v : 0,
-                                         e[2].p != nullptr ? e[2].p->v : 0,
-                                         e[3].p != nullptr ? e[3].p->v : 0}));
-        e[0] = package->add2(e[0], {e[3].p, e[3].w * probability}, var);
-      } else {
-        e[0] = {e[3].p, e[3].w * probability};
-      }
-    }
-
-    // e[1] = sqrt(1-p)*e[1]
-    if (!e[1].w.exactlyZero()) {
-      e[1].w *= std::sqrt(1 - probability);
-    }
-
-    // e[2] = sqrt(1-p)*e[2]
-    if (!e[2].w.exactlyZero()) {
-      e[2].w *= std::sqrt(1 - probability);
-    }
-
-    // e[3] = (1-p)*e[3]
-    if (!e[3].w.exactlyZero()) {
-      e[3].w *= (1 - probability);
-    }
-  }
-
-  void applyDepolarisationToEdges(ArrayOfEdges& e, double probability) {
-    std::array<dCachedEdge, 2> helperEdge{};
-
-    const auto var = static_cast<Qubit>(std::max(
-        {e[0].p != nullptr ? e[0].p->v : 0, e[1].p != nullptr ? e[1].p->v : 0,
-         e[2].p != nullptr ? e[2].p->v : 0,
-         e[3].p != nullptr ? e[3].p->v : 0}));
-
-    auto oldE0Edge = e[0];
-
-    // e[0] = 0.5*((2-p)*e[0] + p*e[3])
-    {
-      // helperEdge[0] = 0.5*((2-p)*e[0]
-      helperEdge[0].p = e[0].p;
-      if (!e[0].w.exactlyZero()) {
-        helperEdge[0].w = e[0].w * (2 - probability) * 0.5;
-      } else {
-        helperEdge[0].w = 0;
-      }
-
-      // helperEdge[1] = 0.5*p*e[3]
-      helperEdge[1].p = e[3].p;
-      if (!e[3].w.exactlyZero()) {
-        helperEdge[1].w = e[3].w * probability * 0.5;
-      } else {
-        helperEdge[1].w = 0;
-      }
-
-      // e[0] = helperEdge[0] + helperEdge[1]
-      e[0] = package->add2(helperEdge[0], helperEdge[1], var);
-    }
-
-    // e[1]=(1-p)*e[1]
-    if (!e[1].w.exactlyZero()) {
-      e[1].w *= (1 - probability);
-    }
-    // e[2]=(1-p)*e[2]
-    if (!e[2].w.exactlyZero()) {
-      e[2].w *= (1 - probability);
-    }
-
-    // e[3] = 0.5*((2-p)*e[3]) + 0.5*(p*e[0])
-    {
-      // helperEdge[0] = 0.5*((2-p)*e[3])
-      helperEdge[0].p = e[3].p;
-      if (!e[3].w.exactlyZero()) {
-        helperEdge[0].w = e[3].w * (2 - probability) * 0.5;
-      } else {
-        helperEdge[0].w = 0;
-      }
-
-      // helperEdge[1] = 0.5*p*e[0]
-      helperEdge[1].p = oldE0Edge.p;
-      if (!oldE0Edge.w.exactlyZero()) {
-        helperEdge[1].w = oldE0Edge.w * probability * 0.5;
-      } else {
-        helperEdge[1].w = 0;
-      }
-      e[3] = package->add2(helperEdge[0], helperEdge[1], var);
-    }
-  }
+  void applyDepolarisationToEdges(ArrayOfEdges& e, double probability);
 };
 
 } // namespace dd

--- a/include/mqt-core/dd/UniqueTable.hpp
+++ b/include/mqt-core/dd/UniqueTable.hpp
@@ -208,7 +208,6 @@ public:
    */
   [[nodiscard]] bool incRef(Node* p) noexcept {
     const auto inc = ::dd::incRef(p);
-    assert(!inc || p != nullptr);
     if (inc && p->ref == 1U) {
       stats[p->v].trackActiveEntry();
     }
@@ -227,7 +226,6 @@ public:
    */
   [[nodiscard]] bool decRef(Node* p) noexcept {
     const auto dec = ::dd::decRef(p);
-    assert(!dec || p != nullptr);
     if (dec && p->ref == 0U) {
       --stats[p->v].numActiveEntries;
     }

--- a/include/mqt-core/dd/UniqueTable.hpp
+++ b/include/mqt-core/dd/UniqueTable.hpp
@@ -208,6 +208,7 @@ public:
    */
   [[nodiscard]] bool incRef(Node* p) noexcept {
     const auto inc = ::dd::incRef(p);
+    assert(!inc || p != nullptr);
     if (inc && p->ref == 1U) {
       stats[p->v].trackActiveEntry();
     }
@@ -226,6 +227,7 @@ public:
    */
   [[nodiscard]] bool decRef(Node* p) noexcept {
     const auto dec = ::dd::decRef(p);
+    assert(!dec || p != nullptr);
     if (dec && p->ref == 0U) {
       --stats[p->v].numActiveEntries;
     }

--- a/src/dd/FunctionalityConstruction.cpp
+++ b/src/dd/FunctionalityConstruction.cpp
@@ -199,6 +199,13 @@ MatrixDD buildFunctionalityRecursive(const qc::Grover* qc,
 
 template MatrixDD buildFunctionality(const qc::QuantumComputation* qc,
                                      Package<DDPackageConfig>& dd);
+template MatrixDD
+buildFunctionality(const qc::QuantumComputation* qc,
+                   Package<dd::DensityMatrixSimulatorDDPackageConfig>& dd);
+template MatrixDD
+buildFunctionality(const qc::QuantumComputation* qc,
+                   Package<dd::StochasticNoiseSimulatorDDPackageConfig>& dd);
+
 template MatrixDD buildFunctionalityRecursive(const qc::QuantumComputation* qc,
                                               Package<DDPackageConfig>& dd);
 template bool buildFunctionalityRecursive(const qc::QuantumComputation* qc,

--- a/src/dd/NoiseFunctionality.cpp
+++ b/src/dd/NoiseFunctionality.cpp
@@ -1,6 +1,434 @@
 #include "dd/NoiseFunctionality.hpp"
 
+namespace {
+
+std::vector<dd::NoiseOperations>
+initializeNoiseEffects(const std::string& cNoiseEffects) {
+  std::vector<dd::NoiseOperations> noiseOperationVector{};
+  for (const auto noise : cNoiseEffects) {
+    switch (noise) {
+    case 'A':
+      noiseOperationVector.push_back(dd::AmplitudeDamping);
+      break;
+    case 'P':
+      noiseOperationVector.push_back(dd::PhaseFlip);
+      break;
+    case 'D':
+      noiseOperationVector.push_back(dd::Depolarization);
+      break;
+    case 'I':
+      noiseOperationVector.push_back(dd::Identity);
+      break;
+    default:
+      throw std::runtime_error("Unknown noise operation '" + cNoiseEffects +
+                               "'\n");
+    }
+  }
+  return noiseOperationVector;
+}
+} // namespace
+
 namespace dd {
-template class StochasticNoiseFunctionality<DDPackageConfig>;
-template class DeterministicNoiseFunctionality<DDPackageConfig>;
+StochasticNoiseFunctionality::StochasticNoiseFunctionality(
+    const std::unique_ptr<Package<StochasticNoiseSimulatorDDPackageConfig>>& dd,
+    const std::size_t nq, double gateNoiseProbability,
+    double amplitudeDampingProb, double multiQubitGateFactor,
+    const std::string& cNoiseEffects)
+    : package(dd.get()), nQubits(nq), dist(0.0, 1.0L),
+      noiseProbability(gateNoiseProbability),
+      noiseProbabilityMulti(gateNoiseProbability * multiQubitGateFactor),
+      sqrtAmplitudeDampingProbability(std::sqrt(amplitudeDampingProb)),
+      oneMinusSqrtAmplitudeDampingProbability(
+          std::sqrt(1 - amplitudeDampingProb)),
+      sqrtAmplitudeDampingProbabilityMulti(std::sqrt(gateNoiseProbability) *
+                                           multiQubitGateFactor),
+      oneMinusSqrtAmplitudeDampingProbabilityMulti(
+          std::sqrt(1 - multiQubitGateFactor * amplitudeDampingProb)),
+      ampDampingTrue({0, sqrtAmplitudeDampingProbability, 0, 0}),
+      ampDampingTrueMulti({0, sqrtAmplitudeDampingProbabilityMulti, 0, 0}),
+      ampDampingFalse({1, 0, 0, oneMinusSqrtAmplitudeDampingProbability}),
+      ampDampingFalseMulti(
+          {1, 0, 0, oneMinusSqrtAmplitudeDampingProbabilityMulti}),
+      noiseEffects(initializeNoiseEffects(cNoiseEffects)),
+      identityDD(package->makeIdent(nQubits)) {
+  sanityCheckOfNoiseProbabilities(gateNoiseProbability, amplitudeDampingProb,
+                                  multiQubitGateFactor);
+  package->incRef(identityDD);
+}
+
+double StochasticNoiseFunctionality::getNoiseProbability(
+    bool multiQubitNoiseFlag) const {
+  return multiQubitNoiseFlag ? noiseProbabilityMulti : noiseProbability;
+}
+
+qc::OpType StochasticNoiseFunctionality::getAmplitudeDampingOperationType(
+    const bool multiQubitNoiseFlag, const bool amplitudeDampingFlag) {
+  if (amplitudeDampingFlag) {
+    return multiQubitNoiseFlag ? qc::MultiATrue : qc::ATrue;
+  }
+  return multiQubitNoiseFlag ? qc::MultiAFalse : qc::AFalse;
+}
+
+GateMatrix StochasticNoiseFunctionality::getAmplitudeDampingOperationMatrix(
+    const bool multiQubitNoiseFlag, const bool amplitudeDampingFlag) const {
+  if (amplitudeDampingFlag) {
+    return multiQubitNoiseFlag ? ampDampingTrueMulti : ampDampingTrue;
+  }
+  return multiQubitNoiseFlag ? ampDampingFalseMulti : ampDampingFalse;
+}
+
+void StochasticNoiseFunctionality::applyNoiseOperation(
+    const std::set<qc::Qubit>& targets, mEdge operation, vEdge& state,
+    std::mt19937_64& generator) {
+  const bool multiQubitOperation = targets.size() > 1;
+
+  for (const auto& target : targets) {
+    auto stackedOperation = generateNoiseOperation(operation, target, generator,
+                                                   false, multiQubitOperation);
+    auto tmp = package->multiply(stackedOperation, state);
+
+    if (ComplexNumbers::mag2(tmp.w) < dist(generator)) {
+      // The probability of amplitude damping does not only depend on the
+      // noise probability, but also the quantum state. Due to the
+      // normalization constraint of decision diagrams the probability for
+      // applying amplitude damping stands in the root edge weight, of the dd
+      // after the noise has been applied
+      stackedOperation = generateNoiseOperation(operation, target, generator,
+                                                true, multiQubitOperation);
+      tmp = package->multiply(stackedOperation, state);
+    }
+    tmp.w = Complex::one();
+
+    package->incRef(tmp);
+    package->decRef(state);
+    state = tmp;
+
+    // I only need to apply the operations once
+    operation = identityDD;
+  }
+}
+
+mEdge StochasticNoiseFunctionality::stackOperation(
+    mEdge operation, const qc::Qubit target, const qc::OpType noiseOperation,
+    const GateMatrix matrix) {
+  if (const auto* op =
+          package->stochasticNoiseOperationCache.lookup(noiseOperation, target);
+      op != nullptr) {
+    return package->multiply(*op, operation);
+  }
+  const auto gateDD = package->makeGateDD(matrix, getNumberOfQubits(), target);
+  package->stochasticNoiseOperationCache.insert(noiseOperation, target, gateDD);
+  return package->multiply(gateDD, operation);
+}
+
+mEdge StochasticNoiseFunctionality::generateNoiseOperation(
+    mEdge operation, qc::Qubit target, std::mt19937_64& generator,
+    const bool amplitudeDamping, const bool multiQubitOperation) {
+  for (const auto& noiseType : noiseEffects) {
+    const auto effect = noiseType == AmplitudeDamping
+                            ? getAmplitudeDampingOperationType(
+                                  multiQubitOperation, amplitudeDamping)
+                            : returnNoiseOperation(noiseType, dist(generator),
+                                                   multiQubitOperation);
+    switch (effect) {
+    case (qc::I): {
+      continue;
+    }
+    case (qc::MultiATrue):
+    case (qc::ATrue): {
+      const GateMatrix amplitudeDampingMatrix =
+          getAmplitudeDampingOperationMatrix(multiQubitOperation, true);
+      operation =
+          stackOperation(operation, target, effect, amplitudeDampingMatrix);
+      break;
+    }
+    case (qc::MultiAFalse):
+    case (qc::AFalse): {
+      const GateMatrix amplitudeDampingMatrix =
+          getAmplitudeDampingOperationMatrix(multiQubitOperation, false);
+      operation =
+          stackOperation(operation, target, effect, amplitudeDampingMatrix);
+      break;
+    }
+    case (qc::X): {
+      operation = stackOperation(operation, target, effect, X_MAT);
+      break;
+    }
+    case (qc::Y): {
+      operation = stackOperation(operation, target, effect, Y_MAT);
+      break;
+    }
+    case (qc::Z): {
+      operation = stackOperation(operation, target, effect, Z_MAT);
+      break;
+    }
+    default: {
+      throw std::runtime_error("Unknown noise operation '" +
+                               std::to_string(effect) + "'\n");
+    }
+    }
+  }
+  return operation;
+}
+
+qc::OpType StochasticNoiseFunctionality::returnNoiseOperation(
+    NoiseOperations noiseOperation, const double prob,
+    const bool multiQubitNoiseFlag) const {
+  switch (noiseOperation) {
+  case NoiseOperations::Depolarization: {
+    if (prob >= (getNoiseProbability(multiQubitNoiseFlag) * 0.75)) {
+      // prob > prob apply qc::I, also 25 % of the time when depolarization is
+      // applied nothing happens
+      return qc::I;
+    }
+    if (prob < (getNoiseProbability(multiQubitNoiseFlag) * 0.25)) {
+      // if 0 < prob < 0.25 (25 % of the time when applying depolarization)
+      // apply qc::X
+      return qc::X;
+    }
+    if (prob < (getNoiseProbability(multiQubitNoiseFlag) * 0.5)) {
+      // if 0.25 < prob < 0.5 (25 % of the time when applying depolarization)
+      // apply qc::Y
+      return qc::Y;
+    }
+    // if 0.5 < prob < 0.75 (25 % of the time when applying depolarization)
+    // apply qc::Z
+    return qc::Z;
+  }
+  case NoiseOperations::PhaseFlip: {
+    if (prob > getNoiseProbability(multiQubitNoiseFlag)) {
+      return qc::I;
+    }
+    return qc::Z;
+  }
+  case NoiseOperations::Identity: {
+    return qc::I;
+  }
+  default:
+    throw std::runtime_error(std::string{"Unknown noise effect '"} +
+                             std::to_string(noiseOperation) + "'");
+  }
+}
+
+DeterministicNoiseFunctionality::DeterministicNoiseFunctionality(
+    const std::unique_ptr<Package<DensityMatrixSimulatorDDPackageConfig>>& dd,
+    const std::size_t nq, double noiseProbabilitySingleQubit,
+    double noiseProbabilityMultiQubit, double ampDampProbSingleQubit,
+    double ampDampProbMultiQubit, const std::string& cNoiseEffects)
+    : package(dd.get()), nQubits(nq),
+      noiseProbSingleQubit(noiseProbabilitySingleQubit),
+      noiseProbMultiQubit(noiseProbabilityMultiQubit),
+      ampDampingProbSingleQubit(ampDampProbSingleQubit),
+      ampDampingProbMultiQubit(ampDampProbMultiQubit),
+      noiseEffects(initializeNoiseEffects(cNoiseEffects)) {
+  sanityCheckOfNoiseProbabilities(noiseProbabilitySingleQubit,
+                                  ampDampProbSingleQubit, 1);
+  sanityCheckOfNoiseProbabilities(noiseProbabilityMultiQubit,
+                                  ampDampProbMultiQubit, 1);
+}
+
+void DeterministicNoiseFunctionality::applyNoiseEffects(
+    dEdge& originalEdge, const std::unique_ptr<qc::Operation>& qcOperation) {
+  auto usedQubits = qcOperation->getUsedQubits();
+  dCachedEdge nodeAfterNoise = {};
+  dEdge::applyDmChangesToEdge(originalEdge);
+  nodeAfterNoise = applyNoiseEffects(originalEdge, usedQubits, false);
+  dEdge::revertDmChangesToEdge(originalEdge);
+  auto r = dEdge{nodeAfterNoise.p, package->cn.lookup(nodeAfterNoise.w)};
+  package->incRef(r);
+  dEdge::alignDensityEdge(originalEdge);
+  package->decRef(originalEdge);
+  originalEdge = r;
+  dEdge::setDensityMatrixTrue(originalEdge);
+}
+
+dCachedEdge DeterministicNoiseFunctionality::applyNoiseEffects(
+    dEdge& originalEdge, const std::set<qc::Qubit>& usedQubits,
+    const bool firstPathEdge) {
+  const auto originalWeight = static_cast<ComplexValue>(originalEdge.w);
+  if (originalEdge.isTerminal() || originalEdge.p->v < *usedQubits.begin()) {
+    return {originalEdge.p, originalWeight};
+  }
+
+  auto originalCopy = dEdge{originalEdge.p, Complex::one()};
+  ArrayOfEdges newEdges{};
+  for (std::size_t i = 0; i < newEdges.size(); i++) {
+    auto& successor = originalCopy.p->e[i];
+    if (firstPathEdge || i == 1) {
+      // If I am to the firstPathEdge I cannot minimize the necessary
+      // operations anymore
+      dEdge::applyDmChangesToEdge(successor);
+      newEdges[i] = applyNoiseEffects(successor, usedQubits, true);
+      dEdge::revertDmChangesToEdge(successor);
+    } else if (i == 2) {
+      // Since e[1] == e[2] (due to density matrix representation), I can skip
+      // calculating e[2]
+      newEdges[2] = newEdges[1];
+    } else {
+      dEdge::applyDmChangesToEdge(successor);
+      newEdges[i] = applyNoiseEffects(successor, usedQubits, false);
+      dEdge::revertDmChangesToEdge(successor);
+    }
+  }
+  if (std::any_of(usedQubits.begin(), usedQubits.end(),
+                  [originalEdge](const qc::Qubit qubit) {
+                    return originalEdge.p->v == qubit;
+                  })) {
+    for (auto const& type : noiseEffects) {
+      switch (type) {
+      case AmplitudeDamping:
+        applyAmplitudeDampingToEdges(newEdges, (usedQubits.size() == 1)
+                                                   ? ampDampingProbSingleQubit
+                                                   : ampDampingProbMultiQubit);
+        break;
+      case PhaseFlip:
+        applyPhaseFlipToEdges(newEdges, (usedQubits.size() == 1)
+                                            ? noiseProbSingleQubit
+                                            : noiseProbMultiQubit);
+        break;
+      case Depolarization:
+        applyDepolarisationToEdges(newEdges, (usedQubits.size() == 1)
+                                                 ? noiseProbSingleQubit
+                                                 : noiseProbMultiQubit);
+        break;
+      case Identity:
+        continue;
+      }
+    }
+  }
+
+  auto e = package->makeDDNode(originalCopy.p->v, newEdges, firstPathEdge);
+  if (e.w.exactlyZero()) {
+    return e;
+  }
+  e.w = e.w * originalWeight;
+  return e;
+}
+
+void DeterministicNoiseFunctionality::applyPhaseFlipToEdges(
+    ArrayOfEdges& e, const double probability) {
+  const auto complexProb = 1. - 2. * probability;
+
+  // e[0] = e[0]
+  // e[1] = (1-2p)*e[1]
+  if (!e[1].w.exactlyZero()) {
+    e[1].w *= complexProb;
+  }
+  // e[2] = (1-2p)*e[2]
+  if (!e[2].w.exactlyZero()) {
+    e[2].w *= complexProb;
+  }
+  // e[3] = e[3]
+}
+
+void DeterministicNoiseFunctionality::applyAmplitudeDampingToEdges(
+    ArrayOfEdges& e, const double probability) {
+  // e[0] = e[0] + p*e[3]
+  if (!e[3].w.exactlyZero()) {
+    if (!e[0].w.exactlyZero()) {
+      const auto var = static_cast<Qubit>(std::max(
+          {e[0].p != nullptr ? e[0].p->v : 0, e[1].p != nullptr ? e[1].p->v : 0,
+           e[2].p != nullptr ? e[2].p->v : 0,
+           e[3].p != nullptr ? e[3].p->v : 0}));
+      e[0] = package->add2(e[0], {e[3].p, e[3].w * probability}, var);
+    } else {
+      e[0] = {e[3].p, e[3].w * probability};
+    }
+  }
+
+  // e[1] = sqrt(1-p)*e[1]
+  if (!e[1].w.exactlyZero()) {
+    e[1].w *= std::sqrt(1 - probability);
+  }
+
+  // e[2] = sqrt(1-p)*e[2]
+  if (!e[2].w.exactlyZero()) {
+    e[2].w *= std::sqrt(1 - probability);
+  }
+
+  // e[3] = (1-p)*e[3]
+  if (!e[3].w.exactlyZero()) {
+    e[3].w *= (1 - probability);
+  }
+}
+
+void DeterministicNoiseFunctionality::applyDepolarisationToEdges(
+    ArrayOfEdges& e, const double probability) {
+  std::array<dCachedEdge, 2> helperEdge{};
+
+  const auto var = static_cast<Qubit>(std::max(
+      {e[0].p != nullptr ? e[0].p->v : 0, e[1].p != nullptr ? e[1].p->v : 0,
+       e[2].p != nullptr ? e[2].p->v : 0, e[3].p != nullptr ? e[3].p->v : 0}));
+
+  auto oldE0Edge = e[0];
+
+  // e[0] = 0.5*((2-p)*e[0] + p*e[3])
+  {
+    // helperEdge[0] = 0.5*((2-p)*e[0]
+    helperEdge[0].p = e[0].p;
+    if (!e[0].w.exactlyZero()) {
+      helperEdge[0].w = e[0].w * (2 - probability) * 0.5;
+    } else {
+      helperEdge[0].w = 0;
+    }
+
+    // helperEdge[1] = 0.5*p*e[3]
+    helperEdge[1].p = e[3].p;
+    if (!e[3].w.exactlyZero()) {
+      helperEdge[1].w = e[3].w * probability * 0.5;
+    } else {
+      helperEdge[1].w = 0;
+    }
+
+    // e[0] = helperEdge[0] + helperEdge[1]
+    e[0] = package->add2(helperEdge[0], helperEdge[1], var);
+  }
+
+  // e[1]=(1-p)*e[1]
+  if (!e[1].w.exactlyZero()) {
+    e[1].w *= (1 - probability);
+  }
+  // e[2]=(1-p)*e[2]
+  if (!e[2].w.exactlyZero()) {
+    e[2].w *= (1 - probability);
+  }
+
+  // e[3] = 0.5*((2-p)*e[3]) + 0.5*(p*e[0])
+  {
+    // helperEdge[0] = 0.5*((2-p)*e[3])
+    helperEdge[0].p = e[3].p;
+    if (!e[3].w.exactlyZero()) {
+      helperEdge[0].w = e[3].w * (2 - probability) * 0.5;
+    } else {
+      helperEdge[0].w = 0;
+    }
+
+    // helperEdge[1] = 0.5*p*e[0]
+    helperEdge[1].p = oldE0Edge.p;
+    if (!oldE0Edge.w.exactlyZero()) {
+      helperEdge[1].w = oldE0Edge.w * probability * 0.5;
+    } else {
+      helperEdge[1].w = 0;
+    }
+    e[3] = package->add2(helperEdge[0], helperEdge[1], var);
+  }
+}
+
+void sanityCheckOfNoiseProbabilities(const double noiseProbability,
+                                     const double amplitudeDampingProb,
+                                     const double multiQubitGateFactor) {
+  if (noiseProbability < 0 || amplitudeDampingProb < 0 ||
+      noiseProbability * multiQubitGateFactor > 1 ||
+      amplitudeDampingProb * multiQubitGateFactor > 1) {
+    throw std::runtime_error(
+        "Error probabilities are faulty!"
+        "\n single qubit error probability: " +
+        std::to_string(noiseProbability) + " multi qubit error probability: " +
+        std::to_string(noiseProbability * multiQubitGateFactor) +
+        "\n single qubit amplitude damping  probability: " +
+        std::to_string(amplitudeDampingProb) +
+        " multi qubit amplitude damping  probability: " +
+        std::to_string(amplitudeDampingProb * multiQubitGateFactor));
+  }
+}
 } // namespace dd

--- a/test/dd/test_dd_noise_functionality.cpp
+++ b/test/dd/test_dd_noise_functionality.cpp
@@ -8,40 +8,11 @@
 
 using namespace qc;
 
-struct StochasticNoiseSimulatorDDPackageConfig : public dd::DDPackageConfig {
-  static constexpr std::size_t STOCHASTIC_CACHE_OPS = OpType::OpCount;
-};
-
 using StochasticNoiseTestPackage =
-    dd::Package<StochasticNoiseSimulatorDDPackageConfig>;
-
-struct DensityMatrixSimulatorDDPackageConfig : public dd::DDPackageConfig {
-  static constexpr std::size_t UT_DM_NBUCKET = 65536U;
-  static constexpr std::size_t UT_DM_INITIAL_ALLOCATION_SIZE = 4096U;
-
-  static constexpr std::size_t CT_DM_DM_MULT_NBUCKET = 16384U;
-  static constexpr std::size_t CT_DM_ADD_NBUCKET = 16384U;
-  static constexpr std::size_t CT_DM_NOISE_NBUCKET = 4096U;
-
-  static constexpr std::size_t UT_MAT_NBUCKET = 16384U;
-  static constexpr std::size_t CT_MAT_ADD_NBUCKET = 4096U;
-  static constexpr std::size_t CT_VEC_ADD_NBUCKET = 4096U;
-  static constexpr std::size_t CT_MAT_TRANS_NBUCKET = 4096U;
-  static constexpr std::size_t CT_MAT_CONJ_TRANS_NBUCKET = 4096U;
-
-  static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET = 1U;
-  static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET = 1U;
-  static constexpr std::size_t UT_VEC_NBUCKET = 1U;
-  static constexpr std::size_t UT_VEC_INITIAL_ALLOCATION_SIZE = 1U;
-  static constexpr std::size_t UT_MAT_INITIAL_ALLOCATION_SIZE = 1U;
-  static constexpr std::size_t CT_VEC_KRON_NBUCKET = 1U;
-  static constexpr std::size_t CT_MAT_KRON_NBUCKET = 1U;
-  static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 1U;
-  static constexpr std::size_t STOCHASTIC_CACHE_OPS = 1U;
-};
+    dd::Package<dd::StochasticNoiseSimulatorDDPackageConfig>;
 
 using DensityMatrixTestPackage =
-    dd::Package<DensityMatrixSimulatorDDPackageConfig>;
+    dd::Package<dd::DensityMatrixSimulatorDDPackageConfig>;
 
 class DDNoiseFunctionalityTest : public ::testing::Test {
 protected:

--- a/test/dd/test_dd_noise_functionality.cpp
+++ b/test/dd/test_dd_noise_functionality.cpp
@@ -281,3 +281,17 @@ TEST_F(DDNoiseFunctionalityTest, testingUsedQubits) {
   EXPECT_EQ(classicalControlledOp.getUsedQubits().size(), 1);
   EXPECT_TRUE(classicalControlledOp.getUsedQubits().count(0) == 1U);
 }
+
+TEST_F(DDNoiseFunctionalityTest, invalidNoiseEffect) {
+  auto dd = std::make_unique<StochasticNoiseTestPackage>(qc.getNqubits());
+  EXPECT_THROW(dd::StochasticNoiseFunctionality(dd, qc.getNqubits(), 0.01, 0.02,
+                                                2., "APK"),
+               std::runtime_error);
+}
+
+TEST_F(DDNoiseFunctionalityTest, invalidNoiseProbabilities) {
+  auto dd = std::make_unique<StochasticNoiseTestPackage>(qc.getNqubits());
+  EXPECT_THROW(
+      dd::StochasticNoiseFunctionality(dd, qc.getNqubits(), 0.3, 0.6, 2, "APD"),
+      std::runtime_error);
+}

--- a/test/dd/test_dd_noise_functionality.cpp
+++ b/test/dd/test_dd_noise_functionality.cpp
@@ -67,8 +67,7 @@ TEST_F(DDNoiseFunctionalityTest, DetSimulateAdder4TrackAPD) {
   auto rootEdge = dd->makeZeroDensityOperator(qc.getNqubits());
   dd->incRef(rootEdge);
 
-  const auto noiseEffects = {dd::AmplitudeDamping, dd::PhaseFlip,
-                             dd::Depolarization, dd::Identity};
+  const auto* const noiseEffects = "APDI";
 
   auto deterministicNoiseFunctionality = dd::DeterministicNoiseFunctionality(
       dd, qc.getNqubits(), 0.01, 0.02, 0.02, 0.04, noiseEffects);
@@ -161,8 +160,7 @@ TEST_F(DDNoiseFunctionalityTest, StochSimulateAdder4TrackAPD) {
       {"0101", 0.}, {"0110", 0.}, {"0111", 0.}, {"1000", 0.}, {"1001", 0.},
       {"1010", 0.}, {"1011", 0.}, {"1100", 0.}, {"1101", 0.}};
 
-  const auto noiseEffects = {dd::AmplitudeDamping, dd::PhaseFlip, dd::Identity,
-                             dd::Depolarization};
+  const auto* const noiseEffects = "APDI";
 
   auto stochasticNoiseFunctionality = dd::StochasticNoiseFunctionality(
       dd, qc.getNqubits(), 0.01, 0.02, 2., noiseEffects);
@@ -214,7 +212,7 @@ TEST_F(DDNoiseFunctionalityTest, StochSimulateAdder4IdentiyError) {
       {"0101", 0.}, {"0110", 0.}, {"0111", 0.}, {"1000", 0.}, {"1001", 0.},
       {"1010", 0.}, {"1011", 0.}, {"1100", 0.}, {"1101", 0.}};
 
-  const auto noiseEffects = {dd::Identity};
+  const auto* const noiseEffects = "I";
 
   auto stochasticNoiseFunctionality = dd::StochasticNoiseFunctionality(
       dd, qc.getNqubits(), 0.01, 0.02, 2., noiseEffects);


### PR DESCRIPTION
## Description

This PR contains a couple of fixes for the noise-aware simulation techniques currently being reworked in cda-tum/mqt-ddsim#321.

More precisely, this PR makes sure that the corresponding DD package configs are already defined in the mqt-core library and that explicit instantiations for the methods relevant for DDSIM are in place.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
