### PR TITLE
🐛 fix check for density matrices in compute tables

### DIFF
--- a/include/mqt-core/dd/ComputeTable.hpp
+++ b/include/mqt-core/dd/ComputeTable.hpp
@@ -90,7 +90,8 @@ public:
       return result;
     }
 
-    if constexpr (std::is_same_v<RightOperandType, dEdge>) {
+    if constexpr (std::is_same_v<RightOperandType, dNode*> ||
+                  std::is_same_v<RightOperandType, dCachedEdge>) {
       // Since density matrices are reduced representations of matrices, a
       // density matrix may not be returned when a matrix is required and vice
       // versa


### PR DESCRIPTION
## Description

This PR fixes an easy to overlook bug in the compute table implementation. The check in the old implementation was never evaluating to true due to the types being used in the various compute tables.
This allowed matrix and density matrix nodes to me mixed because the subsequent condition was never checked.
This PR adjusts the condition so that the checks are evaluated for both, addition and multiplication of density matrices.

Note that this has quite some interesting consequences, where a density matrix can have two successors that have exactly the same structure, but are represented by different DDs due to one (0-successor) representing a density matrix and one (1-successor) representing a matrix. Although both successors have to represent diagonal matrices for this to occur.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
