### PR TITLE
🚨 fix a couple of compiler warnings

### DIFF
--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1803,6 +1803,7 @@ TEST_F(QFRFunctionality, CircuitToOperation) {
   EXPECT_EQ(qc.asOperation(), nullptr);
   qc.x(0);
   const auto& op = qc.asOperation();
+  ASSERT_NE(op, nullptr);
   EXPECT_EQ(op->getType(), qc::X);
   EXPECT_EQ(op->getNcontrols(), 0U);
   EXPECT_EQ(op->getTargets().front(), 0U);
@@ -1811,6 +1812,7 @@ TEST_F(QFRFunctionality, CircuitToOperation) {
   qc.h(0);
   qc.classicControlled(qc::X, 0, 1, {0, 1U}, 1U);
   const auto& op2 = qc.asOperation();
+  ASSERT_NE(op2, nullptr);
   EXPECT_EQ(op2->getType(), qc::Compound);
   EXPECT_TRUE(qc.empty());
 }


### PR DESCRIPTION
## Description

This small PR fixes a handful of compiler warnings that popped up during updating mqt-qmap.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
