### PR TITLE
✨ Collect blocks optimization

### DIFF
--- a/include/mqt-core/CircuitOptimizer.hpp
+++ b/include/mqt-core/CircuitOptimizer.hpp
@@ -74,6 +74,19 @@ public:
    */
   static void backpropagateOutputPermutation(QuantumComputation& qc);
 
+  /**
+   * @brief Collects all operations in the circuit into blocks of a maximum
+   * size.
+   * @details The circuit is traversed and operations are collected into blocks
+   * of a maximum size. The blocks are then appended to the circuit in the order
+   * they were collected. Each block is realized as a compound operation.
+   * Light optimizations are applied to the blocks, such as removing identity
+   * gates and fusing single-qubit gates.
+   * @param qc the quantum circuit
+   * @param maxBlockSize the maximum size of a block
+   */
+  static void collectBlocks(QuantumComputation& qc, std::size_t maxBlockSize);
+
 protected:
   static void removeDiagonalGatesBeforeMeasureRecursive(
       DAG& dag, DAGReverseIterators& dagIterators, Qubit idx,

--- a/test/unittests/circuit_optimizer/test_collect_blocks.cpp
+++ b/test/unittests/circuit_optimizer/test_collect_blocks.cpp
@@ -1,0 +1,168 @@
+#include "CircuitOptimizer.hpp"
+#include "QuantumComputation.hpp"
+
+#include "gtest/gtest.h"
+#include <iostream>
+
+namespace qc {
+TEST(CollectBlocks, emptyCircuit) {
+  QuantumComputation qc(1);
+  qc::CircuitOptimizer::collectBlocks(qc, 1);
+  EXPECT_EQ(qc.getNindividualOps(), 0);
+}
+
+TEST(CollectBlocks, singleGate) {
+  QuantumComputation qc(1);
+  qc.h(0);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::collectBlocks(qc, 1);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isStandardOperation());
+}
+
+TEST(CollectBlocks, collectMultipleSingleQubitGates) {
+  QuantumComputation qc(2);
+  qc.h(0);
+  qc.h(1);
+  qc.x(0);
+  qc.x(1);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::collectBlocks(qc, 1);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.size(), 2);
+  EXPECT_TRUE(qc.front()->isCompoundOperation());
+  EXPECT_TRUE(qc.back()->isCompoundOperation());
+}
+
+TEST(CollectBlocks, mergeBlocks) {
+  QuantumComputation qc(2);
+  qc.h(0);
+  qc.h(1);
+  qc.cx(0, 1);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::collectBlocks(qc, 2);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isCompoundOperation());
+  EXPECT_EQ(dynamic_cast<qc::CompoundOperation*>(qc.front().get())->size(), 3);
+}
+
+TEST(CollectBlocks, mergeBlocks2) {
+  QuantumComputation qc(2);
+  qc.h(1);
+  qc.x(1);
+  qc.h(1);
+  qc.z(0);
+  qc.cx(0, 1);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::collectBlocks(qc, 2);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isCompoundOperation());
+  EXPECT_EQ(dynamic_cast<qc::CompoundOperation*>(qc.front().get())->size(), 5);
+}
+
+TEST(CollectBlocks, addToMultiQubitBlock) {
+  QuantumComputation qc(2);
+  qc.cx(0, 1);
+  qc.cz(0, 1);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::collectBlocks(qc, 2);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isCompoundOperation());
+  EXPECT_EQ(dynamic_cast<qc::CompoundOperation*>(qc.front().get())->size(), 2);
+}
+
+TEST(CollectBlocks, gateTooBig) {
+  QuantumComputation qc(3);
+  qc.h(0);
+  qc.h(1);
+  qc.mcx({0, 1}, 2);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::collectBlocks(qc, 2);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.size(), 2);
+  EXPECT_TRUE(qc.front()->isCompoundOperation());
+  EXPECT_TRUE(qc.back()->isStandardOperation());
+}
+
+TEST(CollectBlocks, gateTooBig2) {
+  QuantumComputation qc(3);
+  qc.h(0);
+  qc.h(1);
+  qc.mcx({0, 1}, 2);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::collectBlocks(qc, 1);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.size(), 3);
+  EXPECT_TRUE(qc.front()->isStandardOperation());
+  EXPECT_TRUE(qc.back()->isStandardOperation());
+}
+
+TEST(CollectBlocks, gateTooBig3) {
+  QuantumComputation qc(5);
+  qc.cx(0, 1);
+  qc.cx(2, 3);
+  qc.h(4);
+  qc.mcx({0, 1, 2, 3}, 4);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::collectBlocks(qc, 3);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.size(), 3);
+  EXPECT_TRUE(qc.back()->isStandardOperation());
+}
+
+TEST(CollectBlocks, endingBlocks) {
+  QuantumComputation qc(3);
+  qc.h(0);
+  qc.cx(1, 2);
+  qc.cx(0, 1);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::collectBlocks(qc, 2);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.size(), 2);
+  EXPECT_TRUE(qc.front()->isStandardOperation());
+  EXPECT_TRUE(qc.back()->isCompoundOperation());
+}
+
+TEST(CollectBlocks, endingBlocks2) {
+  QuantumComputation qc(4);
+  qc.cx(0, 1);
+  qc.cx(1, 2);
+  qc.mcx({0, 1}, 3);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::collectBlocks(qc, 3);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.size(), 2);
+  EXPECT_TRUE(qc.front()->isCompoundOperation());
+  EXPECT_TRUE(qc.back()->isStandardOperation());
+}
+
+TEST(CollectBlocks, interruptBlock) {
+  QuantumComputation qc(1);
+  qc.h(0);
+  qc.reset(0);
+  qc.h(0);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::collectBlocks(qc, 2);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.size(), 3);
+  EXPECT_TRUE(qc.front()->isStandardOperation());
+  EXPECT_TRUE(qc.back()->isStandardOperation());
+}
+
+TEST(CollectBlocks, unprocessableAtBegin) {
+  QuantumComputation qc(1);
+  qc.reset(0);
+  qc.h(0);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::collectBlocks(qc, 1);
+  std::cout << qc << "\n";
+  EXPECT_EQ(qc.size(), 2);
+  EXPECT_TRUE(qc.front()->isNonUnitaryOperation());
+  EXPECT_TRUE(qc.back()->isStandardOperation());
+}
+
+} // namespace qc

--- a/test/unittests/circuit_optimizer/test_reorder_operations.cpp
+++ b/test/unittests/circuit_optimizer/test_reorder_operations.cpp
@@ -1,0 +1,40 @@
+#include "CircuitOptimizer.hpp"
+#include "QuantumComputation.hpp"
+
+#include "gtest/gtest.h"
+#include <iostream>
+
+namespace qc {
+TEST(ReorderOperations, trivialOperationReordering) {
+  QuantumComputation qc(2);
+  qc.h(0);
+  qc.h(1);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::reorderOperations(qc);
+  std::cout << qc << "\n";
+  auto it = qc.begin();
+  const auto target = (*it)->getTargets().at(0);
+  EXPECT_EQ(target, 1);
+  ++it;
+  const auto target2 = (*it)->getTargets().at(0);
+  EXPECT_EQ(target2, 0);
+}
+
+TEST(ReorderOperations, OperationReorderingBarrier) {
+  QuantumComputation qc(2);
+  qc.h(0);
+  qc.barrier({0, 1});
+  qc.h(1);
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::reorderOperations(qc);
+  std::cout << qc << "\n";
+  auto it = qc.begin();
+  const auto target = (*it)->getTargets().at(0);
+  EXPECT_EQ(target, 0);
+  ++it;
+  ++it;
+  const auto target2 = (*it)->getTargets().at(0);
+  EXPECT_EQ(target2, 1);
+}
+
+} // namespace qc

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1450,38 +1450,6 @@ TEST_F(QFRFunctionality, deferMeasurementsErrorOnImplicitReset) {
   EXPECT_THROW(CircuitOptimizer::deferMeasurements(qc), qc::QFRException);
 }
 
-TEST_F(QFRFunctionality, trivialOperationReordering) {
-  QuantumComputation qc(2);
-  qc.h(0);
-  qc.h(1);
-  std::cout << qc << "\n";
-  qc::CircuitOptimizer::reorderOperations(qc);
-  std::cout << qc << "\n";
-  auto it = qc.begin();
-  const auto target = (*it)->getTargets().at(0);
-  EXPECT_EQ(target, 1);
-  ++it;
-  const auto target2 = (*it)->getTargets().at(0);
-  EXPECT_EQ(target2, 0);
-}
-
-TEST_F(QFRFunctionality, OperationReorderingBarrier) {
-  QuantumComputation qc(2);
-  qc.h(0);
-  qc.barrier({0, 1});
-  qc.h(1);
-  std::cout << qc << "\n";
-  qc::CircuitOptimizer::reorderOperations(qc);
-  std::cout << qc << "\n";
-  auto it = qc.begin();
-  const auto target = (*it)->getTargets().at(0);
-  EXPECT_EQ(target, 0);
-  ++it;
-  ++it;
-  const auto target2 = (*it)->getTargets().at(0);
-  EXPECT_EQ(target2, 1);
-}
-
 TEST_F(QFRFunctionality, FlattenRandomClifford) {
   qc::RandomCliffordCircuit rcs(2U, 3U, 0U);
   std::cout << rcs << "\n";


### PR DESCRIPTION
## Description

This PR adds a new optimization pass to the `CircuitOptimizer` which allows to collect blocks of gates acting on a certain number of qubits.
This is heavily inspired by Qiskit's [`CollectMultiQubitBlocks`](https://docs.quantum.ibm.com/api/qiskit/qiskit.transpiler.passes.CollectMultiQBlocks).
Operations are greedily grouped together, and blocks of gates are replaced by compound operations.

This optimization could be useful for QMAP to decrease the number of two-qubit gates in a circuit.
It could also be useful for QCEC since it allows to combine multiple small operations at once before applying them to the decision diagram.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
