### PR TITLE
🐛 Fix scientific notation in QASM import

### DIFF
--- a/test/unittests/test_qasm3_parser.cpp
+++ b/test/unittests/test_qasm3_parser.cpp
@@ -743,12 +743,14 @@ TEST_F(Qasm3ParserTest, ImportQasm3CPrefix) {
 TEST_F(Qasm3ParserTest, ImportQasmScanner) {
   std::stringstream ss{};
   const std::string testfile =
-      "$1 : . .5 -1. -= += ++ *= **= ** /= % %= |= || | &= "
+      "$1 : . .5 -1. 1.25e-3 1e3 -= += ++ *= **= ** /= % %= |= || | &= "
       "&& & ^= ^ ~= ~ ! <= <<= << < >= >>= >> >";
   const auto tokens = std::vector{
       qasm3::Token::Kind::HardwareQubit,
       qasm3::Token::Kind::Colon,
       qasm3::Token::Kind::Dot,
+      qasm3::Token::Kind::FloatLiteral,
+      qasm3::Token::Kind::FloatLiteral,
       qasm3::Token::Kind::FloatLiteral,
       qasm3::Token::Kind::FloatLiteral,
       qasm3::Token::Kind::MinusEquals,


### PR DESCRIPTION
## Description

This PR fixes a small bug in the QASM importer that would prevent it from properly importing floating point numbers in scientific notation.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
