### PR TITLE
🚸 Improved usability for new magnitude addition functionality

### DIFF
--- a/include/mqt-core/dd/DDpackageConfig.hpp
+++ b/include/mqt-core/dd/DDpackageConfig.hpp
@@ -14,6 +14,8 @@ struct DDPackageConfig {
   static constexpr std::size_t UT_MAT_INITIAL_ALLOCATION_SIZE = 2048U;
   static constexpr std::size_t CT_VEC_ADD_NBUCKET = 16384U;
   static constexpr std::size_t CT_MAT_ADD_NBUCKET = 16384U;
+  static constexpr std::size_t CT_VEC_ADD_MAG_NBUCKET = 16384U;
+  static constexpr std::size_t CT_MAT_ADD_MAG_NBUCKET = 16384U;
   static constexpr std::size_t CT_MAT_CONJ_TRANS_NBUCKET = 4096U;
   static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET = 16384U;
   static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET = 16384U;
@@ -34,6 +36,9 @@ struct DDPackageConfig {
 
 struct StochasticNoiseSimulatorDDPackageConfig : public dd::DDPackageConfig {
   static constexpr std::size_t STOCHASTIC_CACHE_OPS = qc::OpType::OpCount;
+
+  static constexpr std::size_t CT_VEC_ADD_MAG_NBUCKET = 1U;
+  static constexpr std::size_t CT_MAT_ADD_MAG_NBUCKET = 1U;
 };
 
 struct DensityMatrixSimulatorDDPackageConfig : public dd::DDPackageConfig {
@@ -58,5 +63,7 @@ struct DensityMatrixSimulatorDDPackageConfig : public dd::DDPackageConfig {
   static constexpr std::size_t CT_MAT_KRON_NBUCKET = 1U;
   static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 1U;
   static constexpr std::size_t STOCHASTIC_CACHE_OPS = 1U;
+  static constexpr std::size_t CT_VEC_ADD_MAG_NBUCKET = 1U;
+  static constexpr std::size_t CT_MAT_ADD_MAG_NBUCKET = 1U;
 };
 } // namespace dd

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -944,6 +944,8 @@ public:
   void clearComputeTables() {
     vectorAdd.clear();
     matrixAdd.clear();
+    vectorAddMagnitudes.clear();
+    matrixAddMagnitudes.clear();
     conjugateMatrixTranspose.clear();
     matrixMatrixMultiplication.clear();
     matrixVectorMultiplication.clear();
@@ -1252,10 +1254,10 @@ public:
   }
 
   ComputeTable<vCachedEdge, vCachedEdge, vCachedEdge,
-               Config::CT_VEC_ADD_NBUCKET>
+               Config::CT_VEC_ADD_MAG_NBUCKET>
       vectorAddMagnitudes{};
   ComputeTable<mCachedEdge, mCachedEdge, mCachedEdge,
-               Config::CT_MAT_ADD_NBUCKET>
+               Config::CT_MAT_ADD_MAG_NBUCKET>
       matrixAddMagnitudes{};
 
   template <class Node> [[nodiscard]] auto& getAddMagnitudesComputeTable() {


### PR DESCRIPTION
## Description

This PR makes sure that the newly introduced magnitude addition function for decision diagrams is as configurable as the rest of the compute tables. Some package types clearly do not need the new functionality and can keep the respective compute table small.
Furthermore, the PR makes sure that the new compute tables are properly reset.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
