### PR TITLE
🚸 allow using raw RST cells in jupyter notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,11 @@ repos:
     rev: 3.2.0
     hooks:
       - id: nb-clean
+        args:
+          - --remove-empty-cells
+          - --preserve-cell-metadata
+          - raw_mimetype
+          - --
 
   # Handling unwanted unicode characters
   - repo: https://github.com/sirosen/texthooks

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -393,14 +393,6 @@
     "mqt_qc = qiskit_to_mqt(qiskit_qc)\n",
     "print(mqt_qc)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d62ae1fde42917",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Description

This PR updates the jupyter notebook cleaning pre-commit check to preserve MIME metadata. This allows to use raw RST cells within jupyter notebooks, which can be very helpful for using Sphinx references as part of the documentation.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
