### PR TITLE
:sparkles: :recycle: Adopt UV in CI and refactor reusable workflows

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -29,7 +29,7 @@ flag_management:
     - name: python
       paths:
         - "src/mqt/**/*.py"
-      after_n_builds: 3
+      after_n_builds: 12
       statuses:
         - type: project
           threshold: 0.5%

--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -97,7 +97,7 @@ jobs:
             .github/codecov.yml
             .github/workflows/reusable-python-linter.yml
             .github/workflows/reusable-python-tests.yml
-            .github/workflows/reusable-python-coverage.yml
+            .github/workflows/reusable-python-minimums.yml
             .github/workflows/reusable-python-ci.yml
             .github/workflows/ci.yml
       - name: Set a flag for running the Python tests

--- a/.github/workflows/reusable-code-ql-python.yml
+++ b/.github/workflows/reusable-code-ql-python.yml
@@ -1,15 +1,6 @@
 name: 📝 • CodeQL • Python
 on:
   workflow_call:
-    inputs:
-      setup-z3:
-        description: "Whether to set up Z3"
-        default: false
-        type: boolean
-      z3-version:
-        description: "The version of Z3 to set up"
-        default: "4.11.2"
-        type: string
 
 jobs:
   analyze:
@@ -17,28 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-    env:
-      CMAKE_BUILD_PARALLEL_LEVEL: 3
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
-      - if: ${{ inputs.setup-z3 }}
-        name: Setup Z3
-        uses: cda-tum/setup-z3@v1
-        with:
-          version: ${{ inputs.z3-version }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-      - name: Setup ccache
-        uses: Chocobo1/setup-ccache-action@v1
-        with:
-          prepend_symlinks_to_path: false
-          override_cache_key: codeql-python
-      - name: Set up mold as linker
-        uses: rui314/setup-mold@v1
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
@@ -48,18 +23,3 @@ jobs:
             - uses: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
-        with:
-          upload: False
-          output: sarif-results
-      - name: filter-sarif
-        uses: advanced-security/filter-sarif@main
-        with:
-          patterns: |
-            -**/extern/**
-            -**/build/**
-          input: sarif-results/python.sarif
-          output: sarif-results/python.sarif
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: sarif-results/python.sarif

--- a/.github/workflows/reusable-code-ql.yml
+++ b/.github/workflows/reusable-code-ql.yml
@@ -38,6 +38,3 @@ jobs:
     if: ${{ inputs.enable-python }}
     name: 🐍
     uses: ./.github/workflows/reusable-code-ql-python.yml
-    with:
-      setup-z3: ${{ inputs.setup-z3 }}
-      z3-version: ${{ inputs.z3-version }}

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -24,105 +24,9 @@ jobs:
       setup-z3: ${{ inputs.setup-z3 }}
       z3-version: ${{ inputs.z3-version }}
 
-  python-tests-ubuntu:
-    name: 🐧 ${{ matrix.python-version }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-    uses: ./.github/workflows/reusable-python-tests.yml
-    with:
-      runs-on: ubuntu-latest
-      python-version: ${{ matrix.python-version }}
-      setup-z3: ${{ inputs.setup-z3 }}
-      z3-version: ${{ inputs.z3-version }}
-
-  python-tests-macos:
-    name: 🍎 ${{ matrix.python-version }} ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.12"]
-        runs-on: [macos-13] # test Intel architecture
-        include:
-          - python-version: "3.12" # testing Apple Silicon on 3.8 is blocked by https://github.com/actions/setup-python/issues/808
-            runs-on: macos-14 # test Apple Silicon architecture
-    uses: ./.github/workflows/reusable-python-tests.yml
-    with:
-      runs-on: ${{ matrix.runs-on }}
-      python-version: ${{ matrix.python-version }}
-      setup-z3: ${{ inputs.setup-z3 }}
-      z3-version: ${{ inputs.z3-version }}
-
-  python-tests-windows:
-    name: 🏁 ${{ matrix.python-version }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.12"]
-    uses: ./.github/workflows/reusable-python-tests.yml
-    with:
-      runs-on: windows-latest
-      python-version: ${{ matrix.python-version }}
-      setup-z3: ${{ inputs.setup-z3 }}
-      z3-version: ${{ inputs.z3-version }}
-
-  coverage:
-    name: 📈 ${{ matrix.python-version }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.12"]
-    uses: ./.github/workflows/reusable-python-coverage.yml
-    with:
-      python-version: ${{ matrix.python-version }}
-      setup-z3: ${{ inputs.setup-z3 }}
-      z3-version: ${{ inputs.z3-version }}
-    secrets:
-      token: ${{ secrets.token }}
-
-  minimums:
-    name: 🐍 Minimal Versions
-    runs-on: ubuntu-latest
-    env:
-      FORCE_COLOR: 3
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-      - if: ${{ inputs.setup-z3 }}
-        name: Setup Z3
-        uses: cda-tum/setup-z3@v1
-        with:
-          version: ${{ inputs.z3-version }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-      - name: Setup ccache
-        uses: Chocobo1/setup-ccache-action@v1
-        with:
-          prepend_symlinks_to_path: false
-          override_cache_key: python-minimums
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.8
-          cache: "pip"
-      - name: Set up mold as linker (Linux only)
-        uses: rui314/setup-mold@v1
-      - name: Tests with minimal versions
-        run: pipx run nox -s minimums -- --cov --cov-report=xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: true
-          flags: python
-          token: ${{ secrets.token }}
-
   dist:
     name: 📦 Check
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -138,3 +42,82 @@ jobs:
       - name: Set up mold as linker (Linux only)
         uses: rui314/setup-mold@v1
       - uses: hynek/build-and-inspect-python-package@v2
+        id: baipp
+    outputs:
+      python-versions: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
+
+  python-tests-ubuntu:
+    name: 🐧 ${{ matrix.python-version }}
+    needs: dist
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJson(needs.build-package.outputs.python-versions) }}
+    uses: ./.github/workflows/reusable-python-tests.yml
+    with:
+      runs-on: ubuntu-latest
+      python-version: ${{ matrix.python-version }}
+      setup-z3: ${{ inputs.setup-z3 }}
+      z3-version: ${{ inputs.z3-version }}
+    secrets:
+      token: ${{ secrets.token }}
+
+  python-tests-macos:
+    name: 🍎 ${{ matrix.python-version }} ${{ matrix.runs-on }}
+    needs: dist
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - ${{ fromJson(needs.build-package.outputs.python-versions)[0] }}
+          - ${{ fromJson(needs.build-package.outputs.python-versions)[-1] }}
+        runs-on: [macos-13] # test Intel architecture
+        include:
+          - runs-on: macos-14 # test Apple Silicon architecture
+            python-version:
+              # testing Apple Silicon on 3.8 is blocked by https://github.com/actions/setup-python/issues/808
+              - ${{ fromJson(needs.build-package.outputs.python-versions)[-1] }}
+    uses: ./.github/workflows/reusable-python-tests.yml
+    with:
+      runs-on: ${{ matrix.runs-on }}
+      python-version: ${{ matrix.python-version }}
+      setup-z3: ${{ inputs.setup-z3 }}
+      z3-version: ${{ inputs.z3-version }}
+    secrets:
+      token: ${{ secrets.token }}
+
+  python-tests-windows:
+    name: 🏁 ${{ matrix.python-version }}
+    needs: dist
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - ${{ fromJson(needs.build-package.outputs.python-versions)[0] }}
+          - ${{ fromJson(needs.build-package.outputs.python-versions)[-1] }}
+    uses: ./.github/workflows/reusable-python-tests.yml
+    with:
+      runs-on: windows-latest
+      python-version: ${{ matrix.python-version }}
+      setup-z3: ${{ inputs.setup-z3 }}
+      z3-version: ${{ inputs.z3-version }}
+    secrets:
+      token: ${{ secrets.token }}
+
+  minimums:
+    name: 🔧 ${{ matrix.python-version }}
+    needs: dist
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - ${{ fromJson(needs.build-package.outputs.python-versions)[0] }}
+          - ${{ fromJson(needs.build-package.outputs.python-versions)[-1] }}
+    uses: ./.github/workflows/reusable-python-minimums.yml
+    with:
+      runs-on: ubuntu-latest
+      python-version: ${{ matrix.python-version }}
+      setup-z3: ${{ inputs.setup-z3 }}
+      z3-version: ${{ inputs.z3-version }}
+    secrets:
+      token: ${{ secrets.token }}

--- a/.github/workflows/reusable-python-linter.yml
+++ b/.github/workflows/reusable-python-linter.yml
@@ -33,15 +33,14 @@ jobs:
         with:
           prepend_symlinks_to_path: false
           override_cache_key: lint
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: "pip"
       - name: Set up mold as linker (Linux only)
         uses: rui314/setup-mold@v1
-      - uses: pre-commit/action@v3.0.1
+      - uses: yezz123/setup-uv@v4
+      - uses: wntrblm/nox@2024.03.02
         with:
-          extra_args: mypy --all-files
+          python-versions: "3.12"
+      - name: Run mypy
+        run: nox -s lint -- mypy
       - name: Run check-sdist
         run: |
           pipx run check-sdist --inject-junk

--- a/.github/workflows/reusable-python-minimums.yml
+++ b/.github/workflows/reusable-python-minimums.yml
@@ -1,4 +1,4 @@
-name: 🐍 • Lint
+name: 🐍 • Minimums
 on:
   workflow_call:
     secrets:
@@ -6,8 +6,12 @@ on:
         description: "The token to use for Codecov"
         required: true
     inputs:
+      runs-on:
+        description: "The platform to run the tests on (ubuntu-latest, macos-latest, windows-latest)"
+        required: true
+        type: string
       python-version:
-        description: "The Python version to use (3.8-3.11)"
+        description: "The Python version to use"
         required: true
         type: string
       setup-z3:
@@ -20,9 +24,9 @@ on:
         type: string
 
 jobs:
-  coverage:
-    name: 📈 Coverage ${{ inputs.python-version }}
-    runs-on: ubuntu-latest
+  python-minimus:
+    name: 🔧 ${{ inputs.runs-on }} ${{ inputs.python-version }}
+    runs-on: ${{ inputs.runs-on }}
     env:
       FORCE_COLOR: 3
     steps:
@@ -30,6 +34,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+      - uses: ilammy/msvc-dev-cmd@v1
       - if: ${{ inputs.setup-z3 }}
         name: Setup Z3
         uses: cda-tum/setup-z3@v1
@@ -41,16 +46,16 @@ jobs:
         uses: Chocobo1/setup-ccache-action@v1
         with:
           prepend_symlinks_to_path: false
-          override_cache_key: python-coverage-${{ inputs.python-version }}
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ inputs.python-version }}
-          cache: "pip"
+          windows_compile_environment: msvc
+          override_cache_key: python-minimus-${{ inputs.runs-on }}-${{ inputs.python-version }}
       - name: Set up mold as linker (Linux only)
         uses: rui314/setup-mold@v1
-      - name: Run session
-        run: pipx run nox -s tests-${{ inputs.python-version }} -- --cov --cov-report=xml
+      - uses: yezz123/setup-uv@v4
+      - uses: wntrblm/nox@2024.03.02
+        with:
+          python-versions: ${{ matrix.python-version }}
+      - name: Tests with minimal versions
+        run: nox -s minimums --verbose -- --cov --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -1,13 +1,17 @@
 name: 🐍 • Tests
 on:
   workflow_call:
+    secrets:
+      token:
+        description: "The token to use for Codecov"
+        required: true
     inputs:
       runs-on:
         description: "The platform to run the tests on (ubuntu-latest, macos-latest, windows-latest)"
         required: true
         type: string
       python-version:
-        description: "The Python version to use (3.8-3.11)"
+        description: "The Python version to use"
         required: true
         type: string
       setup-z3:
@@ -44,18 +48,17 @@ jobs:
           prepend_symlinks_to_path: false
           windows_compile_environment: msvc
           override_cache_key: python-tests-${{ inputs.runs-on }}-${{ inputs.python-version }}
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ inputs.python-version }}
-          cache: "pip"
       - name: Set up mold as linker (Linux only)
         uses: rui314/setup-mold@v1
-      - name: Install nox (non-macos-14)
-        if: ${{ inputs.runs-on != 'macos-14' }}
-        run: pipx install nox
-      - name: Install nox (macos-14)
-        if: ${{ inputs.runs-on == 'macos-14' }}
-        run: brew install nox
+      - uses: yezz123/setup-uv@v4
+      - uses: wntrblm/nox@2024.03.02
+        with:
+          python-versions: ${{ matrix.python-version }}
       - name: Test on 🐍 ${{ inputs.python-version }}
-        run: nox -s tests-${{ inputs.python-version }} --verbose
+        run: nox -s tests-${{ inputs.python-version }} --verbose -- --cov --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          flags: python
+          token: ${{ secrets.token }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,9 @@ import nox
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+nox.needs_version = ">=2024.3.2"
+nox.options.default_venv_backend = "uv|virtualenv"
+
 nox.options.sessions = ["lint", "tests"]
 
 PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shutil
 import sys
 from typing import TYPE_CHECKING
 
@@ -46,13 +47,18 @@ def _run_tests(
     if os.environ.get("CI", None) and sys.platform == "win32":
         env["CMAKE_GENERATOR"] = "Ninja"
 
+    if shutil.which("cmake") is None and shutil.which("cmake3") is None:
+        session.install("cmake")
+    if shutil.which("ninja") is None:
+        session.install("ninja")
+
     _extras = ["test", *extras]
     if "--cov" in posargs:
         _extras.append("coverage")
         posargs.append("--cov-config=pyproject.toml")
 
     session.install(*BUILD_REQUIREMENTS, *install_args, env=env)
-    install_arg = f".[{','.join(_extras)}]"
+    install_arg = f"-ve.[{','.join(_extras)}]"
     session.install("--no-build-isolation", install_arg, *install_args, env=env)
     session.run("pytest", *run_args, *posargs, env=env)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -76,16 +76,13 @@ def minimums(session: nox.Session) -> None:
 
 @nox.session(reuse_venv=True)
 def docs(session: nox.Session) -> None:
-    """Build the docs. Pass "--serve" to serve. Pass "-b linkcheck" to check links."""
+    """Build the docs. Use "--non-interactive" to avoid serving. Pass "-b linkcheck" to check links."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("--serve", action="store_true", help="Serve after building")
     parser.add_argument("-b", dest="builder", default="html", help="Build target (default: html)")
     args, posargs = parser.parse_known_args(session.posargs)
 
-    if args.builder != "html" and args.serve:
-        session.error("Must not specify non-HTML builder with --serve")
-
-    extra_installs = ["sphinx-autobuild"] if args.serve else []
+    serve = args.builder == "html" and session.interactive
+    extra_installs = ["sphinx-autobuild"] if serve else []
     session.install(*BUILD_REQUIREMENTS, *extra_installs)
     session.install("--no-build-isolation", "-ve.[docs]")
     session.chdir("docs")
@@ -103,7 +100,7 @@ def docs(session: nox.Session) -> None:
         *posargs,
     )
 
-    if args.serve:
+    if serve:
         session.run("sphinx-autobuild", *shared_args)
     else:
         session.run("sphinx-build", "--keep-going", *shared_args)

--- a/noxfile.py
+++ b/noxfile.py
@@ -72,15 +72,16 @@ def tests(session: nox.Session) -> None:
     _run_tests(session)
 
 
-@nox.session()
+@nox.session(venv_backend="uv")
 def minimums(session: nox.Session) -> None:
     """Test the minimum versions of dependencies."""
     _run_tests(
         session,
-        install_args=["--constraint=test/python/constraints.txt"],
+        install_args=["--resolution=lowest-direct"],
         run_args=["-Wdefault"],
+        extras=["qiskit", "evaluation"],
     )
-    session.run("pip", "list")
+    session.run("uv", "pip", "list")
 
 
 @nox.session(reuse_venv=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 test = ["pytest>=7.0", "pytest-console-scripts>=1.4", "mqt.core[qiskit, evaluation]"]
-coverage = ["mqt.core[test]", "pytest-cov"]
+coverage = ["mqt.core[test]", "pytest-cov>=4"]
 evaluation = [
     "pandas[output_formatting]>=2.0; python_version < '3.9'",
     "pandas[output-formatting]>=2.1.2; python_version >= '3.9'",

--- a/test/python/constraints.txt
+++ b/test/python/constraints.txt
@@ -1,8 +1,0 @@
-pandas==2.0; python_version < "3.9"
-pandas==2.1.2; python_version >= "3.9"
-pybind11==2.12.0
-pytest==7.0.0
-pytest-console-scripts==1.4
-qiskit==1.0.0
-scikit-build-core==0.8.1
-setuptools-scm==7.0.0


### PR DESCRIPTION
## Description

This PR updates the CI configuration to use `uv` by Astral (the creators of `ruff`), which is an extremely fast Python package installer and resolver, written in Rust. It is sesigned as a drop-in replacement for common `pip` and `pip-tools` workflows.
See https://github.com/astral-sh/uv

Similar to `ruff`, it is extremely fast and in very active development. This should speed up any of the Python-based CI runs without much confirguration overhead.

This PR also uses this opportunity to update the reusable workflows to incorporate `uv` and a cleaner `nox` setup. Furthermore, it eliminates the separate `coverage` workflow in favor of just generating coverage data for all python test runs.
It refactors the `minimums` check to make use of `uv`'s `--resolution=lowest-direct" feature. This allows us to completely get rid of the `constraints.txt` file. 
It also runs the minimums session on the oldest and newest supported python version instead of only the oldest. This allows to cover certain special cases that depend on the python version. 
Last, but not least, it makes use of some new features of https://github.com/hynek/build-and-inspect-python-package to dynamically generate the build matrices for Python versions.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
