### PR TITLE
✨ Support for Qiskit 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ docs = [
     "mqt.core[evaluation]"
 ]
 qiskit = [
-   "qiskit[qasm3-import]>=0.45.0",
+   "qiskit[qasm3-import]>=1.0.0",
 ]
 dev = ["mqt.core[coverage, docs]",]
 
@@ -127,14 +127,8 @@ addopts = ["-ra", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
     "error",
-    'ignore:.*qiskit.__qiskit_version__.*:DeprecationWarning:qiskit:',
-    'ignore:.*qiskit.utils.algorithm_globals.QiskitAlgorithmGlobals*:DeprecationWarning:qiskit',
-    'ignore:.*Building a flow controller with keyword arguments is going to be deprecated*:PendingDeprecationWarning:qiskit',
     'ignore:\s.*Pyarrow.*:DeprecationWarning:',
     'ignore:.*datetime\.datetime\.utcfromtimestamp.*:DeprecationWarning:',
-    'ignore:.*qiskit.utils.parallel*:DeprecationWarning:qiskit',
-    'ignore:.*qiskit.tools.events*:DeprecationWarning:qiskit',
-    'ignore:.*qiskit.qasm*:DeprecationWarning:qiskit',
 ]
 log_cli_level = "info"
 testpaths = ["test/python"]

--- a/test/python/constraints.txt
+++ b/test/python/constraints.txt
@@ -3,6 +3,6 @@ pandas==2.1.2; python_version >= "3.9"
 pybind11==2.11.0
 pytest==7.0.0
 pytest-console-scripts==1.4
-qiskit==0.45.0
+qiskit==1.0.0
 scikit-build-core==0.8.1
 setuptools-scm==7.0.0


### PR DESCRIPTION
## Description

This PR marks the official support of Qiskit 1.0 in mqt-core.

In order to avoid all kinds of ugly compatibility hacks, this PR also changes the minimum required Qiskit version to 1.0.
Since Qiskit has devoted themselves to following semantic versioning from now on out, this hopefully means fewer compatibility changes in the future.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
