### PR TITLE
✨ Elide permutations optimization

### DIFF
--- a/include/mqt-core/CircuitOptimizer.hpp
+++ b/include/mqt-core/CircuitOptimizer.hpp
@@ -85,5 +85,15 @@ public:
    * @param maxBlockSize the maximum size of a block
    */
   static void collectBlocks(QuantumComputation& qc, std::size_t maxBlockSize);
+
+  /**
+   * @brief Elide permutations by propagating them through the circuit.
+   * @details The circuit is traversed and any SWAP gate is eliminated by
+   * propagating the permutation through the circuit. The final layout of the
+   * circuit is updated accordingly. This pass works well together with the
+   * `swapReconstruction` pass.
+   * @param qc the quantum circuit
+   */
+  static void elidePermutations(QuantumComputation& qc);
 };
 } // namespace qc

--- a/include/mqt-core/operations/CompoundOperation.hpp
+++ b/include/mqt-core/operations/CompoundOperation.hpp
@@ -63,6 +63,8 @@ public:
 
   void invert() override;
 
+  void apply(const Permutation& permutation) override;
+
   /**
    * @brief Merge another compound operation into this one.
    * @details This transfers ownership of the operations from the other compound

--- a/include/mqt-core/operations/Control.hpp
+++ b/include/mqt-core/operations/Control.hpp
@@ -46,15 +46,15 @@ inline bool operator!=(const Control& lhs, const Control& rhs) {
 struct CompareControl {
   using is_transparent [[maybe_unused]] = void;
 
-  inline bool operator()(const Control& lhs, const Control& rhs) const {
+  bool operator()(const Control& lhs, const Control& rhs) const {
     return lhs < rhs;
   }
 
-  inline bool operator()(Qubit lhs, const Control& rhs) const {
+  bool operator()(Qubit lhs, const Control& rhs) const {
     return lhs < rhs.qubit;
   }
 
-  inline bool operator()(const Control& lhs, Qubit rhs) const {
+  bool operator()(const Control& lhs, Qubit rhs) const {
     return lhs.qubit < rhs;
   }
 };

--- a/include/mqt-core/operations/NonUnitaryOperation.hpp
+++ b/include/mqt-core/operations/NonUnitaryOperation.hpp
@@ -84,6 +84,8 @@ public:
   void invert() override {
     throw QFRException("Inverting a non-unitary operation is not supported.");
   }
+
+  void apply(const Permutation& permutation) override;
 };
 } // namespace qc
 

--- a/include/mqt-core/operations/Operation.hpp
+++ b/include/mqt-core/operations/Operation.hpp
@@ -115,7 +115,9 @@ public:
 
   virtual void setParameter(const std::vector<fp>& p) { parameter = p; }
 
-  [[nodiscard]] inline virtual bool isUnitary() const { return true; }
+  virtual void apply(const Permutation& permutation);
+
+  [[nodiscard]] virtual bool isUnitary() const { return true; }
 
   [[nodiscard]] inline virtual bool isStandardOperation() const {
     return false;

--- a/include/mqt-core/operations/Operation.hpp
+++ b/include/mqt-core/operations/Operation.hpp
@@ -119,31 +119,21 @@ public:
 
   [[nodiscard]] virtual bool isUnitary() const { return true; }
 
-  [[nodiscard]] inline virtual bool isStandardOperation() const {
+  [[nodiscard]] virtual bool isStandardOperation() const { return false; }
+
+  [[nodiscard]] virtual bool isCompoundOperation() const { return false; }
+
+  [[nodiscard]] virtual bool isNonUnitaryOperation() const { return false; }
+
+  [[nodiscard]] virtual bool isClassicControlledOperation() const {
     return false;
   }
 
-  [[nodiscard]] inline virtual bool isCompoundOperation() const {
-    return false;
-  }
+  [[nodiscard]] virtual bool isSymbolicOperation() const { return false; }
 
-  [[nodiscard]] inline virtual bool isNonUnitaryOperation() const {
-    return false;
-  }
+  [[nodiscard]] virtual bool isControlled() const { return !controls.empty(); }
 
-  [[nodiscard]] inline virtual bool isClassicControlledOperation() const {
-    return false;
-  }
-
-  [[nodiscard]] inline virtual bool isSymbolicOperation() const {
-    return false;
-  }
-
-  [[nodiscard]] inline virtual bool isControlled() const {
-    return !controls.empty();
-  }
-
-  [[nodiscard]] inline virtual bool actsOn(const Qubit i) const {
+  [[nodiscard]] virtual bool actsOn(const Qubit i) const {
     for (const auto& t : targets) {
       if (t == i) {
         return true;

--- a/include/mqt-core/operations/Operation.hpp
+++ b/include/mqt-core/operations/Operation.hpp
@@ -17,12 +17,12 @@
 namespace qc {
 class Operation {
 protected:
-  Controls controls{};
-  Targets targets{};
-  std::vector<fp> parameter{};
+  Controls controls;
+  Targets targets;
+  std::vector<fp> parameter;
 
   OpType type = None;
-  std::string name{};
+  std::string name;
 
   static bool isWholeQubitRegister(const RegisterNames& reg, std::size_t start,
                                    std::size_t end) {

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -1758,9 +1758,10 @@ void elidePermutations(std::vector<std::unique_ptr<Operation>>& ops,
       }
       if (compOp->isConvertibleToSingleOperation()) {
         *it = compOp->collapseToSingleOperation();
+      } else {
+        // also update the tracked controls in the compound operation
+        compOp->getControls() = permutation.apply(compOp->getControls());
       }
-      // make sure to also update the tracked controls in the compound operation
-      compOp->getControls() = permutation.apply(compOp->getControls());
       ++it;
       continue;
     }

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -1759,6 +1759,8 @@ void elidePermutations(std::vector<std::unique_ptr<Operation>>& ops,
       if (compOp->isConvertibleToSingleOperation()) {
         *it = compOp->collapseToSingleOperation();
       }
+      // make sure to also update the tracked controls in the compound operation
+      compOp->getControls() = permutation.apply(compOp->getControls());
       ++it;
       continue;
     }

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -1746,4 +1746,62 @@ void CircuitOptimizer::collectBlocks(qc::QuantumComputation& qc,
   removeIdentities(qc);
 }
 
+void elidePermutations(std::vector<std::unique_ptr<Operation>>& ops,
+                       Permutation& permutation) {
+  for (auto it = ops.begin(); it != ops.end();) {
+    auto& op = *it;
+    if (auto* compOp = dynamic_cast<CompoundOperation*>(op.get())) {
+      elidePermutations(compOp->getOps(), permutation);
+      if (compOp->empty()) {
+        it = ops.erase(it);
+        continue;
+      }
+      if (compOp->isConvertibleToSingleOperation()) {
+        *it = compOp->collapseToSingleOperation();
+      }
+      ++it;
+      continue;
+    }
+
+    if (op->getType() == SWAP && !op->isControlled()) {
+      const auto& targets = op->getTargets();
+      assert(targets.size() == 2U);
+      assert(permutation.find(targets[0]) != permutation.end());
+      assert(permutation.find(targets[1]) != permutation.end());
+      auto& target0 = permutation[targets[0]];
+      auto& target1 = permutation[targets[1]];
+      std::swap(target0, target1);
+      it = ops.erase(it);
+      continue;
+    }
+
+    op->apply(permutation);
+    ++it;
+  }
+}
+
+void CircuitOptimizer::elidePermutations(QuantumComputation& qc) {
+  if (qc.empty()) {
+    return;
+  }
+
+  auto permutation = qc.initialLayout;
+  ::qc::elidePermutations(qc.ops, permutation);
+
+  // adjust the initial layout
+  Permutation initialLayout{};
+  for (auto& [physical, logical] : qc.initialLayout) {
+    initialLayout[logical] = logical;
+  }
+  qc.initialLayout = initialLayout;
+
+  // adjust the output permutation
+  Permutation outputPermutation{};
+  for (auto& [physical, logical] : qc.outputPermutation) {
+    assert(permutation.find(physical) != permutation.end());
+    outputPermutation[permutation[physical]] = logical;
+  }
+  qc.outputPermutation = outputPermutation;
+}
+
 } // namespace qc

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -502,7 +502,7 @@ std::ostream& QuantumComputation::print(std::ostream& os) const {
   size_t i = 0U;
   for (const auto& op : ops) {
     os << std::setw(width) << ++i << ":";
-    op->print(os, {}, static_cast<std::size_t>(width) + 1U, nqubits);
+    op->print(os, initialLayout, static_cast<std::size_t>(width) + 1U, nqubits);
     os << "\n";
   }
 

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -502,7 +502,8 @@ std::ostream& QuantumComputation::print(std::ostream& os) const {
   size_t i = 0U;
   for (const auto& op : ops) {
     os << std::setw(width) << ++i << ":";
-    op->print(os, initialLayout, static_cast<std::size_t>(width) + 1U, nqubits);
+    op->print(os, initialLayout, static_cast<std::size_t>(width) + 1U,
+              getNqubits());
     os << "\n";
   }
 

--- a/src/operations/CompoundOperation.cpp
+++ b/src/operations/CompoundOperation.cpp
@@ -160,6 +160,13 @@ void CompoundOperation::invert() {
   std::reverse(ops.begin(), ops.end());
 }
 
+void CompoundOperation::apply(const Permutation& permutation) {
+  Operation::apply(permutation);
+  for (auto& op : ops) {
+    op->apply(permutation);
+  }
+}
+
 void CompoundOperation::merge(CompoundOperation& op) {
   ops.reserve(ops.size() + op.size());
   ops.insert(ops.end(), std::make_move_iterator(op.begin()),

--- a/src/operations/NonUnitaryOperation.cpp
+++ b/src/operations/NonUnitaryOperation.cpp
@@ -192,4 +192,8 @@ void NonUnitaryOperation::addDepthContribution(
     depths[target] += 1;
   }
 }
+
+void NonUnitaryOperation::apply(const Permutation& permutation) {
+  getTargets() = permutation.apply(getTargets());
+}
 } // namespace qc

--- a/src/operations/Operation.cpp
+++ b/src/operations/Operation.cpp
@@ -1,6 +1,7 @@
 #include "operations/Operation.hpp"
 
 #include <algorithm>
+#include <cassert>
 
 namespace qc {
 
@@ -173,6 +174,11 @@ void Operation::addDepthContribution(std::vector<std::size_t>& depths) const {
   for (const auto& control : getControls()) {
     depths[control.qubit] = maxDepth;
   }
+}
+
+void Operation::apply(const Permutation& permutation) {
+  getTargets() = permutation.apply(getTargets());
+  getControls() = permutation.apply(getControls());
 }
 
 } // namespace qc

--- a/src/parsers/QCParser.cpp
+++ b/src/parsers/QCParser.cpp
@@ -136,8 +136,7 @@ int qc::QuantumComputation::readQCHeader(std::istream& is,
             constants.at(constidx - inputs.size()) == "1") {
           // add X operation in case of initial value 1
           if (constants.at(constidx - inputs.size()) == "1") {
-            emplace_back<StandardOperation>(nqubits + nancillae,
-                                            static_cast<Qubit>(constidx), X);
+            x(static_cast<Qubit>(constidx));
           }
           varMap.insert({var, static_cast<Qubit>(constidx++)});
         } else {

--- a/test/unittests/circuit_optimizer/test_elide_permutations.cpp
+++ b/test/unittests/circuit_optimizer/test_elide_permutations.cpp
@@ -119,7 +119,7 @@ TEST(ElidePermutations, compoundOperation3) {
 TEST(ElidePermutations, compoundOperation4) {
   QuantumComputation qc(3);
   QuantumComputation op(2);
-  qc.swap(0, 1);
+  qc.swap(0, 2);
   op.cx(0, 1);
   op.h(0);
   qc.emplace_back(op.asOperation());
@@ -131,8 +131,12 @@ TEST(ElidePermutations, compoundOperation4) {
 
   EXPECT_EQ(qc.size(), 1);
   EXPECT_TRUE(qc.front()->isCompoundOperation());
-  EXPECT_EQ(qc.outputPermutation[0], 1);
-  EXPECT_EQ(qc.outputPermutation[1], 0);
+  EXPECT_TRUE(qc.front()->isControlled());
+  EXPECT_EQ(qc.front()->getControls().size(), 1);
+  EXPECT_EQ(qc.front()->getControls().begin()->qubit, 0);
+  EXPECT_EQ(qc.outputPermutation[0], 2);
+  EXPECT_EQ(qc.outputPermutation[1], 1);
+  EXPECT_EQ(qc.outputPermutation[2], 0);
 }
 
 TEST(ElidePermutations, nonUnitaryOperation) {

--- a/test/unittests/circuit_optimizer/test_elide_permutations.cpp
+++ b/test/unittests/circuit_optimizer/test_elide_permutations.cpp
@@ -49,6 +49,25 @@ TEST(ElidePermutations, simpleInitialLayout) {
   EXPECT_EQ(qc.outputPermutation[0], 0);
 }
 
+TEST(ElidePermutations, applyPermutionCompound) {
+  QuantumComputation qc(2);
+  qc.cx(0, 1);
+  auto op = qc.asCompoundOperation();
+  op->addControl(2);
+  Permutation perm{};
+  perm[0] = 2;
+  perm[1] = 1;
+  perm[2] = 0;
+  op->apply(perm);
+  EXPECT_EQ(op->size(), 1);
+  EXPECT_TRUE(op->isControlled());
+  EXPECT_EQ(op->getControls().size(), 1);
+  EXPECT_EQ(op->getControls().begin()->qubit, 0);
+  EXPECT_EQ(op->getOps().front()->getTargets().front(), 1);
+  EXPECT_EQ(op->getOps().front()->getControls().size(), 2);
+  EXPECT_EQ(op->getOps().front()->getControls(), Controls({0, 2}));
+}
+
 TEST(ElidePermutations, compoundOperation) {
   QuantumComputation qc(2);
   QuantumComputation op(2);

--- a/test/unittests/circuit_optimizer/test_elide_permutations.cpp
+++ b/test/unittests/circuit_optimizer/test_elide_permutations.cpp
@@ -1,0 +1,137 @@
+#include "CircuitOptimizer.hpp"
+#include "QuantumComputation.hpp"
+
+#include "gtest/gtest.h"
+#include <iostream>
+
+namespace qc {
+TEST(ElidePermutations, emptyCircuit) {
+  QuantumComputation qc(1);
+  qc::CircuitOptimizer::elidePermutations(qc);
+  EXPECT_EQ(qc.size(), 0);
+}
+
+TEST(ElidePermutations, simpleSwap) {
+  QuantumComputation qc(2);
+  qc.swap(0, 1);
+  qc.h(1);
+
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::elidePermutations(qc);
+  std::cout << qc << "\n";
+
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isStandardOperation());
+  auto reference = StandardOperation(0, H);
+  EXPECT_EQ(*qc.front(), reference);
+
+  EXPECT_EQ(qc.outputPermutation[0], 1);
+  EXPECT_EQ(qc.outputPermutation[1], 0);
+}
+
+TEST(ElidePermutations, simpleInitialLayout) {
+  QuantumComputation qc(1);
+  qc.initialLayout = {};
+  qc.initialLayout[2] = 0;
+  qc.outputPermutation = {};
+  qc.outputPermutation[2] = 0;
+  qc.h(2);
+
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::elidePermutations(qc);
+  std::cout << qc << "\n";
+
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isStandardOperation());
+  auto reference = StandardOperation(0, H);
+  EXPECT_EQ(*qc.front(), reference);
+  EXPECT_EQ(qc.initialLayout[0], 0);
+  EXPECT_EQ(qc.outputPermutation[0], 0);
+}
+
+TEST(ElidePermutations, compoundOperation) {
+  QuantumComputation qc(2);
+  QuantumComputation op(2);
+  op.cx(0, 1);
+  op.swap(0, 1);
+  op.cx(0, 1);
+  qc.emplace_back(op.asOperation());
+  qc.cx(1, 0);
+
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::elidePermutations(qc);
+  std::cout << qc << "\n";
+
+  EXPECT_EQ(qc.size(), 2);
+  EXPECT_TRUE(qc.front()->isCompoundOperation());
+  auto& compound = dynamic_cast<CompoundOperation&>(*qc.front());
+  EXPECT_EQ(compound.size(), 2);
+  auto reference = StandardOperation(0_pc, 1, X);
+  auto reference2 = StandardOperation(1_pc, 0, X);
+  EXPECT_EQ(*compound.getOps().front(), reference);
+  EXPECT_EQ(*compound.getOps().back(), reference2);
+  EXPECT_EQ(*qc.back(), reference);
+  EXPECT_EQ(qc.outputPermutation[0], 1);
+  EXPECT_EQ(qc.outputPermutation[1], 0);
+}
+
+TEST(ElidePermutations, compoundOperation2) {
+  QuantumComputation qc(2);
+  QuantumComputation op(2);
+  op.swap(0, 1);
+  op.cx(0, 1);
+  qc.emplace_back(op.asOperation());
+  qc.cx(0, 1);
+
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::elidePermutations(qc);
+  std::cout << qc << "\n";
+
+  EXPECT_EQ(qc.size(), 2);
+  EXPECT_TRUE(qc.front()->isStandardOperation());
+  auto reference = StandardOperation(1_pc, 0, X);
+  EXPECT_EQ(*qc.front(), reference);
+  EXPECT_TRUE(qc.back()->isStandardOperation());
+  EXPECT_EQ(*qc.back(), reference);
+  EXPECT_EQ(qc.outputPermutation[0], 1);
+  EXPECT_EQ(qc.outputPermutation[1], 0);
+}
+
+TEST(ElidePermutations, compoundOperation3) {
+  QuantumComputation qc(2);
+  QuantumComputation op(2);
+  op.swap(0, 1);
+  qc.emplace_back(op.asOperation());
+  qc.cx(0, 1);
+
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::elidePermutations(qc);
+  std::cout << qc << "\n";
+
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isStandardOperation());
+  auto reference = StandardOperation(1_pc, 0, X);
+  EXPECT_EQ(*qc.front(), reference);
+  EXPECT_EQ(qc.outputPermutation[0], 1);
+  EXPECT_EQ(qc.outputPermutation[1], 0);
+}
+
+TEST(ElidePermutations, nonUnitaryOperation) {
+  QuantumComputation qc(2, 2);
+  qc.swap(0, 1);
+  qc.measure(1, 0);
+  qc.outputPermutation[0] = 1;
+  qc.outputPermutation[1] = 0;
+
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::elidePermutations(qc);
+  std::cout << qc << "\n";
+
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isNonUnitaryOperation());
+  auto reference = NonUnitaryOperation(0, 0);
+  EXPECT_EQ(*qc.front(), reference);
+  EXPECT_EQ(qc.outputPermutation[0], 0);
+  EXPECT_EQ(qc.outputPermutation[1], 1);
+}
+} // namespace qc

--- a/test/unittests/circuit_optimizer/test_elide_permutations.cpp
+++ b/test/unittests/circuit_optimizer/test_elide_permutations.cpp
@@ -101,7 +101,7 @@ TEST(ElidePermutations, compoundOperation3) {
   QuantumComputation qc(2);
   QuantumComputation op(2);
   op.swap(0, 1);
-  qc.emplace_back(op.asOperation());
+  qc.emplace_back(op.asCompoundOperation());
   qc.cx(0, 1);
 
   std::cout << qc << "\n";
@@ -112,6 +112,25 @@ TEST(ElidePermutations, compoundOperation3) {
   EXPECT_TRUE(qc.front()->isStandardOperation());
   auto reference = StandardOperation(1_pc, 0, X);
   EXPECT_EQ(*qc.front(), reference);
+  EXPECT_EQ(qc.outputPermutation[0], 1);
+  EXPECT_EQ(qc.outputPermutation[1], 0);
+}
+
+TEST(ElidePermutations, compoundOperation4) {
+  QuantumComputation qc(3);
+  QuantumComputation op(2);
+  qc.swap(0, 1);
+  op.cx(0, 1);
+  op.h(0);
+  qc.emplace_back(op.asOperation());
+  qc.back()->addControl(2);
+
+  std::cout << qc << "\n";
+  qc::CircuitOptimizer::elidePermutations(qc);
+  std::cout << qc << "\n";
+
+  EXPECT_EQ(qc.size(), 1);
+  EXPECT_TRUE(qc.front()->isCompoundOperation());
   EXPECT_EQ(qc.outputPermutation[0], 1);
   EXPECT_EQ(qc.outputPermutation[1], 0);
 }


### PR DESCRIPTION
## Description

This PR introduces a new optimization that allows to elide permutations from circuits.
Essentially, it starts with the initial layout, applies it to every gate of the circuit. 
Upon encountering a `SWAP` gate, the tracked permutation is updated and the gate eliminated.
Finally, the output permutation of the circuit is updated.

The PR also includes some fixes for newer clang-tidy warnings as well as a small printing fix for quantum circuits.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
