### PR TITLE
✨ add method for computing the conjugate of a vector DD

### DIFF
--- a/include/mqt-core/dd/DDpackageConfig.hpp
+++ b/include/mqt-core/dd/DDpackageConfig.hpp
@@ -14,6 +14,7 @@ struct DDPackageConfig {
   static constexpr std::size_t UT_MAT_INITIAL_ALLOCATION_SIZE = 2048U;
   static constexpr std::size_t CT_VEC_ADD_NBUCKET = 16384U;
   static constexpr std::size_t CT_MAT_ADD_NBUCKET = 16384U;
+  static constexpr std::size_t CT_VEC_CONJ_NBUCKET = 4096U;
   static constexpr std::size_t CT_MAT_CONJ_TRANS_NBUCKET = 4096U;
   static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET = 16384U;
   static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET = 16384U;
@@ -34,6 +35,8 @@ struct DDPackageConfig {
 
 struct StochasticNoiseSimulatorDDPackageConfig : public dd::DDPackageConfig {
   static constexpr std::size_t STOCHASTIC_CACHE_OPS = qc::OpType::OpCount;
+
+  static constexpr std::size_t CT_VEC_CONJ_NBUCKET = 1U;
 };
 
 struct DensityMatrixSimulatorDDPackageConfig : public dd::DDPackageConfig {
@@ -58,5 +61,6 @@ struct DensityMatrixSimulatorDDPackageConfig : public dd::DDPackageConfig {
   static constexpr std::size_t CT_MAT_KRON_NBUCKET = 1U;
   static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 1U;
   static constexpr std::size_t STOCHASTIC_CACHE_OPS = 1U;
+  static constexpr std::size_t CT_VEC_CONJ_NBUCKET = 1U;
 };
 } // namespace dd

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -944,6 +944,7 @@ public:
   void clearComputeTables() {
     vectorAdd.clear();
     matrixAdd.clear();
+    conjugateVector.clear();
     conjugateMatrixTranspose.clear();
     matrixMatrixMultiplication.clear();
     matrixVectorMultiplication.clear();
@@ -1413,6 +1414,39 @@ public:
     auto r = makeDDNode(var, edge);
     computeTable.insert(x, y, r);
     return r;
+  }
+
+  ///
+  /// Vector conjugation
+  ///
+  UnaryComputeTable<vNode*, vCachedEdge, Config::CT_VEC_CONJ_NBUCKET>
+      conjugateVector{};
+
+  vEdge conjugate(const vEdge& a) {
+    auto r = conjugateRec(a);
+    return {r.p, cn.lookup(r.w)};
+  }
+
+  vCachedEdge conjugateRec(const vEdge& a) {
+    if (a.isZeroTerminal()) {
+      return vCachedEdge::zero();
+    }
+
+    if (a.isTerminal()) {
+      return {a.p, ComplexNumbers::conj(a.w)};
+    }
+
+    if (const auto* r = conjugateVector.lookup(a.p); r != nullptr) {
+      return {r->p, r->w * ComplexNumbers::conj(a.w)};
+    }
+
+    std::array<vCachedEdge, 2> e{};
+    e[0] = conjugateRec(a.p->e[0]);
+    e[1] = conjugateRec(a.p->e[1]);
+    auto res = makeDDNode(a.p->v, e);
+    conjugateVector.insert(a.p, res);
+    res.w = res.w * ComplexNumbers::conj(a.w);
+    return res;
   }
 
   ///

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -2432,3 +2432,32 @@ TEST(DDPackageTest, ReduceAncillaRegression) {
 
   EXPECT_EQ(outputMatrix, expected);
 }
+
+TEST(DDPackageTest, VectorConjugate) {
+  auto dd = std::make_unique<dd::Package<>>(2);
+
+  EXPECT_EQ(dd->conjugate(dd::vEdge::zero()), dd::vEdge::zero());
+
+  EXPECT_EQ(dd->conjugate(dd::vEdge::one()), dd::vEdge::one());
+  EXPECT_EQ(dd->conjugate(dd::vEdge::terminal(dd->cn.lookup(0., 1.))),
+            dd::vEdge::terminal(dd->cn.lookup(0., -1.)));
+
+  dd::CVec vec{{0., 0.5},
+               {0.5 * dd::SQRT2_2, 0.5 * dd::SQRT2_2},
+               {0., -0.5},
+               {-0.5 * dd::SQRT2_2, -0.5 * dd::SQRT2_2}};
+
+  auto vecDD = dd->makeStateFromVector(vec);
+  std::cout << "Vector:\n";
+  vecDD.printVector();
+  auto conjVecDD = dd->conjugate(vecDD);
+  std::cout << "Conjugated vector:\n";
+  conjVecDD.printVector();
+
+  auto conjVec = conjVecDD.getVector();
+  const dd::fp tolerance = 1e-10;
+  for (auto i = 0U; i < vec.size(); ++i) {
+    EXPECT_NEAR(conjVec[i].real(), vec[i].real(), tolerance);
+    EXPECT_NEAR(conjVec[i].imag(), -vec[i].imag(), tolerance);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a convenience method for efficiently computing the complex conjugate of a vector decision diagram, i.e., a new decision diagram, where every amplitude is complex conjugated. This amounts to traversing the decision diagram and conjugating each edge weight. As such, it directly scales with the number of nodes in the decision diagram.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
