### PR TITLE
👷🔧🍎 enable Python 3.8+ tests on macos-14 runners

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -29,7 +29,7 @@ flag_management:
     - name: python
       paths:
         - "src/mqt/**/*.py"
-      after_n_builds: 10
+      after_n_builds: 11
       statuses:
         - type: project
           threshold: 0.5%

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -75,10 +75,7 @@ jobs:
         python-version:
           - ${{ fromJson(needs.dist.outputs.python-versions)[0] }}
           - ${{ needs.dist.outputs.max-python-version }}
-        runs-on: [macos-13] # test Intel architecture
-        include:
-          - runs-on: macos-14 # test Apple Silicon architecture
-            python-version: ${{ needs.dist.outputs.max-python-version }} # testing Apple Silicon on 3.8 is blocked by https://github.com/actions/setup-python/issues/808
+        runs-on: [macos-13, macos-14]
     uses: ./.github/workflows/reusable-python-tests.yml
     with:
       runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
## Description

GitHub's `macos-14` runners now also support Python 3.8 and 3.9. This PR adjusts the reusable workflows to remove the special handling that was in place previously. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
