### PR TITLE
🚨 Fix new warnings revealed by clang-tidy 18

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,13 +1,12 @@
 FormatStyle: file
 
 Checks: |
-  clang-diagnostic-*,
-  clang-analyzer-*,
-  -clang-analyzer-core.NullDereference,
   boost-*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
   clang-analyzer-*,
+  -clang-analyzer-core.NullDereference,
+  clang-diagnostic-*,
   cppcoreguidelines-*,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-special-member-functions,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.0.1
     with:
       cmake-args: -DBUILD_MQT_CORE_BENCHMARKS=ON
-      files-changed-only: false
 
   python-tests:
     name: 🐍 Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.0.1
     with:
       cmake-args: -DBUILD_MQT_CORE_BENCHMARKS=ON
+      files-changed-only: false
 
   python-tests:
     name: 🐍 Test

--- a/eval/eval_dd_package.cpp
+++ b/eval/eval_dd_package.cpp
@@ -8,16 +8,24 @@
 #include "algorithms/WState.hpp"
 #include "dd/Benchmark.hpp"
 #include "dd/FunctionalityConstruction.hpp"
+#include "dd/Package.hpp"
 #include "dd/statistics/PackageStatistics.hpp"
-#include "nlohmann/json.hpp"
 
+#include <array>
+#include <bitset>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <exception>
+#include <fstream>
+#include <ios>
+#include <iostream>
+#include <memory>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <utility>
 
 namespace dd {
-
-static const std::string FILENAME_START = "results_";
-static const std::string FILENAME_END = ".json";
 
 static constexpr std::size_t SEED = 42U;
 
@@ -26,9 +34,9 @@ protected:
   void verifyAndSave(const std::string& name, const std::string& type,
                      qc::QuantumComputation& qc, const Experiment& exp) {
 
-    const std::string& filename = FILENAME_START + inputFilename + FILENAME_END;
+    const std::string& filename = "results_" + inputFilename + ".json";
 
-    nlohmann::json j;
+    nlohmann::basic_json<> j;
     std::fstream file(filename, std::ios::in | std::ios::out | std::ios::ate);
     if (!file.is_open()) {
       std::ofstream outputFile(filename);

--- a/include/mqt-core/CircuitOptimizer.hpp
+++ b/include/mqt-core/CircuitOptimizer.hpp
@@ -4,10 +4,8 @@
 #include "QuantumComputation.hpp"
 #include "operations/Operation.hpp"
 
-#include <array>
 #include <cstddef>
 #include <memory>
-#include <unordered_set>
 
 namespace qc {
 

--- a/include/mqt-core/Permutation.hpp
+++ b/include/mqt-core/Permutation.hpp
@@ -10,7 +10,7 @@
 namespace qc {
 class Permutation : public std::map<Qubit, Qubit> {
 public:
-  [[nodiscard]] inline Controls apply(const Controls& controls) const {
+  [[nodiscard]] Controls apply(const Controls& controls) const {
     if (empty()) {
       return controls;
     }
@@ -20,7 +20,7 @@ public:
     }
     return c;
   }
-  [[nodiscard]] inline Targets apply(const Targets& targets) const {
+  [[nodiscard]] Targets apply(const Targets& targets) const {
     if (empty()) {
       return targets;
     }

--- a/include/mqt-core/QuantumComputation.hpp
+++ b/include/mqt-core/QuantumComputation.hpp
@@ -3,22 +3,28 @@
 #include "Definitions.hpp"
 #include "operations/ClassicControlledOperation.hpp"
 #include "operations/CompoundOperation.hpp"
+#include "operations/Control.hpp"
+#include "operations/Expression.hpp"
 #include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
 #include "operations/StandardOperation.hpp"
 #include "operations/SymbolicOperation.hpp"
 
 #include <algorithm>
-#include <fstream>
-#include <iomanip>
+#include <array>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
-#include <limits>
-#include <locale>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <random>
 #include <sstream>
 #include <string>
+#include <unordered_set>
+#include <utility>
+#include <variant>
 #include <vector>
 
 namespace qc {
@@ -33,7 +39,7 @@ public:
   friend class CircuitOptimizer;
 
 protected:
-  std::vector<std::unique_ptr<Operation>> ops{};
+  std::vector<std::unique_ptr<Operation>> ops;
   std::size_t nqubits = 0;
   std::size_t nclassics = 0;
   std::size_t nancillae = 0;
@@ -41,9 +47,9 @@ protected:
 
   // register names are used as keys, while the values are `{startIndex,
   // length}` pairs
-  QuantumRegisterMap qregs{};
-  ClassicalRegisterMap cregs{};
-  QuantumRegisterMap ancregs{};
+  QuantumRegisterMap qregs;
+  ClassicalRegisterMap cregs;
+  QuantumRegisterMap ancregs;
 
   std::mt19937_64 mt;
   std::size_t seed = 0;
@@ -328,8 +334,8 @@ public:
   Permutation initialLayout{};
   Permutation outputPermutation{};
 
-  std::vector<bool> ancillary{};
-  std::vector<bool> garbage{};
+  std::vector<bool> ancillary;
+  std::vector<bool> garbage;
 
   [[nodiscard]] std::size_t getNindividualOps() const;
   [[nodiscard]] std::size_t getNsingleQubitOps() const;
@@ -553,7 +559,7 @@ public:
                                     OP_NAME_TO_TYPE.at(#op));                  \
   }
 
-  DEFINE_TWO_TARGET_OPERATION(swap)
+  DEFINE_TWO_TARGET_OPERATION(swap) // NOLINT: bugprone-exception-escape
   DEFINE_TWO_TARGET_OPERATION(dcx)
   DEFINE_TWO_TARGET_OPERATION(ecr)
   DEFINE_TWO_TARGET_OPERATION(iswap)
@@ -709,16 +715,13 @@ public:
 
   void import(const std::string& filename);
   void import(const std::string& filename, Format format);
-  void import(std::istream& is, Format format) {
-    import(std::move(is), format);
-  }
-  void import(std::istream&& is, Format format);
+  void import(std::istream& is, Format format);
   void initializeIOMapping();
   // append measurements to the end of the circuit according to the tracked
   // output permutation
   void appendMeasurementsAccordingToOutputPermutation(
       const std::string& registerName = "c");
-  // search for current position of target value in map and afterwards exchange
+  // search for current position of target value in map and afterward exchange
   // it with the value at new position
   static void findAndSWAP(Qubit targetValue, Qubit newPosition,
                           Permutation& map) {
@@ -731,7 +734,7 @@ public:
   }
 
   // this function augments a given circuit by additional registers
-  void addQubitRegister(std::size_t, const std::string& regName = "q");
+  void addQubitRegister(std::size_t nq, const std::string& regName = "q");
   void addClassicalRegister(std::size_t nc, const std::string& regName = "c");
   void addAncillaryRegister(std::size_t nq, const std::string& regName = "anc");
   // a function to combine all quantum registers (qregs and ancregs) into a
@@ -819,15 +822,12 @@ public:
   static std::ostream& printPermutation(const Permutation& permutation,
                                         std::ostream& os = std::cout);
 
-  virtual void dump(const std::string& filename, Format format);
-  virtual void dump(const std::string& filename);
-  virtual void dump(std::ostream& of, Format format) {
-    dump(std::move(of), format);
-  }
-  virtual void dump(std::ostream&& of, Format format);
+  void dump(const std::string& filename, Format format);
+  void dump(const std::string& filename);
+  void dump(std::ostream& of, Format format);
   void dumpOpenQASM2(std::ostream& of) { dumpOpenQASM(of, false); }
   void dumpOpenQASM3(std::ostream& of) { dumpOpenQASM(of, true); }
-  virtual void dumpOpenQASM(std::ostream& of, bool openQasm3);
+  void dumpOpenQASM(std::ostream& of, bool openQasm3);
 
   /**
    * @brief Returns the OpenQASM representation of the circuit
@@ -902,7 +902,7 @@ public:
   // Modifiers (pass-through)
   void clear() noexcept { ops.clear(); }
   // NOLINTNEXTLINE(readability-identifier-naming)
-  void pop_back() { return ops.pop_back(); }
+  void pop_back() { ops.pop_back(); }
   void resize(std::size_t count) { ops.resize(count); }
   iterator erase(const_iterator pos) { return ops.erase(pos); }
   iterator erase(const_iterator first, const_iterator last) {
@@ -920,7 +920,7 @@ public:
 
   // NOLINTNEXTLINE(readability-identifier-naming)
   template <class T, class... Args> void emplace_back(Args&&... args) {
-    ops.emplace_back(std::make_unique<T>(args...));
+    ops.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
   }
 
   // NOLINTNEXTLINE(readability-identifier-naming)

--- a/include/mqt-core/algorithms/BernsteinVazirani.hpp
+++ b/include/mqt-core/algorithms/BernsteinVazirani.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
-#include <QuantumComputation.hpp>
-#include <bitset>
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
+
+#include <cstddef>
+#include <ostream>
+#include <string>
 
 namespace qc {
 class BernsteinVazirani : public QuantumComputation {
@@ -9,7 +13,7 @@ public:
   BitString s = 0;
   std::size_t bitwidth = 1;
   bool dynamic = false;
-  std::string expected{};
+  std::string expected;
 
   explicit BernsteinVazirani(const BitString& hiddenString, bool dyn = false);
   explicit BernsteinVazirani(std::size_t nq, bool dyn = false);

--- a/include/mqt-core/algorithms/Entanglement.hpp
+++ b/include/mqt-core/algorithms/Entanglement.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <QuantumComputation.hpp>
+#include "QuantumComputation.hpp"
+
+#include <cstddef>
 
 namespace qc {
 class Entanglement : public QuantumComputation {

--- a/include/mqt-core/algorithms/GoogleRandomCircuitSampling.hpp
+++ b/include/mqt-core/algorithms/GoogleRandomCircuitSampling.hpp
@@ -1,26 +1,39 @@
 #pragma once
 
-#include <QuantumComputation.hpp>
-#include <chrono>
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
+#include "operations/Operation.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace qc {
-enum Layout { Rectangular, Bristlecone };
+enum Layout : std::uint8_t { Rectangular, Bristlecone };
 
 class GoogleRandomCircuitSampling : public QuantumComputation {
 public:
-  std::vector<std::vector<std::unique_ptr<Operation>>> cycles{};
+  std::vector<std::vector<std::unique_ptr<Operation>>> cycles;
   Layout layout = Rectangular;
   std::string pathPrefix =
       "../../../Benchmarks/GoogleRandomCircuitSampling/inst/";
 
   explicit GoogleRandomCircuitSampling(const std::string& filename);
 
-  GoogleRandomCircuitSampling(std::string prefix, std::uint16_t device,
-                              std::uint16_t depth, std::uint16_t instance);
+  [[maybe_unused]] GoogleRandomCircuitSampling(std::string prefix,
+                                               std::uint16_t device,
+                                               std::uint16_t depth,
+                                               std::uint16_t instance);
 
-  GoogleRandomCircuitSampling(std::string prefix, std::uint16_t x,
-                              std::uint16_t y, std::uint16_t depth,
-                              std::uint16_t instance);
+  [[maybe_unused]] GoogleRandomCircuitSampling(std::string prefix,
+                                               std::uint16_t x, std::uint16_t y,
+                                               std::uint16_t depth,
+                                               std::uint16_t instance);
 
   void importGRCS(const std::string& filename);
 

--- a/include/mqt-core/algorithms/Grover.hpp
+++ b/include/mqt-core/algorithms/Grover.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
 
-#include <bitset>
-#include <functional>
-#include <random>
+#include <cstddef>
+#include <ostream>
+#include <string>
 
 namespace qc {
 class Grover : public QuantumComputation {
@@ -12,7 +13,7 @@ public:
   std::size_t seed = 0;
   BitString targetValue = 0;
   std::size_t iterations = 1;
-  std::string expected{};
+  std::string expected;
   std::size_t nDataQubits{};
 
   explicit Grover(std::size_t nq, std::size_t s = 0);

--- a/include/mqt-core/algorithms/QFT.hpp
+++ b/include/mqt-core/algorithms/QFT.hpp
@@ -2,6 +2,9 @@
 
 #include "QuantumComputation.hpp"
 
+#include <cstddef>
+#include <ostream>
+
 namespace qc {
 class QFT : public QuantumComputation {
 public:

--- a/include/mqt-core/algorithms/QPE.hpp
+++ b/include/mqt-core/algorithms/QPE.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
+
+#include <cstddef>
+#include <ostream>
 
 namespace qc {
 class QPE : public QuantumComputation {

--- a/include/mqt-core/algorithms/RandomCliffordCircuit.hpp
+++ b/include/mqt-core/algorithms/RandomCliffordCircuit.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
-#include <QuantumComputation.hpp>
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
+
+#include <cstddef>
+#include <cstdint>
 #include <functional>
-#include <random>
+#include <ostream>
 
 namespace qc {
 class RandomCliffordCircuit : public QuantumComputation {

--- a/include/mqt-core/algorithms/WState.hpp
+++ b/include/mqt-core/algorithms/WState.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <QuantumComputation.hpp>
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
 
 namespace qc {
 class WState : public QuantumComputation {

--- a/include/mqt-core/datastructures/DirectedAcyclicGraph.hpp
+++ b/include/mqt-core/datastructures/DirectedAcyclicGraph.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "Definitions.hpp"
 #include "DirectedGraph.hpp"
 
 #include <algorithm>
 #include <cassert>
-#include <iostream>
+#include <cstddef>
 #include <sstream>
 #include <stack>
 #include <stdexcept>
+#include <vector>
 
 namespace qc {
 

--- a/include/mqt-core/datastructures/DirectedGraph.hpp
+++ b/include/mqt-core/datastructures/DirectedGraph.hpp
@@ -1,10 +1,15 @@
 #pragma once
 
-#include "Definitions.hpp"
-
+#include <cstddef>
 #include <numeric>
+#include <ostream>
 #include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 namespace qc {
 
@@ -14,10 +19,10 @@ namespace qc {
  * @tparam V the type of the vertices in the graph. Must implement `operator<<`.
  */
 template <class V> class DirectedGraph {
-  static_assert(
-      std::is_same<decltype(std::declval<std::ostream&>() << std::declval<V>()),
-                   std::ostream&>::value,
-      "V must support `operator<<`.");
+  static_assert(std::is_same_v<decltype(std::declval<std::ostream&>()
+                                        << std::declval<V>()),
+                               std::ostream&>,
+                "V must support `operator<<`.");
 
 protected:
   // the adjecency matrix works with indices
@@ -36,6 +41,11 @@ protected:
   std::vector<std::size_t> outDegrees;
 
 public:
+  DirectedGraph() = default;
+  DirectedGraph(const DirectedGraph&) = default;
+  DirectedGraph(DirectedGraph&&) = default;
+  DirectedGraph& operator=(const DirectedGraph&) = default;
+  DirectedGraph& operator=(DirectedGraph&&) = default;
   virtual ~DirectedGraph() = default;
   virtual auto addVertex(const V& v) -> void {
     // check whether the vertex is already in the graph, if so do nothing

--- a/include/mqt-core/datastructures/DisjointSet.hpp
+++ b/include/mqt-core/datastructures/DisjointSet.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstddef>
 #include <unordered_map>
 
 namespace qc {

--- a/include/mqt-core/datastructures/Layer.hpp
+++ b/include/mqt-core/datastructures/Layer.hpp
@@ -8,6 +8,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 #include <unordered_set>
@@ -128,6 +129,10 @@ protected:
 
 public:
   Layer() = default;
+  Layer(const Layer&) = default;
+  Layer(Layer&&) = default;
+  Layer& operator=(const Layer&) = default;
+  Layer& operator=(Layer&&) = default;
   ~Layer() = default;
   explicit Layer(const QuantumComputation& qc) { constructDAG(qc); }
   [[nodiscard]] auto getExecutableSet() const -> const ExecutableSet& {

--- a/include/mqt-core/datastructures/UndirectedGraph.hpp
+++ b/include/mqt-core/datastructures/UndirectedGraph.hpp
@@ -2,10 +2,17 @@
 
 #include "Definitions.hpp"
 
+#include <cstddef>
 #include <numeric>
 #include <optional>
+#include <ostream>
 #include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 namespace qc {
 

--- a/include/mqt-core/dd/Benchmark.hpp
+++ b/include/mqt-core/dd/Benchmark.hpp
@@ -1,9 +1,14 @@
 #pragma once
 
 #include "dd/Package.hpp"
-#include "nlohmann/json.hpp"
+#include "dd/Package_fwd.hpp"
 
 #include <chrono>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <string>
 
 namespace qc {
 class QuantumComputation;
@@ -12,10 +17,15 @@ class QuantumComputation;
 namespace dd {
 
 struct Experiment {
-  std::unique_ptr<Package<>> dd{};
-  nlohmann::json stats = nlohmann::json::object();
+  std::unique_ptr<Package<>> dd;
+  nlohmann::basic_json<> stats = nlohmann::basic_json<>::object();
   std::chrono::duration<double> runtime{};
 
+  Experiment() = default;
+  Experiment(const Experiment&) = delete;
+  Experiment(Experiment&&) = default;
+  Experiment& operator=(const Experiment&) = delete;
+  Experiment& operator=(Experiment&&) = default;
   virtual ~Experiment() = default;
 
   [[nodiscard]] virtual bool success() const noexcept { return false; }

--- a/include/mqt-core/dd/CachedEdge.hpp
+++ b/include/mqt-core/dd/CachedEdge.hpp
@@ -15,9 +15,9 @@ namespace dd {
 ///-----------------------------------------------------------------------------
 ///                        \n Forward declarations \n
 ///-----------------------------------------------------------------------------
-struct vNode;
-struct mNode;
-struct dNode;
+struct vNode; // NOLINT(readability-identifier-naming)
+struct mNode; // NOLINT(readability-identifier-naming)
+struct dNode; // NOLINT(readability-identifier-naming)
 class ComplexNumbers;
 template <typename T> class MemoryManager;
 
@@ -42,7 +42,7 @@ using isMatrixVariant =
  */
 template <typename Node> struct CachedEdge {
   Node* p{};
-  ComplexValue w{};
+  ComplexValue w;
 
   CachedEdge() = default;
   CachedEdge(Node* n, const ComplexValue& v) : p(n), w(v) {}

--- a/include/mqt-core/dd/Complex.hpp
+++ b/include/mqt-core/dd/Complex.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Definitions.hpp"
 #include "dd/DDDefinitions.hpp"
 #include "dd/RealNumber.hpp"
 

--- a/include/mqt-core/dd/ComplexNumbers.hpp
+++ b/include/mqt-core/dd/ComplexNumbers.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
+#include "dd/CachedEdge.hpp"
 #include "dd/Complex.hpp"
 #include "dd/DDDefinitions.hpp"
-#include "dd/Node.hpp"
+#include "dd/Edge.hpp"
 #include "dd/RealNumberUniqueTable.hpp"
+
+#include <complex>
+#include <cstddef>
 
 namespace dd {
 

--- a/include/mqt-core/dd/ComplexValue.hpp
+++ b/include/mqt-core/dd/ComplexValue.hpp
@@ -5,6 +5,8 @@
 #include <cmath>
 #include <complex>
 #include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <iostream>
 #include <string>
 #include <utility>

--- a/include/mqt-core/dd/ComputeTable.hpp
+++ b/include/mqt-core/dd/ComputeTable.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "dd/DDDefinitions.hpp"
+#include "Definitions.hpp"
 #include "dd/Node.hpp"
 #include "dd/statistics/TableStatistics.hpp"
 
 #include <array>
 #include <bitset>
 #include <cstddef>
+#include <functional>
 #include <iostream>
-#include <utility>
 
 namespace dd {
 

--- a/include/mqt-core/dd/DDDefinitions.hpp
+++ b/include/mqt-core/dd/DDDefinitions.hpp
@@ -3,7 +3,9 @@
 #include "Definitions.hpp"
 
 #include <array>
+#include <cmath>
 #include <complex>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <type_traits>
@@ -41,7 +43,7 @@ static constexpr std::uint8_t RADIX = 2;
 // max no. of edges = RADIX^2
 static constexpr std::uint8_t NEDGE = RADIX * RADIX;
 
-enum class BasisStates {
+enum class BasisStates : std::uint8_t {
   zero,  // NOLINT(readability-identifier-naming)
   one,   // NOLINT(readability-identifier-naming)
   plus,  // NOLINT(readability-identifier-naming)

--- a/include/mqt-core/dd/DensityNoiseTable.hpp
+++ b/include/mqt-core/dd/DensityNoiseTable.hpp
@@ -6,8 +6,8 @@
 #include <array>
 #include <bitset>
 #include <cstddef>
-#include <iostream>
-#include <utility>
+#include <functional>
+#include <vector>
 
 namespace dd {
 

--- a/include/mqt-core/dd/FunctionalityConstruction.hpp
+++ b/include/mqt-core/dd/FunctionalityConstruction.hpp
@@ -1,8 +1,17 @@
 #pragma once
 
+#include "Permutation.hpp"
 #include "QuantumComputation.hpp"
 #include "algorithms/Grover.hpp"
 #include "dd/Operations.hpp"
+#include "dd/Package_fwd.hpp"
+#include "operations/OpType.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <ostream>
+#include <stack>
+#include <vector>
 
 namespace dd {
 using namespace qc;

--- a/include/mqt-core/dd/MemoryManager.hpp
+++ b/include/mqt-core/dd/MemoryManager.hpp
@@ -5,7 +5,6 @@
 
 #include <cstddef>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 namespace dd {

--- a/include/mqt-core/dd/Node.hpp
+++ b/include/mqt-core/dd/Node.hpp
@@ -96,7 +96,7 @@ struct dNode {                        // NOLINT(readability-identifier-naming)
   isDensityMatrixTempFlagSet(const std::uintptr_t p) noexcept {
     return (p & (1ULL << 2)) != 0U;
   }
-  [[nodiscard]] static inline bool
+  [[nodiscard]] static bool
   isDensityMatrixNode(const std::uintptr_t p) noexcept {
     return (p & (1ULL << 3)) != 0U;
   }
@@ -131,7 +131,7 @@ struct dNode {                        // NOLINT(readability-identifier-naming)
     p = reinterpret_cast<dNode*>(reinterpret_cast<std::uintptr_t>(p) & (~7ULL));
   }
 
-  [[nodiscard]] static inline std::uintptr_t
+  [[nodiscard]] static std::uintptr_t
   getDensityMatrixTempFlags(dNode*& p) noexcept {
     return getDensityMatrixTempFlags(reinterpret_cast<std::uintptr_t>(p));
   }

--- a/include/mqt-core/dd/NoiseFunctionality.hpp
+++ b/include/mqt-core/dd/NoiseFunctionality.hpp
@@ -1,19 +1,21 @@
 #pragma once
 
-#include "dd/ComplexNumbers.hpp"
-#include "dd/GateMatrixDefinitions.hpp"
+#include "Definitions.hpp"
+#include "dd/DDDefinitions.hpp"
+#include "dd/DDpackageConfig.hpp"
 #include "dd/Node.hpp"
 #include "dd/Package.hpp"
 #include "operations/OpType.hpp"
 #include "operations/Operation.hpp"
 
-#include <algorithm>
 #include <array>
 #include <cassert>
-#include <complex>
-#include <map>
-#include <optional>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <random>
+#include <set>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/include/mqt-core/dd/Operations.hpp
+++ b/include/mqt-core/dd/Operations.hpp
@@ -1,13 +1,26 @@
 #pragma once
 
+#include "Definitions.hpp"
+#include "Permutation.hpp"
+#include "dd/DDDefinitions.hpp"
 #include "dd/GateMatrixDefinitions.hpp"
 #include "dd/Package.hpp"
+#include "dd/Package_fwd.hpp"
 #include "operations/ClassicControlledOperation.hpp"
 #include "operations/CompoundOperation.hpp"
+#include "operations/Control.hpp"
 #include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
 #include "operations/StandardOperation.hpp"
 
-#include <variant>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace dd {
 // single-target Operations

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -26,7 +26,6 @@
 #include <bitset>
 #include <cassert>
 #include <cmath>
-#include <complex>
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
@@ -34,7 +33,6 @@
 #include <iterator>
 #include <limits>
 #include <map>
-#include <optional>
 #include <queue>
 #include <random>
 #include <regex>
@@ -111,7 +109,7 @@ public:
    * @note The real and imaginary part of complex numbers are treated
    * separately. Hence, it suffices for the manager to only manage real numbers.
    */
-  MemoryManager<RealNumber> cMemoryManager{};
+  MemoryManager<RealNumber> cMemoryManager;
 
   /**
    * @brief Get the memory manager for a given type
@@ -1150,7 +1148,8 @@ public:
   void performCollapsingMeasurement(vEdge& rootEdge, const Qubit index,
                                     const fp probability,
                                     const bool measureZero) {
-    GateMatrix measurementMatrix = measureZero ? MEAS_ZERO_MAT : MEAS_ONE_MAT;
+    const GateMatrix measurementMatrix =
+        measureZero ? MEAS_ZERO_MAT : MEAS_ONE_MAT;
 
     const auto measurementGate = makeGateDD(measurementMatrix, index);
 
@@ -1737,14 +1736,14 @@ public:
       return 0.;
     }
 
-    std::size_t leftIdx = i;
+    const std::size_t leftIdx = i;
     fp leftContribution = 0.;
     if (!e.p->e[0].w.approximatelyZero()) {
       leftContribution = fidelityOfMeasurementOutcomesRecursive(
           e.p->e[0], probs, leftIdx, permutation, nQubits);
     }
 
-    std::size_t rightIdx = i | (1ULL << e.p->v);
+    const std::size_t rightIdx = i | (1ULL << e.p->v);
     auto rightContribution = 0.;
     if (!e.p->e[1].w.approximatelyZero()) {
       rightContribution = fidelityOfMeasurementOutcomesRecursive(

--- a/include/mqt-core/dd/Simulation.hpp
+++ b/include/mqt-core/dd/Simulation.hpp
@@ -2,7 +2,14 @@
 
 #include "QuantumComputation.hpp"
 #include "algorithms/GoogleRandomCircuitSampling.hpp"
+#include "dd/DDDefinitions.hpp"
 #include "dd/Operations.hpp"
+#include "dd/Package_fwd.hpp"
+
+#include <cstddef>
+#include <map>
+#include <optional>
+#include <string>
 
 namespace dd {
 using namespace qc;

--- a/include/mqt-core/dd/StochasticNoiseOperationTable.hpp
+++ b/include/mqt-core/dd/StochasticNoiseOperationTable.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
 #include "Definitions.hpp"
-#include "dd/DDDefinitions.hpp"
 #include "dd/statistics/TableStatistics.hpp"
 
 #include <array>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
 #include <vector>
 
 namespace dd {

--- a/include/mqt-core/dd/UnaryComputeTable.hpp
+++ b/include/mqt-core/dd/UnaryComputeTable.hpp
@@ -1,13 +1,11 @@
 #pragma once
 
-#include "DDDefinitions.hpp"
 #include "dd/statistics/TableStatistics.hpp"
 
 #include <array>
 #include <bitset>
 #include <cstddef>
-#include <iostream>
-#include <utility>
+#include <functional>
 
 namespace dd {
 

--- a/include/mqt-core/dd/UniqueTable.hpp
+++ b/include/mqt-core/dd/UniqueTable.hpp
@@ -1,18 +1,20 @@
 #pragma once
 
-#include "dd/DDDefinitions.hpp"
+#include "Definitions.hpp"
 #include "dd/Edge.hpp"
 #include "dd/MemoryManager.hpp"
 #include "dd/Node.hpp"
 #include "dd/statistics/UniqueTableStatistics.hpp"
-#include "nlohmann/json.hpp"
 
 #include <algorithm>
 #include <array>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <iostream>
+#include <nlohmann/json.hpp>
+#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -97,7 +99,7 @@ public:
   }
 
   /// Get a JSON object with the statistics
-  [[nodiscard]] nlohmann::json
+  [[nodiscard]] nlohmann::basic_json<>
   getStatsJson(const bool includeIndividualTables = false) const {
     if (std::all_of(stats.begin(), stats.end(),
                     [](const UniqueTableStatistics& stat) {
@@ -121,7 +123,7 @@ public:
       totalStats.gcRuns = std::max(totalStats.gcRuns, stat.gcRuns);
     }
 
-    nlohmann::json j;
+    nlohmann::basic_json<> j;
     j["total"] = totalStats.json();
     if (includeIndividualTables) {
       std::size_t v = 0U;
@@ -304,7 +306,7 @@ public:
       std::cout << "\tq" << q << ":"
                 << "\n";
       for (std::size_t key = 0; key < table.size(); ++key) {
-        auto p = table[key];
+        auto* p = table[key];
         if (p != nullptr) {
           std::cout << "\tkey=" << key << ": ";
         }

--- a/include/mqt-core/dd/statistics/PackageStatistics.hpp
+++ b/include/mqt-core/dd/statistics/PackageStatistics.hpp
@@ -1,7 +1,18 @@
 #pragma once
 
+#include "dd/Complex.hpp"
+#include "dd/ComplexNumbers.hpp"
+#include "dd/ComplexValue.hpp"
+#include "dd/DDpackageConfig.hpp"
+#include "dd/Edge.hpp"
+#include "dd/Node.hpp"
 #include "dd/Package.hpp"
-#include "nlohmann/json.hpp"
+#include "dd/RealNumber.hpp"
+
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <ostream>
+#include <string>
 
 namespace dd {
 
@@ -96,10 +107,10 @@ template <class Config>
 }
 
 template <class Config = DDPackageConfig>
-[[nodiscard]] static nlohmann::json
+[[nodiscard]] static nlohmann::basic_json<>
 getStatistics(Package<Config>* package,
               const bool includeIndividualTables = false) {
-  nlohmann::json j;
+  nlohmann::basic_json<> j;
 
   auto& vector = j["vector"];
   vector["unique_table"] =
@@ -156,9 +167,9 @@ getStatistics(Package<Config>* package,
  * @return A JSON representation of the statistics
  */
 template <class Config = DDPackageConfig>
-[[nodiscard]] static nlohmann::json
+[[nodiscard]] static nlohmann::basic_json<>
 getDataStructureStatistics(Package<Config>* package) {
-  nlohmann::json j;
+  nlohmann::basic_json<> j;
 
   // Information about key data structures
   // For every entry, we store the size in bytes and the alignment in bytes

--- a/include/mqt-core/dd/statistics/Statistics.hpp
+++ b/include/mqt-core/dd/statistics/Statistics.hpp
@@ -8,6 +8,11 @@
 namespace dd {
 
 struct Statistics {
+  Statistics() = default;
+  Statistics(const Statistics&) = default;
+  Statistics(Statistics&&) = default;
+  Statistics& operator=(const Statistics&) = default;
+  Statistics& operator=(Statistics&&) = default;
   virtual ~Statistics() = default;
 
   /// Reset all statistics (except for peak values)

--- a/include/mqt-core/dd/statistics/TableStatistics.hpp
+++ b/include/mqt-core/dd/statistics/TableStatistics.hpp
@@ -3,6 +3,7 @@
 #include "dd/statistics/Statistics.hpp"
 
 #include <cstddef>
+#include <nlohmann/json_fwd.hpp>
 
 namespace dd {
 

--- a/include/mqt-core/dd/statistics/UniqueTableStatistics.hpp
+++ b/include/mqt-core/dd/statistics/UniqueTableStatistics.hpp
@@ -2,6 +2,9 @@
 
 #include "dd/statistics/TableStatistics.hpp"
 
+#include <cstddef>
+#include <nlohmann/json_fwd.hpp>
+
 namespace dd {
 /// \brief A class for storing statistics of a unique table
 struct UniqueTableStatistics : public TableStatistics {

--- a/include/mqt-core/ecc/Ecc.hpp
+++ b/include/mqt-core/ecc/Ecc.hpp
@@ -1,6 +1,18 @@
 #pragma once
 
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/OpType.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace ecc {
 using Qubit = qc::Qubit;
@@ -8,7 +20,7 @@ using QubitCount = std::size_t;
 
 class Ecc {
 public:
-  enum class ID {
+  enum class ID : std::uint8_t {
     Id,
     Q3Shor,
     Q9Shor,

--- a/include/mqt-core/ecc/Id.hpp
+++ b/include/mqt-core/ecc/Id.hpp
@@ -2,6 +2,11 @@
 
 #include "Ecc.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/Operation.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <utility>
 namespace ecc {
 class Id : public Ecc {
 public:

--- a/include/mqt-core/ecc/Q18Surface.hpp
+++ b/include/mqt-core/ecc/Q18Surface.hpp
@@ -2,6 +2,14 @@
 
 #include "Ecc.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/Operation.hpp"
+
+#include <array>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
 namespace ecc {
 class Q18Surface : public Ecc {
 public:

--- a/include/mqt-core/ecc/Q3Shor.hpp
+++ b/include/mqt-core/ecc/Q3Shor.hpp
@@ -1,7 +1,15 @@
 #pragma once
 
+#include "Definitions.hpp"
 #include "Ecc.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <utility>
 namespace ecc {
 class Q3Shor : public Ecc {
 public:

--- a/include/mqt-core/ecc/Q5Laflamme.hpp
+++ b/include/mqt-core/ecc/Q5Laflamme.hpp
@@ -2,6 +2,13 @@
 
 #include "Ecc.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <utility>
 namespace ecc {
 class Q5Laflamme : public Ecc {
 public:

--- a/include/mqt-core/ecc/Q7Steane.hpp
+++ b/include/mqt-core/ecc/Q7Steane.hpp
@@ -1,7 +1,16 @@
 #pragma once
 
+#include "Definitions.hpp"
 #include "Ecc.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <utility>
 namespace ecc {
 class Q7Steane : public Ecc {
 public:

--- a/include/mqt-core/ecc/Q9Shor.hpp
+++ b/include/mqt-core/ecc/Q9Shor.hpp
@@ -2,6 +2,11 @@
 
 #include "Ecc.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/Operation.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <utility>
 namespace ecc {
 class Q9Shor : public Ecc {
 public:

--- a/include/mqt-core/ecc/Q9Surface.hpp
+++ b/include/mqt-core/ecc/Q9Surface.hpp
@@ -2,6 +2,13 @@
 
 #include "Ecc.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/Operation.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <set>
+#include <utility>
 
 // Reference to this ecc in https://arxiv.org/pdf/1608.05053.pdf
 namespace ecc {

--- a/include/mqt-core/na/NAComputation.hpp
+++ b/include/mqt-core/na/NAComputation.hpp
@@ -53,7 +53,7 @@ public:
   template <class T, class... Args> auto emplaceBack(Args&&... args) -> void {
     static_assert(std::is_base_of_v<NAOperation, T>,
                   "T must be a subclass of NAOperation.");
-    operations.emplace_back(std::make_unique<T>(args...));
+    operations.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
   }
   auto clear(const bool clearInitialPositions = true) -> void {
     operations.clear();

--- a/include/mqt-core/na/NADefinitions.hpp
+++ b/include/mqt-core/na/NADefinitions.hpp
@@ -7,8 +7,12 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <ostream>
 #include <sstream>
+#include <string>
 
 namespace na {
 /// Class to store two-dimensional coordinates

--- a/include/mqt-core/operations/ClassicControlledOperation.hpp
+++ b/include/mqt-core/operations/ClassicControlledOperation.hpp
@@ -1,7 +1,17 @@
 #pragma once
 
+#include "Definitions.hpp"
 #include "Operation.hpp"
+#include "Permutation.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
 
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <ostream>
+#include <string>
 #include <utility>
 
 namespace qc {
@@ -24,14 +34,14 @@ std::ostream& operator<<(std::ostream& os, const ComparisonKind& kind);
 class ClassicControlledOperation final : public Operation {
 private:
   std::unique_ptr<Operation> op;
-  ClassicalRegister controlRegister{};
+  ClassicalRegister controlRegister;
   std::uint64_t expectedValue = 1U;
   ComparisonKind comparisonKind = ComparisonKind::Eq;
 
 public:
   // Applies operation `_op` if the creg starting at index `control` has the
   // expected value
-  ClassicControlledOperation(std::unique_ptr<qc::Operation>& operation,
+  ClassicControlledOperation(std::unique_ptr<qc::Operation>&& operation,
                              ClassicalRegister controlReg,
                              std::uint64_t expectedVal = 1U,
                              ComparisonKind kind = ComparisonKind::Eq)
@@ -133,7 +143,7 @@ public:
   }
 
   void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
-                    const RegisterNames& creg, size_t indent,
+                    const RegisterNames& creg, std::size_t indent,
                     bool openQASM3) const override {
     of << std::string(indent * OUTPUT_INDENT_SIZE, ' ');
     of << "if (";

--- a/include/mqt-core/operations/CompoundOperation.hpp
+++ b/include/mqt-core/operations/CompoundOperation.hpp
@@ -1,19 +1,22 @@
 #pragma once
 
+#include "Definitions.hpp"
 #include "Operation.hpp"
 #include "Permutation.hpp"
 #include "operations/Control.hpp"
 
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <ostream>
+#include <set>
 #include <vector>
 
 namespace qc {
 
 class CompoundOperation final : public Operation {
 private:
-  std::vector<std::unique_ptr<Operation>> ops{};
+  std::vector<std::unique_ptr<Operation>> ops;
 
 public:
   explicit CompoundOperation();
@@ -130,7 +133,7 @@ public:
   // Modifiers (pass-through)
   void clear() noexcept { ops.clear(); }
   // NOLINTNEXTLINE(readability-identifier-naming)
-  void pop_back() { return ops.pop_back(); }
+  void pop_back() { ops.pop_back(); }
   void resize(std::size_t count) { ops.resize(count); }
   std::vector<std::unique_ptr<Operation>>::iterator
   erase(std::vector<std::unique_ptr<Operation>>::const_iterator pos) {
@@ -144,7 +147,7 @@ public:
 
   // NOLINTNEXTLINE(readability-identifier-naming)
   template <class T, class... Args> void emplace_back(Args&&... args) {
-    ops.emplace_back(std::make_unique<T>(args...));
+    ops.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
   }
 
   // NOLINTNEXTLINE(readability-identifier-naming)
@@ -161,7 +164,8 @@ public:
   std::vector<std::unique_ptr<Operation>>::iterator
   insert(std::vector<std::unique_ptr<Operation>>::const_iterator iterator,
          Args&&... args) {
-    return ops.insert(iterator, std::make_unique<T>(args...));
+    return ops.insert(iterator,
+                      std::make_unique<T>(std::forward<Args>(args)...));
   }
   template <class T>
   std::vector<std::unique_ptr<Operation>>::iterator

--- a/include/mqt-core/operations/Expression.hpp
+++ b/include/mqt-core/operations/Expression.hpp
@@ -4,9 +4,12 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <numeric>
 #include <ostream>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <unordered_map>

--- a/include/mqt-core/operations/NonUnitaryOperation.hpp
+++ b/include/mqt-core/operations/NonUnitaryOperation.hpp
@@ -1,12 +1,23 @@
 #pragma once
 
+#include "Definitions.hpp"
 #include "Operation.hpp"
+#include "Permutation.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <ostream>
+#include <set>
+#include <vector>
 
 namespace qc {
 
 class NonUnitaryOperation final : public Operation {
 protected:
-  std::vector<Bit> classics{}; // vector for the classical bits to measure into
+  std::vector<Bit> classics; // vector for the classical bits to measure into
 
   static void printMeasurement(std::ostream& os, const std::vector<Qubit>& q,
                                const std::vector<Bit>& c,
@@ -34,7 +45,7 @@ public:
 
   [[nodiscard]] const std::vector<Bit>& getClassics() const { return classics; }
   std::vector<Bit>& getClassics() { return classics; }
-  [[nodiscard]] size_t getNclassics() const { return classics.size(); }
+  [[nodiscard]] std::size_t getNclassics() const { return classics.size(); }
 
   [[nodiscard]] std::set<Qubit> getUsedQubits() const override {
     const auto& opTargets = getTargets();

--- a/include/mqt-core/operations/OpType.hpp
+++ b/include/mqt-core/operations/OpType.hpp
@@ -2,8 +2,8 @@
 
 #include <array>
 #include <cstdint>
-#include <functional>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 

--- a/include/mqt-core/operations/Operation.hpp
+++ b/include/mqt-core/operations/Operation.hpp
@@ -3,15 +3,16 @@
 #include "Definitions.hpp"
 #include "OpType.hpp"
 #include "Permutation.hpp"
+#include "operations/Control.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstring>
-#include <fstream>
-#include <iomanip>
+#include <functional>
 #include <iostream>
-#include <map>
 #include <memory>
 #include <set>
+#include <string>
 #include <vector>
 
 namespace qc {

--- a/include/mqt-core/operations/StandardOperation.hpp
+++ b/include/mqt-core/operations/StandardOperation.hpp
@@ -1,8 +1,18 @@
 #pragma once
 
+#include "Definitions.hpp"
 #include "Operation.hpp"
+#include "Permutation.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
 
 #include <cmath>
+#include <cstddef>
+#include <memory>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace qc {
 class StandardOperation : public Operation {
@@ -92,7 +102,7 @@ public:
   }
 
   void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
-                    const RegisterNames& creg, size_t indent,
+                    const RegisterNames& creg, std::size_t indent,
                     bool openQASM3) const override;
 
   [[nodiscard]] auto commutesAtQubit(const Operation& other,

--- a/include/mqt-core/operations/SymbolicOperation.hpp
+++ b/include/mqt-core/operations/SymbolicOperation.hpp
@@ -26,7 +26,7 @@ template <class... Ts> Overload(Ts...) -> Overload<Ts...>;
 
 class SymbolicOperation final : public StandardOperation {
 protected:
-  std::vector<std::optional<Symbolic>> symbolicParameter{};
+  std::vector<std::optional<Symbolic>> symbolicParameter;
 
   static OpType parseU3(const Symbolic& theta, fp& phi, fp& lambda);
   static OpType parseU3(fp& theta, const Symbolic& phi, fp& lambda);
@@ -116,19 +116,19 @@ public:
     return std::make_unique<SymbolicOperation>(*this);
   }
 
-  [[nodiscard]] inline bool isSymbolicOperation() const override {
+  [[nodiscard]] bool isSymbolicOperation() const override {
     return std::any_of(symbolicParameter.begin(), symbolicParameter.end(),
                        [](const auto& sym) { return sym.has_value(); });
   }
 
-  [[nodiscard]] inline bool isStandardOperation() const override {
+  [[nodiscard]] bool isStandardOperation() const override {
     return std::all_of(symbolicParameter.begin(), symbolicParameter.end(),
                        [](const auto& sym) { return !sym.has_value(); });
   }
 
   [[nodiscard]] bool equals(const Operation& op, const Permutation& perm1,
                             const Permutation& perm2) const override;
-  [[nodiscard]] inline bool equals(const Operation& op) const override {
+  [[nodiscard]] bool equals(const Operation& op) const override {
     return equals(op, {}, {});
   }
 

--- a/include/mqt-core/parsers/qasm3_parser/Exception.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/Exception.hpp
@@ -2,11 +2,17 @@
 
 #include "Statement.hpp"
 
+#include <exception>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+
 namespace qasm3 {
 class CompilerError final : public std::exception {
 public:
-  std::string message{};
-  std::shared_ptr<DebugInfo> debugInfo{};
+  std::string message;
+  std::shared_ptr<DebugInfo> debugInfo;
 
   CompilerError(std::string msg, std::shared_ptr<DebugInfo> debug)
       : message(std::move(msg)), debugInfo(std::move(debug)) {}
@@ -30,7 +36,7 @@ public:
 
 class ConstEvalError final : public std::exception {
 public:
-  std::string message{};
+  std::string message;
 
   explicit ConstEvalError(std::string msg) : message(std::move(msg)) {}
 
@@ -41,7 +47,7 @@ public:
 
 class TypeCheckError final : public std::exception {
 public:
-  std::string message{};
+  std::string message;
 
   explicit TypeCheckError(std::string msg) : message(std::move(msg)) {}
 

--- a/include/mqt-core/parsers/qasm3_parser/Gate.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/Gate.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
-#include "NestedEnvironment.hpp"
-#include "QuantumComputation.hpp"
 #include "Statement.hpp"
+#include "operations/OpType.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace qasm3 {
 struct GateInfo {

--- a/include/mqt-core/parsers/qasm3_parser/InstVisitor.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/InstVisitor.hpp
@@ -89,7 +89,7 @@ public:
       std::shared_ptr<MeasureExpression> measureExpression) = 0;
 
   // A manually implemented visitor function with a templated return type.
-  // This is not possible as a virtual function in expression, which is why
+  // This is impossible as a virtual function in expression, which is why
   // we define it manually.
   T visit(const std::shared_ptr<Expression>& expression) {
     if (expression == nullptr) {

--- a/include/mqt-core/parsers/qasm3_parser/Parser.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/Parser.hpp
@@ -7,14 +7,21 @@
 #pragma once
 
 #include "Exception.hpp"
+#include "Permutation.hpp"
 #include "Scanner.hpp"
 #include "Statement.hpp"
 #include "StdGates.hpp"
+#include "parsers/qasm3_parser/Token.hpp"
+#include "parsers/qasm3_parser/Types.hpp"
 
 #include <iostream>
+#include <memory>
+#include <optional>
 #include <sstream>
 #include <stack>
 #include <stdexcept>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace qasm3 {
@@ -60,7 +67,7 @@ class Parser {
     }
   };
 
-  std::stack<ScannerState> scanner{};
+  std::stack<ScannerState> scanner;
   std::shared_ptr<DebugInfo> includeDebugInfo{nullptr};
 
   [[noreturn]] void error(const Token& token, const std::string& msg) {

--- a/include/mqt-core/parsers/qasm3_parser/Scanner.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/Scanner.hpp
@@ -2,12 +2,18 @@
 
 #include "Token.hpp"
 
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <optional>
+#include <string>
+#include <unordered_map>
 
 namespace qasm3 {
 class Scanner {
   std::istream* is;
-  std::unordered_map<std::string, Token::Kind> keywords{};
+  std::unordered_map<std::string, Token::Kind> keywords;
   char ch = 0;
   size_t line = 1;
   size_t col = 0;

--- a/include/mqt-core/parsers/qasm3_parser/Statement.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/Statement.hpp
@@ -93,7 +93,7 @@ public:
 class BinaryExpression : public Expression,
                          public std::enable_shared_from_this<BinaryExpression> {
 public:
-  enum Op {
+  enum Op : uint8_t {
     Power,
     Add,
     Subtract,
@@ -131,7 +131,7 @@ std::optional<qc::ComparisonKind> getComparisonKind(BinaryExpression::Op op);
 class UnaryExpression : public Expression,
                         public std::enable_shared_from_this<UnaryExpression> {
 public:
-  enum Op {
+  enum Op : uint8_t {
     BitwiseNot,
     LogicalNot,
     Negate,
@@ -169,7 +169,7 @@ public:
 class IdentifierList : public Expression,
                        public std::enable_shared_from_this<IdentifierList> {
 public:
-  std::vector<std::shared_ptr<IdentifierExpression>> identifiers{};
+  std::vector<std::shared_ptr<IdentifierExpression>> identifiers;
 
   explicit IdentifierList(
       std::vector<std::shared_ptr<IdentifierExpression>> ids)
@@ -371,7 +371,7 @@ class AssignmentStatement
     : public Statement,
       public std::enable_shared_from_this<AssignmentStatement> {
 public:
-  enum Type {
+  enum Type : uint8_t {
     Assignment,
     PlusAssignment,
     MinusAssignment,

--- a/include/mqt-core/parsers/qasm3_parser/StdGates.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/StdGates.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include "Gate.hpp"
+#include "operations/OpType.hpp"
 
+#include <map>
+#include <memory>
 #include <string>
 
 namespace qasm3 {

--- a/include/mqt-core/parsers/qasm3_parser/Token.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/Token.hpp
@@ -1,15 +1,20 @@
 #pragma once
 
-#include "QuantumComputation.hpp"
+#include "Definitions.hpp"
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
 #include <utility>
 
 namespace qasm3 {
 
 struct Token {
 public:
-  enum class Kind {
+  enum class Kind : uint8_t {
     None,
 
     OpenQasm,

--- a/include/mqt-core/parsers/qasm3_parser/Types.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/Types.hpp
@@ -2,8 +2,10 @@
 
 #include "InstVisitor.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
 
 namespace qasm3 {
@@ -42,7 +44,7 @@ public:
   virtual std::string toString() = 0;
 };
 
-enum DesignatedTy {
+enum DesignatedTy : uint8_t {
   Qubit,
   Bit,
   Int,
@@ -133,7 +135,7 @@ public:
   std::string designatorToString();
 };
 
-enum UnsizedTy { Bool, Duration };
+enum UnsizedTy : uint8_t { Bool, Duration };
 
 template <typename T> class UnsizedType : public Type<T> {
 public:

--- a/include/mqt-core/parsers/qasm3_parser/passes/ConstEvalPass.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/passes/ConstEvalPass.hpp
@@ -3,11 +3,21 @@
 #include "CompilerPass.hpp"
 #include "Definitions.hpp"
 #include "parsers/qasm3_parser/Exception.hpp"
+#include "parsers/qasm3_parser/InstVisitor.hpp"
 #include "parsers/qasm3_parser/NestedEnvironment.hpp"
+#include "parsers/qasm3_parser/Statement.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <variant>
 
 namespace qasm3::const_eval {
 struct ConstEvalValue {
-  enum Type {
+  enum Type : uint8_t {
     ConstInt,
     ConstUint,
     ConstFloat,
@@ -83,7 +93,7 @@ class ConstEvalPass : public CompilerPass,
                       public DefaultInstVisitor,
                       public ExpressionVisitor<std::optional<ConstEvalValue>>,
                       public TypeVisitor<std::shared_ptr<Expression>> {
-  NestedEnvironment<ConstEvalValue> env{};
+  NestedEnvironment<ConstEvalValue> env;
 
   template <typename T> static int64_t castToWidth(int64_t value) {
     return static_cast<int64_t>(static_cast<T>(value));

--- a/include/mqt-core/parsers/qasm3_parser/passes/TypeCheckPass.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/passes/TypeCheckPass.hpp
@@ -1,9 +1,17 @@
 #pragma once
 
 #include "ConstEvalPass.hpp"
+#include "parsers/qasm3_parser/Exception.hpp"
+#include "parsers/qasm3_parser/InstVisitor.hpp"
+#include "parsers/qasm3_parser/Statement.hpp"
 #include "parsers/qasm3_parser/Types.hpp"
+#include "parsers/qasm3_parser/passes/CompilerPass.hpp"
 
 #include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
 
 namespace qasm3::type_checking {
 

--- a/include/mqt-core/python/pybind11.hpp
+++ b/include/mqt-core/python/pybind11.hpp
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
+#include <pybind11/pybind11.h> // IWYU pragma: export
+#include <pybind11/stl.h>      // IWYU pragma: export
 
 namespace mqt {
 namespace py = pybind11;

--- a/include/mqt-core/python/qiskit/QuantumCircuit.hpp
+++ b/include/mqt-core/python/qiskit/QuantumCircuit.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "pybind11/pybind11.h"
-#include "pybind11/pytypes.h"
+#include "operations/Expression.hpp"
+#include "operations/OpType.hpp"
+#include "python/pybind11.hpp" // IWYU pragma: keep
 
-#include <regex>
-#include <type_traits>
-#include <variant>
+#include <pybind11/pytypes.h>
 
 namespace py = pybind11;
 

--- a/include/mqt-core/zx/FunctionalityConstruction.hpp
+++ b/include/mqt-core/zx/FunctionalityConstruction.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
+#include "Permutation.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/Expression.hpp"
+#include "operations/Operation.hpp"
 #include "zx/ZXDefinitions.hpp"
 #include "zx/ZXDiagram.hpp"
 
 #include <cstddef>
 #include <optional>
+#include <vector>
 
 namespace zx {
 class FunctionalityConstruction {

--- a/include/mqt-core/zx/Rational.hpp
+++ b/include/mqt-core/zx/Rational.hpp
@@ -1,21 +1,21 @@
 #pragma once
 
 #if defined(GMP)
-#include "boost/multiprecision/gmp.hpp"
+#include <boost/multiprecision/gmp.hpp> // IWYU pragma: keep
 using Rational = boost::multiprecision::mpq_rational;
 using BigInt = boost::multiprecision::mpz_int;
 #else
-#include "boost/multiprecision/cpp_int.hpp"
+#include <boost/multiprecision/cpp_int.hpp> // IWYU pragma: keep
+#include <boost/multiprecision/fwd.hpp>
 using Rational = boost::multiprecision::cpp_rational;
 using BigInt = boost::multiprecision::cpp_int;
 #endif
 
+#include <boost/multiprecision/rational_adaptor.hpp>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
-#include <type_traits>
-#include <utility>
 
 namespace zx {
 
@@ -81,7 +81,7 @@ public:
   explicit operator double() const { return this->toDouble(); }
 
 private:
-  Rational frac{};
+  Rational frac;
 
   void modPi();
 

--- a/include/mqt-core/zx/Utils.hpp
+++ b/include/mqt-core/zx/Utils.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "operations/Expression.hpp"
 #include "zx/ZXDefinitions.hpp"
 
+#include <cassert>
 #include <cstdint>
 #include <iterator>
 #include <optional>

--- a/include/mqt-core/zx/ZXDefinitions.hpp
+++ b/include/mqt-core/zx/ZXDefinitions.hpp
@@ -3,9 +3,13 @@
 #include "operations/Expression.hpp"
 #include "zx/Rational.hpp"
 
+#include <cstddef>
 #include <cstdint>
+#include <ostream>
 #include <stdexcept>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace zx {
 

--- a/include/mqt-core/zx/ZXDiagram.hpp
+++ b/include/mqt-core/zx/ZXDiagram.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
-#include "operations/Expression.hpp"
 #include "zx/Utils.hpp"
 #include "zx/ZXDefinitions.hpp"
 
+#include <cassert>
 #include <cstddef>
 #include <optional>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -155,7 +154,7 @@ private:
   std::vector<Vertex> outputs;
   std::size_t nvertices = 0;
   std::size_t nedges = 0;
-  PiExpression globalPhase = {};
+  PiExpression globalPhase;
 
   std::vector<Vertex> initGraph(std::size_t nqubits);
   void closeGraph(const std::vector<Vertex>& qubitVertices);

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -1,10 +1,27 @@
 #include "CircuitOptimizer.hpp"
 
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
+#include "operations/CompoundOperation.hpp"
 #include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/StandardOperation.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <ios>
+#include <iostream>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/src/QuantumComputation.cpp
+++ b/src/QuantumComputation.cpp
@@ -1,7 +1,33 @@
 #include "QuantumComputation.hpp"
 
+#include "Definitions.hpp"
+#include "operations/CompoundOperation.hpp"
+#include "operations/Control.hpp"
+#include "operations/Expression.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/StandardOperation.hpp"
+#include "operations/SymbolicOperation.hpp"
+
+#include <algorithm>
 #include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <istream>
+#include <iterator>
 #include <memory>
+#include <optional>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
 
 namespace qc {
 
@@ -95,7 +121,7 @@ void QuantumComputation::import(const std::string& filename, Format format) {
   }
 }
 
-void QuantumComputation::import(std::istream&& is, Format format) {
+void QuantumComputation::import(std::istream& is, Format format) {
   // reset circuit before importing
   reset();
 
@@ -634,7 +660,7 @@ void QuantumComputation::dump(const std::string& filename, Format format) {
   dump(of, format);
 }
 
-void QuantumComputation::dump(std::ostream&& of, Format format) {
+void QuantumComputation::dump(std::ostream& of, Format format) {
   switch (format) {
   case Format::OpenQASM3:
     dumpOpenQASM(of, true);

--- a/src/algorithms/BernsteinVazirani.cpp
+++ b/src/algorithms/BernsteinVazirani.cpp
@@ -1,5 +1,11 @@
 #include "algorithms/BernsteinVazirani.hpp"
 
+#include "Definitions.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <ostream>
+
 namespace qc {
 BernsteinVazirani::BernsteinVazirani(const BitString& hiddenString,
                                      const bool dyn)

--- a/src/algorithms/Entanglement.cpp
+++ b/src/algorithms/Entanglement.cpp
@@ -1,5 +1,11 @@
 #include "algorithms/Entanglement.hpp"
 
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
+
+#include <cstddef>
+#include <string>
+
 namespace qc {
 Entanglement::Entanglement(const std::size_t nq) : QuantumComputation(nq, nq) {
   name = "entanglement_" + std::to_string(nq);

--- a/src/algorithms/GoogleRandomCircuitSampling.cpp
+++ b/src/algorithms/GoogleRandomCircuitSampling.cpp
@@ -1,5 +1,18 @@
 #include "algorithms/GoogleRandomCircuitSampling.hpp"
 
+#include "Definitions.hpp"
+#include "operations/OpType.hpp"
+#include "operations/StandardOperation.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
 #include <utility>
 
 namespace qc {
@@ -52,8 +65,7 @@ GoogleRandomCircuitSampling::GoogleRandomCircuitSampling(
 void GoogleRandomCircuitSampling::importGRCS(const std::string& filename) {
   auto ifs = std::ifstream(filename);
   if (!ifs.good()) {
-    std::cerr << "Error opening/reading from file: " << filename << "\n";
-    exit(3);
+    throw QFRException("Error opening/reading from file: " + filename);
   }
   const std::size_t slash = filename.find_last_of('/');
   const std::size_t dot = filename.find_last_of('.');

--- a/src/algorithms/Grover.cpp
+++ b/src/algorithms/Grover.cpp
@@ -1,5 +1,17 @@
 #include "algorithms/Grover.hpp"
 
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
+#include "operations/Control.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <ostream>
+#include <random>
+#include <string>
+#include <type_traits>
+
 namespace qc {
 /***
  * Private Methods

--- a/src/algorithms/QFT.cpp
+++ b/src/algorithms/QFT.cpp
@@ -1,5 +1,14 @@
 #include "algorithms/QFT.hpp"
 
+#include "Definitions.hpp"
+#include "operations/OpType.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <ostream>
+#include <string>
+#include <vector>
+
 namespace qc {
 QFT::QFT(const std::size_t nq, const bool includeMeas, const bool dyn)
     : precision(nq), includeMeasurements(includeMeas), dynamic(dyn) {

--- a/src/algorithms/QPE.cpp
+++ b/src/algorithms/QPE.cpp
@@ -1,5 +1,14 @@
 #include "algorithms/QPE.hpp"
 
+#include "Definitions.hpp"
+#include "operations/OpType.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <ostream>
+#include <random>
+
 namespace qc {
 QPE::QPE(const std::size_t nq, const bool exact, const bool iter)
     : precision(nq), iterative(iter) {

--- a/src/algorithms/RandomCliffordCircuit.cpp
+++ b/src/algorithms/RandomCliffordCircuit.cpp
@@ -1,5 +1,17 @@
 #include "algorithms/RandomCliffordCircuit.hpp"
 
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
+#include "operations/CompoundOperation.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <ostream>
+#include <random>
+
 namespace qc {
 
 RandomCliffordCircuit::RandomCliffordCircuit(const std::size_t nq,

--- a/src/algorithms/WState.cpp
+++ b/src/algorithms/WState.cpp
@@ -1,5 +1,11 @@
 #include "algorithms/WState.hpp"
 
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
+
+#include <cmath>
+#include <string>
+
 namespace qc {
 void fGate(QuantumComputation& qc, const Qubit i, const Qubit j, const Qubit k,
            const Qubit n) {

--- a/src/datastructures/Layer.cpp
+++ b/src/datastructures/Layer.cpp
@@ -2,9 +2,9 @@
 
 #include "Definitions.hpp"
 #include "QuantumComputation.hpp"
-#include "datastructures/UndirectedGraph.hpp"
 #include "operations/OpType.hpp"
 
+#include <cstddef>
 #include <memory>
 #include <sstream>
 #include <stdexcept>

--- a/src/dd/Benchmark.cpp
+++ b/src/dd/Benchmark.cpp
@@ -6,6 +6,12 @@
 #include "dd/Simulation.hpp"
 #include "dd/statistics/PackageStatistics.hpp"
 
+#include <chrono>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <string>
+
 namespace dd {
 
 std::unique_ptr<SimulationExperiment>

--- a/src/dd/CachedEdge.cpp
+++ b/src/dd/CachedEdge.cpp
@@ -1,8 +1,10 @@
 #include "dd/CachedEdge.hpp"
 
+#include "Definitions.hpp"
 #include "dd/Complex.hpp"
 #include "dd/ComplexNumbers.hpp"
 #include "dd/DDDefinitions.hpp"
+#include "dd/Edge.hpp"
 #include "dd/MemoryManager.hpp"
 #include "dd/Node.hpp"
 #include "dd/RealNumber.hpp"
@@ -10,6 +12,8 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cstddef>
+#include <functional>
 #include <optional>
 
 namespace dd {

--- a/src/dd/Complex.cpp
+++ b/src/dd/Complex.cpp
@@ -1,6 +1,7 @@
 #include "dd/Complex.hpp"
 
 #include "dd/ComplexValue.hpp"
+#include "dd/DDDefinitions.hpp"
 #include "dd/RealNumber.hpp"
 
 #include <complex>

--- a/src/dd/ComplexNumbers.cpp
+++ b/src/dd/ComplexNumbers.cpp
@@ -1,10 +1,13 @@
 #include "dd/ComplexNumbers.hpp"
 
+#include "dd/Complex.hpp"
 #include "dd/ComplexValue.hpp"
+#include "dd/DDDefinitions.hpp"
 #include "dd/RealNumber.hpp"
 
 #include <cmath>
 #include <complex>
+#include <cstddef>
 
 namespace dd {
 

--- a/src/dd/ComplexValue.cpp
+++ b/src/dd/ComplexValue.cpp
@@ -1,10 +1,15 @@
 #include "dd/ComplexValue.hpp"
 
+#include "Definitions.hpp"
+#include "dd/DDDefinitions.hpp"
 #include "dd/RealNumber.hpp"
 
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <iomanip>
 #include <istream>
 #include <ostream>
@@ -87,8 +92,15 @@ ComplexValue::getLowestFraction(const fp x,
 }
 
 void ComplexValue::printFormatted(std::ostream& os, fp num, bool imaginary) {
+  if (std::signbit(num)) {
+    os << "-";
+    num = -num;
+  } else if (imaginary) {
+    os << "+";
+  }
+
   if (RealNumber::approximatelyZero(num)) {
-    os << (std::signbit(num) ? "-" : "+") << "0" << (imaginary ? "i" : "");
+    os << "0" << (imaginary ? "i" : "");
     return;
   }
 
@@ -100,17 +112,14 @@ void ComplexValue::printFormatted(std::ostream& os, fp num, bool imaginary) {
   // suitable fraction a/b found
   if (const auto error = absnum - approx;
       RealNumber::approximatelyZero(error)) {
-    const std::string sign = std::signbit(num) ? "-" : (imaginary ? "+" : "");
-
     if (fraction.first == 1U && fraction.second == 1U) {
-      os << sign << (imaginary ? "i" : "1");
+      os << (imaginary ? "i" : "1");
     } else if (fraction.second == 1U) {
-      os << sign << fraction.first << (imaginary ? "i" : "");
+      os << fraction.first << (imaginary ? "i" : "");
     } else if (fraction.first == 1U) {
-      os << sign << (imaginary ? "i" : "1") << "/" << fraction.second;
+      os << (imaginary ? "i" : "1") << "/" << fraction.second;
     } else {
-      os << sign << fraction.first << (imaginary ? "i" : "") << "/"
-         << fraction.second;
+      os << fraction.first << (imaginary ? "i" : "") << "/" << fraction.second;
     }
 
     return;
@@ -122,17 +131,16 @@ void ComplexValue::printFormatted(std::ostream& os, fp num, bool imaginary) {
   // suitable fraction a/(b * sqrt(2)) found
   if (const auto error = abssqrt - approx;
       RealNumber::approximatelyZero(error)) {
-    const std::string sign = std::signbit(num) ? "-" : (imaginary ? "+" : "");
 
     if (fraction.first == 1U && fraction.second == 1U) {
-      os << sign << (imaginary ? "i" : "1") << "/√2";
+      os << (imaginary ? "i" : "1") << "/√2";
     } else if (fraction.second == 1U) {
-      os << sign << fraction.first << (imaginary ? "i" : "") << "/√2";
+      os << fraction.first << (imaginary ? "i" : "") << "/√2";
     } else if (fraction.first == 1U) {
-      os << sign << (imaginary ? "i" : "1") << "/(" << fraction.second << "√2)";
+      os << (imaginary ? "i" : "1") << "/(" << fraction.second << "√2)";
     } else {
-      os << sign << fraction.first << (imaginary ? "i" : "") << "/("
-         << fraction.second << "√2)";
+      os << fraction.first << (imaginary ? "i" : "") << "/(" << fraction.second
+         << "√2)";
     }
     return;
   }
@@ -142,23 +150,22 @@ void ComplexValue::printFormatted(std::ostream& os, fp num, bool imaginary) {
   approx = static_cast<fp>(fraction.first) / static_cast<fp>(fraction.second);
   // suitable fraction a/b π found
   if (const auto error = abspi - approx; RealNumber::approximatelyZero(error)) {
-    const std::string sign = std::signbit(num) ? "-" : (imaginary ? "+" : "");
     const std::string imagUnit = imaginary ? "i" : "";
 
     if (fraction.first == 1U && fraction.second == 1U) {
-      os << sign << "π" << imagUnit;
+      os << "π" << imagUnit;
     } else if (fraction.second == 1U) {
-      os << sign << fraction.first << "π" << imagUnit;
+      os << fraction.first << "π" << imagUnit;
     } else if (fraction.first == 1U) {
-      os << sign << "π" << imagUnit << "/" << fraction.second;
+      os << "π" << imagUnit << "/" << fraction.second;
     } else {
-      os << sign << fraction.first << "π" << imagUnit << "/" << fraction.second;
+      os << fraction.first << "π" << imagUnit << "/" << fraction.second;
     }
     return;
   }
 
   if (imaginary) { // default
-    os << (std::signbit(num) ? "" : "+") << num << "i";
+    os << num << "i";
   } else {
     os << num;
   }

--- a/src/dd/Edge.cpp
+++ b/src/dd/Edge.cpp
@@ -1,5 +1,6 @@
 #include "dd/Edge.hpp"
 
+#include "Definitions.hpp"
 #include "dd/Complex.hpp"
 #include "dd/ComplexNumbers.hpp"
 #include "dd/DDDefinitions.hpp"
@@ -12,11 +13,14 @@
 #include <cassert>
 #include <cmath>
 #include <complex>
+#include <cstddef>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <optional>
 #include <string>
 #include <unordered_set>
+#include <utility>
 
 namespace dd {
 

--- a/src/dd/FunctionalityConstruction.cpp
+++ b/src/dd/FunctionalityConstruction.cpp
@@ -1,5 +1,15 @@
 #include "dd/FunctionalityConstruction.hpp"
 
+#include "QuantumComputation.hpp"
+#include "algorithms/Grover.hpp"
+#include "dd/Package.hpp"
+#include "dd/Package_fwd.hpp"
+
+#include <bitset>
+#include <cmath>
+#include <cstddef>
+#include <stack>
+
 namespace dd {
 template <class Config>
 MatrixDD buildFunctionality(const QuantumComputation* qc, Package<Config>& dd) {

--- a/src/dd/MemoryManager.cpp
+++ b/src/dd/MemoryManager.cpp
@@ -4,6 +4,7 @@
 #include "dd/RealNumber.hpp"
 
 #include <cassert>
+#include <cstddef>
 
 namespace dd {
 

--- a/src/dd/Node.cpp
+++ b/src/dd/Node.cpp
@@ -3,6 +3,7 @@
 #include "dd/ComplexNumbers.hpp"
 
 #include <cassert>
+#include <cstdint>
 #include <utility>
 
 namespace dd {

--- a/src/dd/NoiseFunctionality.cpp
+++ b/src/dd/NoiseFunctionality.cpp
@@ -1,5 +1,26 @@
 #include "dd/NoiseFunctionality.hpp"
 
+#include "Definitions.hpp"
+#include "dd/ComplexNumbers.hpp"
+#include "dd/DDDefinitions.hpp"
+#include "dd/DDpackageConfig.hpp"
+#include "dd/GateMatrixDefinitions.hpp"
+#include "dd/Node.hpp"
+#include "dd/Package.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
 namespace {
 
 std::vector<dd::NoiseOperations>

--- a/src/dd/Operations.cpp
+++ b/src/dd/Operations.cpp
@@ -1,5 +1,22 @@
 #include "dd/Operations.hpp"
 
+#include "Definitions.hpp"
+#include "dd/DDDefinitions.hpp"
+#include "dd/Package.hpp"
+#include "operations/CompoundOperation.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
+
+#include <cstddef>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <ostream>
+#include <sstream>
+#include <variant>
+#include <vector>
+
 namespace dd {
 template <class Config>
 void dumpTensor(qc::Operation* op, std::ostream& of,

--- a/src/dd/RealNumber.cpp
+++ b/src/dd/RealNumber.cpp
@@ -1,6 +1,14 @@
 #include "dd/RealNumber.hpp"
 
+#include "dd/DDDefinitions.hpp"
+
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <istream>
+#include <limits>
+#include <ostream>
 
 namespace dd {
 

--- a/src/dd/RealNumberUniqueTable.cpp
+++ b/src/dd/RealNumberUniqueTable.cpp
@@ -1,10 +1,15 @@
 #include "dd/RealNumberUniqueTable.hpp"
 
+#include "dd/DDDefinitions.hpp"
+#include "dd/MemoryManager.hpp"
 #include "dd/RealNumber.hpp"
 
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
 #include <limits>
 
 namespace dd {

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -1,6 +1,23 @@
 #include "dd/Simulation.hpp"
 
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
+#include "algorithms/GoogleRandomCircuitSampling.hpp"
+#include "dd/DDDefinitions.hpp"
 #include "dd/GateMatrixDefinitions.hpp"
+#include "dd/Package.hpp"
+#include "dd/Package_fwd.hpp"
+#include "dd/RealNumber.hpp"
+#include "operations/ClassicControlledOperation.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
+
+#include <array>
+#include <cstddef>
+#include <map>
+#include <optional>
+#include <random>
+#include <string>
 
 namespace dd {
 template <class Config>

--- a/src/dd/statistics/MemoryManagerStatistics.cpp
+++ b/src/dd/statistics/MemoryManagerStatistics.cpp
@@ -2,9 +2,11 @@
 
 #include "dd/Node.hpp"
 #include "dd/RealNumber.hpp"
-#include "nlohmann/json.hpp"
+#include "dd/statistics/Statistics.hpp"
 
 #include <algorithm>
+#include <cstddef>
+#include <nlohmann/json.hpp>
 
 namespace dd {
 
@@ -69,12 +71,13 @@ template <typename T> void MemoryManagerStatistics<T>::reset() noexcept {
   numAvailableForReuse = 0U;
 }
 
-template <typename T> nlohmann::json MemoryManagerStatistics<T>::json() const {
+template <typename T>
+nlohmann::basic_json<> MemoryManagerStatistics<T>::json() const {
   if (peakNumUsed == 0) {
     return "unused";
   }
 
-  nlohmann::json j = Statistics::json();
+  auto j = Statistics::json();
   j["memory_allocated_MiB"] = getAllocatedMemoryMiB();
   j["memory_used_MiB"] = getUsedMemoryMiB();
   j["memory_used_MiB_peak"] = getPeakUsedMemoryMiB();

--- a/src/dd/statistics/Statistics.cpp
+++ b/src/dd/statistics/Statistics.cpp
@@ -1,10 +1,11 @@
 #include "dd/statistics/Statistics.hpp"
 
-#include "nlohmann/json.hpp"
+#include <nlohmann/json.hpp>
+#include <string>
 
 namespace dd {
 
-nlohmann::json Statistics::json() const { return nlohmann::json{}; }
+nlohmann::basic_json<> Statistics::json() const { return nlohmann::json{}; }
 
 std::string Statistics::toString() const { return json().dump(2U); }
 

--- a/src/dd/statistics/TableStatistics.cpp
+++ b/src/dd/statistics/TableStatistics.cpp
@@ -1,6 +1,9 @@
 #include "dd/statistics/TableStatistics.hpp"
 
-#include "nlohmann/json.hpp"
+#include "dd/statistics/Statistics.hpp"
+
+#include <algorithm>
+#include <nlohmann/json.hpp>
 
 namespace dd {
 
@@ -41,12 +44,12 @@ double TableStatistics::getMemoryMiB() const noexcept {
   return static_cast<double>(numBuckets) * getEntrySizeMiB();
 }
 
-nlohmann::json TableStatistics::json() const {
+nlohmann::basic_json<> TableStatistics::json() const {
   if (lookups == 0) {
     return "unused";
   }
 
-  nlohmann::json j = Statistics::json();
+  auto j = Statistics::json();
   j["num_buckets"] = numBuckets;
   j["memory_MiB"] = getMemoryMiB();
   j["num_entries"] = numEntries;

--- a/src/dd/statistics/UniqueTableStatistics.cpp
+++ b/src/dd/statistics/UniqueTableStatistics.cpp
@@ -1,8 +1,9 @@
 #include "dd/statistics/UniqueTableStatistics.hpp"
 
-#include "nlohmann/json.hpp"
+#include "dd/statistics/TableStatistics.hpp"
 
 #include <algorithm>
+#include <nlohmann/json.hpp>
 
 namespace dd {
 
@@ -16,12 +17,12 @@ void UniqueTableStatistics::reset() noexcept {
   numActiveEntries = 0U;
 }
 
-nlohmann::json UniqueTableStatistics::json() const {
+nlohmann::basic_json<> UniqueTableStatistics::json() const {
   if (lookups == 0) {
     return "unused";
   }
 
-  nlohmann::json j = TableStatistics::json();
+  auto j = TableStatistics::json();
   j["num_active_entries"] = numActiveEntries;
   j["peak_num_active_entries"] = peakNumActiveEntries;
   j["gc_runs"] = gcRuns;

--- a/src/ecc/Ecc.cpp
+++ b/src/ecc/Ecc.cpp
@@ -1,5 +1,10 @@
 #include "ecc/Ecc.hpp"
 
+#include "QuantumComputation.hpp"
+
+#include <cstddef>
+#include <memory>
+
 namespace ecc {
 void Ecc::initMappedCircuit() {
   qcOriginal->stripIdleQubits(true, false);

--- a/src/ecc/Q18Surface.cpp
+++ b/src/ecc/Q18Surface.cpp
@@ -1,4 +1,16 @@
 #include "ecc/Q18Surface.hpp"
+
+#include "ecc/Ecc.hpp"
+#include "operations/Control.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
+
+#include <array>
+#include <cstddef>
+#include <map>
+#include <stdexcept>
+#include <utility>
 namespace ecc {
 void Q18Surface::measureAndCorrect() {
   if (isDecoded) {

--- a/src/ecc/Q3Shor.cpp
+++ b/src/ecc/Q3Shor.cpp
@@ -1,4 +1,16 @@
 #include "ecc/Q3Shor.hpp"
+
+#include "Definitions.hpp"
+#include "ecc/Ecc.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
+#include "operations/StandardOperation.hpp"
+
+#include <array>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
 namespace ecc {
 void Q3Shor::writeEncoding() {
   if (!isDecoded || !gatesWritten) {

--- a/src/ecc/Q5Laflamme.cpp
+++ b/src/ecc/Q5Laflamme.cpp
@@ -1,4 +1,15 @@
 #include "ecc/Q5Laflamme.hpp"
+
+#include "ecc/Ecc.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
+#include "operations/StandardOperation.hpp"
+
+#include <array>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
 namespace ecc {
 void Q5Laflamme::writeEncoding() {
   Ecc::writeEncoding();

--- a/src/ecc/Q7Steane.cpp
+++ b/src/ecc/Q7Steane.cpp
@@ -1,4 +1,17 @@
 #include "ecc/Q7Steane.hpp"
+
+#include "Definitions.hpp"
+#include "ecc/Ecc.hpp"
+#include "operations/Control.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
+#include "operations/StandardOperation.hpp"
+
+#include <array>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
 namespace ecc {
 void Q7Steane::writeEncoding() {
   if (!isDecoded) {

--- a/src/ecc/Q9Shor.cpp
+++ b/src/ecc/Q9Shor.cpp
@@ -1,4 +1,16 @@
 #include "ecc/Q9Shor.hpp"
+
+#include "ecc/Ecc.hpp"
+#include "operations/Control.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
+#include "operations/StandardOperation.hpp"
+
+#include <array>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
 namespace ecc {
 void Q9Shor::writeEncoding() {
   if (!isDecoded) {

--- a/src/ecc/Q9Surface.cpp
+++ b/src/ecc/Q9Surface.cpp
@@ -1,4 +1,15 @@
 #include "ecc/Q9Surface.hpp"
+
+#include "ecc/Ecc.hpp"
+#include "operations/Control.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
+
+#include <array>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
 namespace ecc {
 void Q9Surface::measureAndCorrect() {
   if (isDecoded) {

--- a/src/operations/ClassicControlledOperation.cpp
+++ b/src/operations/ClassicControlledOperation.cpp
@@ -1,5 +1,10 @@
 #include "operations/ClassicControlledOperation.hpp"
 
+#include "Definitions.hpp"
+
+#include <ostream>
+#include <string>
+
 namespace qc {
 
 std::string toString(const ComparisonKind& kind) {

--- a/src/operations/Expression.cpp
+++ b/src/operations/Expression.cpp
@@ -1,5 +1,8 @@
 #include "operations/Expression.hpp"
 
+#include <ostream>
+#include <string>
+
 namespace sym {
 
 Variable::Variable(const std::string& name) {

--- a/src/operations/NonUnitaryOperation.cpp
+++ b/src/operations/NonUnitaryOperation.cpp
@@ -6,9 +6,20 @@
 
 #include "operations/NonUnitaryOperation.hpp"
 
+#include "Definitions.hpp"
+#include "Permutation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
+
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <iomanip>
+#include <ostream>
+#include <set>
+#include <stdexcept>
 #include <utility>
+#include <vector>
 
 namespace qc {
 // Measurement constructor

--- a/src/operations/Operation.cpp
+++ b/src/operations/Operation.cpp
@@ -1,7 +1,18 @@
 #include "operations/Operation.hpp"
 
+#include "Definitions.hpp"
+#include "Permutation.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
+
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <ostream>
+#include <set>
+#include <vector>
 
 namespace qc {
 

--- a/src/operations/StandardOperation.cpp
+++ b/src/operations/StandardOperation.cpp
@@ -1,12 +1,21 @@
 #include "operations/StandardOperation.hpp"
 
-#include "operations/CompoundOperation.hpp"
+#include "Definitions.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
 
 #include <algorithm>
 #include <cassert>
-#include <numeric>
+#include <cmath>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <ostream>
 #include <sstream>
-#include <variant>
+#include <utility>
+#include <vector>
 
 namespace qc {
 /***

--- a/src/operations/SymbolicOperation.cpp
+++ b/src/operations/SymbolicOperation.cpp
@@ -1,9 +1,18 @@
 #include "operations/SymbolicOperation.hpp"
 
 #include "Definitions.hpp"
+#include "Permutation.hpp"
+#include "operations/Control.hpp"
+#include "operations/Expression.hpp"
+#include "operations/OpType.hpp"
 #include "operations/StandardOperation.hpp"
 
+#include <cstddef>
+#include <cstdlib>
+#include <ostream>
+#include <utility>
 #include <variant>
+#include <vector>
 
 namespace qc {
 
@@ -152,7 +161,7 @@ OpType SymbolicOperation::parseU1([[maybe_unused]] const Symbolic& lambda) {
 }
 
 void SymbolicOperation::checkSymbolicUgate() {
-  // NOLINTBEGIN(bugprone-unchecked-optional-access) - we check for this
+  // NOLINTBEGIN(bugprone-unchecked-optional-access) – we check for this
   if (type == P) {
     if (!isSymbolicParameter(0)) {
       type = StandardOperation::parseU1(parameter[0]);
@@ -316,7 +325,7 @@ StandardOperation SymbolicOperation::getInstantiatedOperation(
 }
 
 // Instantiates this Operation
-// Afterwards casting to StandardOperation can be done if assignment is total
+// Afterward casting to StandardOperation can be done if assignment is total
 void SymbolicOperation::instantiate(const VariableAssignment& assignment) {
   for (std::size_t i = 0; i < symbolicParameter.size(); ++i) {
     parameter.at(i) = getInstantiation(getParameter(i), assignment);
@@ -327,7 +336,7 @@ void SymbolicOperation::instantiate(const VariableAssignment& assignment) {
 
 void SymbolicOperation::negateSymbolicParameter(const std::size_t index) {
   if (isSymbolicParameter(index)) {
-    // NOLINTBEGIN(bugprone-unchecked-optional-access) - we check for this
+    // NOLINTBEGIN(bugprone-unchecked-optional-access) – we check for this
     symbolicParameter.at(index) = -symbolicParameter.at(index).value();
     // NOLINTEND(bugprone-unchecked-optional-access)
   } else {
@@ -338,7 +347,7 @@ void SymbolicOperation::negateSymbolicParameter(const std::size_t index) {
 void SymbolicOperation::addToSymbolicParameter(const std::size_t index,
                                                const fp value) {
   if (isSymbolicParameter(index)) {
-    // NOLINTBEGIN(bugprone-unchecked-optional-access) - we check for this
+    // NOLINTBEGIN(bugprone-unchecked-optional-access) – we check for this
     symbolicParameter.at(index) = symbolicParameter.at(index).value() + value;
     // NOLINTEND(bugprone-unchecked-optional-access)
   } else {

--- a/src/parsers/GRCSParser.cpp
+++ b/src/parsers/GRCSParser.cpp
@@ -1,4 +1,10 @@
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
+
+#include <cstddef>
+#include <istream>
+#include <sstream>
+#include <string>
 
 void qc::QuantumComputation::importGRCS(std::istream& is) {
   std::size_t nq{};

--- a/src/parsers/QASM3Parser.cpp
+++ b/src/parsers/QASM3Parser.cpp
@@ -1,5 +1,13 @@
+#include "Definitions.hpp"
+#include "Permutation.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/ClassicControlledOperation.hpp"
+#include "operations/CompoundOperation.hpp"
+#include "operations/Control.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
 #include "operations/Operation.hpp"
+#include "operations/StandardOperation.hpp"
 #include "parsers/qasm3_parser/Exception.hpp"
 #include "parsers/qasm3_parser/Gate.hpp"
 #include "parsers/qasm3_parser/InstVisitor.hpp"
@@ -7,11 +15,21 @@
 #include "parsers/qasm3_parser/Parser.hpp"
 #include "parsers/qasm3_parser/Statement.hpp"
 #include "parsers/qasm3_parser/StdGates.hpp"
+#include "parsers/qasm3_parser/Types.hpp"
 #include "parsers/qasm3_parser/passes/ConstEvalPass.hpp"
 #include "parsers/qasm3_parser/passes/TypeCheckPass.hpp"
 
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 using namespace qasm3;
 using const_eval::ConstEvalPass;
@@ -23,10 +41,10 @@ class OpenQasm3Parser final : public InstVisitor {
   ConstEvalPass constEvalPass;
   TypeCheckPass typeCheckPass;
 
-  NestedEnvironment<std::shared_ptr<DeclarationStatement>> declarations{};
+  NestedEnvironment<std::shared_ptr<DeclarationStatement>> declarations;
   qc::QuantumComputation* qc{};
 
-  std::vector<std::unique_ptr<qc::Operation>> ops{};
+  std::vector<std::unique_ptr<qc::Operation>> ops;
 
   std::map<std::string, std::shared_ptr<Gate>> gates = STANDARD_GATES;
 
@@ -764,14 +782,15 @@ public:
     if (!ifStatement->thenStatements.empty()) {
       auto thenOps = translateBlockOperations(ifStatement->thenStatements);
       qc->emplace_back(std::make_unique<qc::ClassicControlledOperation>(
-          thenOps, creg->second, rhs->getUInt(), *comparisonKind));
+          std::move(thenOps), creg->second, rhs->getUInt(), *comparisonKind));
     }
     if (!ifStatement->elseStatements.empty()) {
       const auto invertedComparsionKind =
           qc::getInvertedComparsionKind(*comparisonKind);
       auto elseOps = translateBlockOperations(ifStatement->elseStatements);
       qc->emplace_back(std::make_unique<qc::ClassicControlledOperation>(
-          elseOps, creg->second, rhs->getUInt(), invertedComparsionKind));
+          std::move(elseOps), creg->second, rhs->getUInt(),
+          invertedComparsionKind));
     }
   }
 

--- a/src/parsers/QCParser.cpp
+++ b/src/parsers/QCParser.cpp
@@ -1,6 +1,19 @@
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
+#include "operations/StandardOperation.hpp"
 
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <ios>
+#include <istream>
+#include <limits>
+#include <map>
 #include <regex>
+#include <string>
+#include <vector>
 
 void qc::QuantumComputation::importQC(std::istream& is) {
   std::map<std::string, Qubit> varMap{};

--- a/src/parsers/RealParser.cpp
+++ b/src/parsers/RealParser.cpp
@@ -1,6 +1,21 @@
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
+#include "operations/StandardOperation.hpp"
 
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <ios>
+#include <iostream>
+#include <istream>
+#include <limits>
+#include <map>
 #include <regex>
+#include <sstream>
+#include <string>
+#include <vector>
 
 void qc::QuantumComputation::importReal(std::istream& is) {
   auto line = readRealHeader(is);

--- a/src/parsers/TFCParser.cpp
+++ b/src/parsers/TFCParser.cpp
@@ -1,6 +1,17 @@
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
 
+#include <algorithm>
+#include <cstddef>
+#include <ios>
+#include <istream>
+#include <limits>
+#include <map>
 #include <regex>
+#include <string>
+#include <vector>
 
 void qc::QuantumComputation::importTFC(std::istream& is) {
   std::map<std::string, Qubit> varMap{};

--- a/src/parsers/qasm3_parser/Parser.cpp
+++ b/src/parsers/qasm3_parser/Parser.cpp
@@ -1,8 +1,21 @@
 #include "parsers/qasm3_parser/Parser.hpp"
 
+#include "Definitions.hpp"
+#include "Permutation.hpp"
+#include "parsers/qasm3_parser/Statement.hpp"
 #include "parsers/qasm3_parser/StdGates.hpp"
+#include "parsers/qasm3_parser/Token.hpp"
+#include "parsers/qasm3_parser/Types.hpp"
 
+#include <fstream>
+#include <istream>
+#include <memory>
 #include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace qasm3 {
 void Parser::scan() {

--- a/src/parsers/qasm3_parser/Scanner.cpp
+++ b/src/parsers/qasm3_parser/Scanner.cpp
@@ -1,5 +1,7 @@
 #include "parsers/qasm3_parser/Scanner.hpp"
 
+#include "parsers/qasm3_parser/Token.hpp"
+
 #include <cstdint>
 #include <istream>
 #include <optional>

--- a/src/parsers/qasm3_parser/Statement.cpp
+++ b/src/parsers/qasm3_parser/Statement.cpp
@@ -1,5 +1,9 @@
 #include "parsers/qasm3_parser/Statement.hpp"
 
+#include "operations/ClassicControlledOperation.hpp"
+
+#include <optional>
+
 namespace qasm3 {
 
 std::optional<qc::ComparisonKind> getComparisonKind(BinaryExpression::Op op) {

--- a/src/parsers/qasm3_parser/passes/ConstEvalPass.cpp
+++ b/src/parsers/qasm3_parser/passes/ConstEvalPass.cpp
@@ -1,8 +1,18 @@
 #include "parsers/qasm3_parser/passes/ConstEvalPass.hpp"
 
 #include "parsers/qasm3_parser/Exception.hpp"
+#include "parsers/qasm3_parser/Statement.hpp"
+#include "parsers/qasm3_parser/Types.hpp"
 
+#include <algorithm>
+#include <cassert>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
 
 namespace qasm3::const_eval {
 namespace {

--- a/src/parsers/qasm3_parser/passes/TypeCheckPass.cpp
+++ b/src/parsers/qasm3_parser/passes/TypeCheckPass.cpp
@@ -4,15 +4,18 @@
 #include "parsers/qasm3_parser/Statement.hpp"
 #include "parsers/qasm3_parser/Types.hpp"
 
+#include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
-#include <vector>
+#include <memory>
+#include <sstream>
 
 namespace qasm3::type_checking {
 
 void TypeCheckPass::visitGateStatement(
     std::shared_ptr<GateDeclaration> gateStatement) {
-  // we save the current environment to restore it afterwards
+  // we save the current environment to restore it afterward
   const auto oldEnv = env;
 
   for (const auto& param : gateStatement->parameters->identifiers) {

--- a/src/python/operations/register_classic_controlled_operation.cpp
+++ b/src/python/operations/register_classic_controlled_operation.cpp
@@ -1,5 +1,11 @@
+#include "Definitions.hpp"
 #include "operations/ClassicControlledOperation.hpp"
+#include "operations/Operation.hpp"
 #include "python/pybind11.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <sstream>
 
 namespace mqt {
 
@@ -10,9 +16,8 @@ void registerClassicControlledOperation(py::module& m) {
   ccop.def(
       py::init([](qc::Operation* operation, qc::ClassicalRegister controlReg,
                   std::uint64_t expectedVal) {
-        auto op = operation->clone();
-        return std::make_unique<qc::ClassicControlledOperation>(op, controlReg,
-                                                                expectedVal);
+        return std::make_unique<qc::ClassicControlledOperation>(
+            operation->clone(), controlReg, expectedVal);
       }),
       "operation"_a, "control_register"_a, "expected_value"_a = 1U);
   ccop.def_property_readonly("operation",

--- a/src/python/operations/register_compound_operation.cpp
+++ b/src/python/operations/register_compound_operation.cpp
@@ -1,5 +1,12 @@
 #include "operations/CompoundOperation.hpp"
+#include "operations/Operation.hpp"
 #include "python/pybind11.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <sstream>
+#include <utility>
+#include <vector>
 
 namespace mqt {
 

--- a/src/python/operations/register_control.cpp
+++ b/src/python/operations/register_control.cpp
@@ -1,6 +1,8 @@
+#include "Definitions.hpp"
 #include "operations/Control.hpp"
-#include "pybind11/operators.h"
 #include "python/pybind11.hpp"
+
+#include <pybind11/operators.h>
 
 namespace mqt {
 

--- a/src/python/operations/register_non_unitary_operation.cpp
+++ b/src/python/operations/register_non_unitary_operation.cpp
@@ -1,5 +1,11 @@
+#include "Definitions.hpp"
 #include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
 #include "python/pybind11.hpp"
+
+#include <sstream>
+#include <vector>
 
 namespace mqt {
 

--- a/src/python/operations/register_operation.cpp
+++ b/src/python/operations/register_operation.cpp
@@ -1,6 +1,8 @@
+#include "operations/Control.hpp"
 #include "operations/Operation.hpp"
-#include "pybind11/operators.h"
 #include "python/pybind11.hpp"
+
+#include <sstream>
 
 namespace mqt {
 

--- a/src/python/operations/register_optype.cpp
+++ b/src/python/operations/register_optype.cpp
@@ -1,6 +1,8 @@
 #include "operations/OpType.hpp"
 #include "python/pybind11.hpp"
 
+#include <string>
+
 namespace mqt {
 
 void registerOptype(py::module& m) {

--- a/src/python/operations/register_standard_operation.cpp
+++ b/src/python/operations/register_standard_operation.cpp
@@ -1,5 +1,12 @@
+#include "Definitions.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
 #include "operations/StandardOperation.hpp"
 #include "python/pybind11.hpp"
+
+#include <sstream>
+#include <vector>
 
 namespace mqt {
 

--- a/src/python/operations/register_symbolic_operation.cpp
+++ b/src/python/operations/register_symbolic_operation.cpp
@@ -1,5 +1,12 @@
+#include "Definitions.hpp"
+#include "operations/Control.hpp"
+#include "operations/Expression.hpp"
+#include "operations/OpType.hpp"
+#include "operations/StandardOperation.hpp"
 #include "operations/SymbolicOperation.hpp"
 #include "python/pybind11.hpp"
+
+#include <vector>
 
 namespace mqt {
 

--- a/src/python/qiskit/QuantumCircuit.cpp
+++ b/src/python/qiskit/QuantumCircuit.cpp
@@ -1,5 +1,24 @@
 #include "python/qiskit/QuantumCircuit.hpp"
 
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
+#include "operations/Control.hpp"
+#include "operations/Expression.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/StandardOperation.hpp"
+#include "operations/SymbolicOperation.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <regex>
+#include <set>
+#include <sstream>
+#include <tuple>
+#include <vector>
+
 void qc::qiskit::QuantumCircuit::import(qc::QuantumComputation& qc,
                                         const py::object& circ) {
   qc.reset();

--- a/src/python/register_permutation.cpp
+++ b/src/python/register_permutation.cpp
@@ -1,6 +1,10 @@
+#include "Definitions.hpp"
 #include "Permutation.hpp"
-#include "pybind11/operators.h"
+#include "operations/Control.hpp"
 #include "python/pybind11.hpp"
+
+#include <pybind11/operators.h>
+#include <sstream>
 
 namespace mqt {
 

--- a/src/python/register_quantum_computation.cpp
+++ b/src/python/register_quantum_computation.cpp
@@ -1,9 +1,18 @@
 #include "Definitions.hpp"
 #include "QuantumComputation.hpp"
 #include "operations/Control.hpp"
+#include "operations/Expression.hpp"
 #include "operations/OpType.hpp"
 #include "operations/Operation.hpp"
 #include "python/pybind11.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace mqt {
 

--- a/src/python/symbolic/register_expression.cpp
+++ b/src/python/symbolic/register_expression.cpp
@@ -1,8 +1,10 @@
 #include "operations/Expression.hpp"
-#include "pybind11/operators.h"
 #include "python/pybind11.hpp"
 
+#include <cstddef>
+#include <pybind11/operators.h>
 #include <sstream>
+#include <vector>
 
 namespace mqt {
 

--- a/src/python/symbolic/register_term.cpp
+++ b/src/python/symbolic/register_term.cpp
@@ -1,7 +1,7 @@
 #include "operations/Expression.hpp"
-#include "pybind11/operators.h"
 #include "python/pybind11.hpp"
 
+#include <pybind11/operators.h>
 #include <sstream>
 
 namespace mqt {

--- a/src/python/symbolic/register_variable.cpp
+++ b/src/python/symbolic/register_variable.cpp
@@ -2,6 +2,7 @@
 #include "python/pybind11.hpp"
 
 #include <pybind11/operators.h>
+#include <string>
 
 namespace mqt {
 

--- a/src/zx/FunctionalityConstruction.cpp
+++ b/src/zx/FunctionalityConstruction.cpp
@@ -1,11 +1,17 @@
 #include "zx/FunctionalityConstruction.hpp"
 
+#include "Permutation.hpp"
+#include "QuantumComputation.hpp"
+#include "operations/CompoundOperation.hpp"
+#include "operations/Expression.hpp"
 #include "operations/OpType.hpp"
+#include "operations/SymbolicOperation.hpp"
 #include "zx/Rational.hpp"
 #include "zx/ZXDefinitions.hpp"
 #include "zx/ZXDiagram.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <variant>

--- a/src/zx/Rational.cpp
+++ b/src/zx/Rational.cpp
@@ -2,6 +2,10 @@
 
 #include "zx/ZXDefinitions.hpp"
 
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+
 namespace zx {
 
 PiRational::PiRational(double val) {

--- a/src/zx/Simplify.cpp
+++ b/src/zx/Simplify.cpp
@@ -1,9 +1,10 @@
 #include "zx/Simplify.hpp"
 
 #include "zx/Rules.hpp"
+#include "zx/ZXDefinitions.hpp"
 #include "zx/ZXDiagram.hpp"
 
-#include <utility>
+#include <cstddef>
 
 namespace zx {
 

--- a/src/zx/Utils.cpp
+++ b/src/zx/Utils.cpp
@@ -1,6 +1,9 @@
 #include "zx/Utils.hpp"
 
-#include <cstddef>
+#include "zx/ZXDefinitions.hpp"
+
+#include <optional>
+#include <vector>
 
 namespace zx {
 Vertices::VertexIterator::VertexIterator(

--- a/src/zx/ZXDiagram.cpp
+++ b/src/zx/ZXDiagram.cpp
@@ -6,8 +6,12 @@
 #include "zx/ZXDefinitions.hpp"
 
 #include <algorithm>
+#include <cstddef>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 namespace zx {
 
@@ -159,9 +163,8 @@ void ZXDiagram::removeVertex(const Vertex toRemove) {
 std::vector<Edge>::iterator ZXDiagram::getEdgePtr(const Vertex from,
                                                   const Vertex to) {
   auto& incident = edges[from];
-  auto edge = std::find_if(incident.begin(), incident.end(),
-                           [&](const auto& e) { return e.to == to; });
-  return edge;
+  return std::find_if(incident.begin(), incident.end(),
+                      [&](const auto& e) { return e.to == to; });
 }
 
 [[nodiscard]] std::vector<std::pair<Vertex, const VertexData&>>

--- a/test/algorithms/eval_dynamic_circuits.cpp
+++ b/test/algorithms/eval_dynamic_circuits.cpp
@@ -1,15 +1,23 @@
 #include "CircuitOptimizer.hpp"
+#include "Definitions.hpp"
 #include "algorithms/BernsteinVazirani.hpp"
 #include "algorithms/QFT.hpp"
 #include "algorithms/QPE.hpp"
 #include "dd/Benchmark.hpp"
-#include "dd/Export.hpp"
+#include "dd/DDDefinitions.hpp"
+#include "dd/Operations.hpp"
+#include "dd/Package.hpp"
+#include "dd/Package_fwd.hpp"
 #include "dd/Simulation.hpp"
 
-#include "gtest/gtest.h"
 #include <bitset>
 #include <chrono>
-#include <iomanip>
+#include <cstdlib>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -18,7 +26,7 @@ protected:
   std::size_t precision{};
   qc::fp theta{};
   std::size_t expectedResult{};
-  std::string expectedResultRepresentation{};
+  std::string expectedResultRepresentation;
   std::unique_ptr<qc::QuantumComputation> qpe;
   std::unique_ptr<qc::QuantumComputation> iqpe;
   std::size_t qpeNgates{};
@@ -67,7 +75,7 @@ protected:
     }
     std::stringstream ss{};
     for (auto i = static_cast<int>(precision - 1); i >= 0; --i) {
-      if ((expectedResult & (1ULL << i)) != 0) {
+      if ((expectedResult & (1ULL << static_cast<std::size_t>(i))) != 0) {
         ss << 1;
       } else {
         ss << 0;
@@ -210,9 +218,9 @@ protected:
   std::size_t precision{};
   dd::fp theta{};
   std::size_t expectedResult{};
-  std::string expectedResultRepresentation{};
+  std::string expectedResultRepresentation;
   std::size_t secondExpectedResult{};
-  std::string secondExpectedResultRepresentation{};
+  std::string secondExpectedResultRepresentation;
   std::unique_ptr<qc::QuantumComputation> qpe;
   std::unique_ptr<qc::QuantumComputation> iqpe;
   std::size_t qpeNgates{};

--- a/test/algorithms/test_bernsteinvazirani.cpp
+++ b/test/algorithms/test_bernsteinvazirani.cpp
@@ -1,9 +1,16 @@
 #include "CircuitOptimizer.hpp"
+#include "Definitions.hpp"
 #include "algorithms/BernsteinVazirani.hpp"
 #include "dd/Benchmark.hpp"
+#include "dd/Package.hpp"
 #include "dd/Simulation.hpp"
 
-#include "gtest/gtest.h"
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
+#include <sstream>
 
 class BernsteinVazirani : public testing::TestWithParam<std::uint64_t> {
 protected:
@@ -120,7 +127,7 @@ TEST_P(BernsteinVazirani, DynamicEquivalenceSimulation) {
   auto dbv = qc::BernsteinVazirani(s, true);
 
   // transform dynamic circuits by first eliminating reset operations and
-  // afterwards deferring measurements
+  // afterward deferring measurements
   qc::CircuitOptimizer::eliminateResets(dbv);
   qc::CircuitOptimizer::deferMeasurements(dbv);
   qc::CircuitOptimizer::backpropagateOutputPermutation(dbv);

--- a/test/algorithms/test_entanglement.cpp
+++ b/test/algorithms/test_entanglement.cpp
@@ -1,8 +1,14 @@
 #include "algorithms/Entanglement.hpp"
 #include "dd/Benchmark.hpp"
-#include "dd/Simulation.hpp"
+#include "dd/DDDefinitions.hpp"
+#include "dd/Package.hpp"
+#include "dd/Package_fwd.hpp"
 
-#include "gtest/gtest.h"
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 
 class Entanglement : public testing::TestWithParam<std::size_t> {

--- a/test/algorithms/test_grcs.cpp
+++ b/test/algorithms/test_grcs.cpp
@@ -1,7 +1,12 @@
 #include "algorithms/GoogleRandomCircuitSampling.hpp"
+#include "dd/Package.hpp"
 #include "dd/Simulation.hpp"
 
-#include "gtest/gtest.h"
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
+#include <optional>
 
 class GRCS : public testing::Test {
 protected:

--- a/test/algorithms/test_grover.cpp
+++ b/test/algorithms/test_grover.cpp
@@ -1,9 +1,19 @@
 #include "algorithms/Grover.hpp"
 #include "dd/Benchmark.hpp"
+#include "dd/DDDefinitions.hpp"
+#include "dd/Package.hpp"
+#include "dd/Package_fwd.hpp"
 
-#include "gtest/gtest.h"
+#include <algorithm>
 #include <cmath>
+#include <complex>
+#include <cstddef>
+#include <gtest/gtest.h>
 #include <iostream>
+#include <memory>
+#include <sstream>
+#include <tuple>
+#include <utility>
 
 class Grover
     : public testing::TestWithParam<std::tuple<std::size_t, std::size_t>> {

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -1,10 +1,19 @@
 #include "algorithms/QFT.hpp"
 #include "dd/Benchmark.hpp"
+#include "dd/DDDefinitions.hpp"
 #include "dd/FunctionalityConstruction.hpp"
+#include "dd/Package.hpp"
+#include "dd/RealNumber.hpp"
 
-#include "gtest/gtest.h"
+#include <cassert>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
 #include <iostream>
+#include <memory>
+#include <sstream>
+#include <utility>
 
 class QFT : public testing::TestWithParam<std::size_t> {
 protected:

--- a/test/algorithms/test_qpe.cpp
+++ b/test/algorithms/test_qpe.cpp
@@ -1,12 +1,24 @@
 #include "CircuitOptimizer.hpp"
+#include "Definitions.hpp"
 #include "algorithms/QPE.hpp"
 #include "dd/Benchmark.hpp"
+#include "dd/DDDefinitions.hpp"
 #include "dd/FunctionalityConstruction.hpp"
+#include "dd/Package.hpp"
+#include "dd/Package_fwd.hpp"
 #include "dd/Simulation.hpp"
 
-#include "gtest/gtest.h"
 #include <bitset>
-#include <iomanip>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <set>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -17,9 +29,9 @@ protected:
   qc::fp theta{};
   bool exactlyRepresentable{};
   std::uint64_t expectedResult{};
-  std::string expectedResultRepresentation{};
+  std::string expectedResultRepresentation;
   std::uint64_t secondExpectedResult{};
-  std::string secondExpectedResultRepresentation{};
+  std::string secondExpectedResultRepresentation;
 
   void TearDown() override {}
   void SetUp() override {

--- a/test/algorithms/test_random_clifford.cpp
+++ b/test/algorithms/test_random_clifford.cpp
@@ -1,8 +1,10 @@
 #include "algorithms/RandomCliffordCircuit.hpp"
 #include "dd/Benchmark.hpp"
 
-#include "gtest/gtest.h"
-#include <string>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <sstream>
 
 class RandomClifford : public testing::TestWithParam<std::size_t> {
 protected:

--- a/test/algorithms/test_wstate.cpp
+++ b/test/algorithms/test_wstate.cpp
@@ -1,8 +1,18 @@
+#include "Definitions.hpp"
 #include "algorithms/WState.hpp"
 #include "dd/Benchmark.hpp"
+#include "dd/ComplexNumbers.hpp"
+#include "dd/DDDefinitions.hpp"
+#include "dd/Package.hpp"
+#include "dd/RealNumber.hpp"
 
-#include "gtest/gtest.h"
+#include <cstddef>
+#include <gtest/gtest.h>
 #include <iostream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 class WState : public testing::TestWithParam<qc::Qubit> {};

--- a/test/datastructures/test_directed_acyclic_graph.cpp
+++ b/test/datastructures/test_directed_acyclic_graph.cpp
@@ -1,6 +1,7 @@
 #include "datastructures/DirectedAcyclicGraph.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+#include <vector>
 
 namespace qc {
 TEST(DirectedAcyclicGraph, Reachable) {

--- a/test/datastructures/test_directed_graph.cpp
+++ b/test/datastructures/test_directed_graph.cpp
@@ -1,6 +1,7 @@
 #include "datastructures/DirectedGraph.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+#include <tuple>
 
 namespace qc {
 TEST(DirectedGraph, Numbered) {

--- a/test/datastructures/test_disjoint_set.cpp
+++ b/test/datastructures/test_disjoint_set.cpp
@@ -1,6 +1,7 @@
 #include "datastructures/DisjointSet.hpp"
 
 #include <gtest/gtest.h>
+#include <vector>
 
 namespace qc {
 TEST(DisjointSet, FindSet) {

--- a/test/datastructures/test_layer.cpp
+++ b/test/datastructures/test_layer.cpp
@@ -4,13 +4,10 @@
 #include "operations/OpType.hpp"
 #include "operations/StandardOperation.hpp"
 
-#include "gtest/gtest.h"
-#include <fstream>
-#include <iostream>
+#include <algorithm>
+#include <gtest/gtest.h>
 #include <memory>
-#include <random>
-#include <sstream>
-#include <string>
+#include <tuple>
 #include <vector>
 
 namespace qc {

--- a/test/datastructures/test_undirected_graph.cpp
+++ b/test/datastructures/test_undirected_graph.cpp
@@ -1,6 +1,7 @@
 #include "datastructures/UndirectedGraph.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+#include <tuple>
 
 namespace qc {
 TEST(UndirectedGraph, Numbered) {

--- a/test/dd/test_complex.cpp
+++ b/test/dd/test_complex.cpp
@@ -1,18 +1,25 @@
 #include "dd/ComplexNumbers.hpp"
 #include "dd/DDDefinitions.hpp"
 #include "dd/Export.hpp"
+#include "dd/MemoryManager.hpp"
+#include "dd/RealNumber.hpp"
+#include "dd/RealNumberUniqueTable.hpp"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include <array>
+#include <cstddef>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <iomanip>
+#include <iostream>
 #include <limits>
+#include <sstream>
 #include <vector>
 
 using namespace dd;
 
 class CNTest : public testing::Test {
 protected:
-  MemoryManager<RealNumber> mm{};
+  MemoryManager<RealNumber> mm;
   RealNumberUniqueTable ut{mm};
   ComplexNumbers cn{ut};
 };
@@ -243,7 +250,7 @@ TEST(DDComplexTest, NumberPrintingFormattedFractions) {
   std::stringstream ss{};
 
   ComplexValue::printFormatted(ss, 0.0, false);
-  EXPECT_STREQ(ss.str().c_str(), "+0");
+  EXPECT_STREQ(ss.str().c_str(), "0");
   ss.str("");
   ComplexValue::printFormatted(ss, -0.0, false);
   EXPECT_STREQ(ss.str().c_str(), "-0");

--- a/test/dd/test_dd_functionality.cpp
+++ b/test/dd/test_dd_functionality.cpp
@@ -1,10 +1,26 @@
 #include "CircuitOptimizer.hpp"
+#include "Definitions.hpp"
+#include "Permutation.hpp"
 #include "QuantumComputation.hpp"
+#include "dd/DDDefinitions.hpp"
 #include "dd/FunctionalityConstruction.hpp"
+#include "dd/Operations.hpp"
+#include "dd/Package.hpp"
 #include "dd/Simulation.hpp"
+#include "operations/Control.hpp"
+#include "operations/OpType.hpp"
+#include "operations/StandardOperation.hpp"
 
-#include "gtest/gtest.h"
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
 #include <random>
+#include <sstream>
+#include <string>
+#include <vector>
 
 using namespace qc;
 

--- a/test/dd/test_dd_noise_functionality.cpp
+++ b/test/dd/test_dd_noise_functionality.cpp
@@ -1,9 +1,23 @@
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
+#include "dd/DDDefinitions.hpp"
 #include "dd/DDpackageConfig.hpp"
 #include "dd/NoiseFunctionality.hpp"
 #include "dd/Operations.hpp"
+#include "dd/Package.hpp"
+#include "operations/OpType.hpp"
 
-#include "gtest/gtest.h"
+#include <algorithm>
+#include <bitset>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <functional>
+#include <gtest/gtest.h>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <utility>
 
 using namespace qc;
 
@@ -45,7 +59,7 @@ protected:
     qc.h(3);
   }
 
-  qc::QuantumComputation qc{};
+  qc::QuantumComputation qc;
   size_t stochRuns = 1000U;
 };
 
@@ -300,10 +314,9 @@ TEST_F(DDNoiseFunctionalityTest, testingUsedQubits) {
   EXPECT_TRUE(compoundOp.getUsedQubits().count(0));
   EXPECT_TRUE(compoundOp.getUsedQubits().count(1));
 
-  std::unique_ptr<qc::Operation> xOp =
-      std::make_unique<qc::StandardOperation>(0, qc::X);
-  auto classicalControlledOp =
-      qc::ClassicControlledOperation(xOp, std::pair{0, nqubits}, 1U);
+  auto classicalControlledOp = qc::ClassicControlledOperation(
+      std::make_unique<qc::StandardOperation>(0, qc::X), std::pair{0, nqubits},
+      1U);
   EXPECT_EQ(classicalControlledOp.getUsedQubits().size(), 1);
   EXPECT_TRUE(classicalControlledOp.getUsedQubits().count(0) == 1U);
 }

--- a/test/dd/test_edge_functionality.cpp
+++ b/test/dd/test_edge_functionality.cpp
@@ -1,6 +1,15 @@
+#include "dd/DDDefinitions.hpp"
+#include "dd/GateMatrixDefinitions.hpp"
+#include "dd/Node.hpp"
 #include "dd/Package.hpp"
+#include "dd/RealNumber.hpp"
 
-#include "gtest/gtest.h"
+#include <cmath>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <iomanip>
+#include <memory>
+#include <sstream>
 
 namespace dd {
 

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -1,17 +1,32 @@
+#include "Definitions.hpp"
 #include "dd/DDDefinitions.hpp"
+#include "dd/DDpackageConfig.hpp"
 #include "dd/Export.hpp"
 #include "dd/GateMatrixDefinitions.hpp"
+#include "dd/MemoryManager.hpp"
+#include "dd/Node.hpp"
 #include "dd/Package.hpp"
+#include "dd/RealNumber.hpp"
 #include "dd/statistics/PackageStatistics.hpp"
 #include "operations/Control.hpp"
 
-#include "gtest/gtest.h"
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
 #include <iomanip>
+#include <iostream>
+#include <limits>
 #include <memory>
 #include <random>
 #include <sstream>
 #include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 using namespace qc::literals;
@@ -1358,39 +1373,12 @@ TEST(DDPackageTest, CloseToIdentityWithGarbageInTheMiddle) {
                                     {true, false, true}, false));
 }
 
-struct DensityMatrixSimulatorDDPackageConfigTesting
-    : public dd::DDPackageConfig {
-  static constexpr std::size_t UT_DM_NBUCKET = 65536U;
-  static constexpr std::size_t UT_DM_INITIAL_ALLOCATION_SIZE = 4096U;
-
-  static constexpr std::size_t CT_DM_DM_MULT_NBUCKET = 16384U;
-  static constexpr std::size_t CT_DM_ADD_NBUCKET = 16384U;
-  static constexpr std::size_t CT_DM_NOISE_NBUCKET = 4096U;
-
-  static constexpr std::size_t UT_MAT_NBUCKET = 16384U;
-  static constexpr std::size_t CT_MAT_ADD_NBUCKET = 4096U;
-  static constexpr std::size_t CT_VEC_ADD_NBUCKET = 4096U;
-  static constexpr std::size_t CT_MAT_TRANS_NBUCKET = 4096U;
-  static constexpr std::size_t CT_MAT_CONJ_TRANS_NBUCKET = 4096U;
-
-  static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET = 1U;
-  static constexpr std::size_t CT_MAT_VEC_MULT_NBUCKET = 1U;
-  static constexpr std::size_t UT_VEC_NBUCKET = 1U;
-  static constexpr std::size_t UT_VEC_INITIAL_ALLOCATION_SIZE = 1U;
-  static constexpr std::size_t UT_MAT_INITIAL_ALLOCATION_SIZE = 1U;
-  static constexpr std::size_t CT_VEC_KRON_NBUCKET = 1U;
-  static constexpr std::size_t CT_MAT_KRON_NBUCKET = 1U;
-  static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 1U;
-  static constexpr std::size_t STOCHASTIC_CACHE_OPS = 1U;
-};
-
-using DensityMatrixPackageTest =
-    dd::Package<DensityMatrixSimulatorDDPackageConfigTesting>;
-
 TEST(DDPackageTest, dNodeMultiply) {
   // Multiply dNode with mNode (MxMxM)
   const auto nrQubits = 3U;
-  auto dd = std::make_unique<DensityMatrixPackageTest>(nrQubits);
+  auto dd =
+      std::make_unique<dd::Package<dd::DensityMatrixSimulatorDDPackageConfig>>(
+          nrQubits);
   // Make zero density matrix
   auto state = dd->makeZeroDensityOperator(dd->qubits());
   dd->incRef(state);
@@ -1437,7 +1425,9 @@ TEST(DDPackageTest, dNodeMultiply) {
 TEST(DDPackageTest, dNodeMultiply2) {
   // Multiply dNode with mNode (MxMxM)
   const auto nrQubits = 3U;
-  auto dd = std::make_unique<DensityMatrixPackageTest>(nrQubits);
+  auto dd =
+      std::make_unique<dd::Package<dd::DensityMatrixSimulatorDDPackageConfig>>(
+          nrQubits);
   // Make zero density matrix
   auto state = dd->makeZeroDensityOperator(dd->qubits());
   dd->incRef(state);
@@ -1477,7 +1467,9 @@ TEST(DDPackageTest, dNodeMultiply2) {
 TEST(DDPackageTest, dNodeMulCache1) {
   // Make caching test with dNodes
   const auto nrQubits = 1U;
-  auto dd = std::make_unique<DensityMatrixPackageTest>(nrQubits);
+  auto dd =
+      std::make_unique<dd::Package<dd::DensityMatrixSimulatorDDPackageConfig>>(
+          nrQubits);
   // Make zero density matrix
   auto state = dd->makeZeroDensityOperator(nrQubits);
   dd->incRef(state);
@@ -1559,15 +1551,10 @@ TEST(DDPackageTest, calCulpDistance) {
   EXPECT_EQ(tmp1, 0);
 }
 
-struct StochPackageConfig : public dd::DDPackageConfig {
-  static constexpr std::size_t STOCHASTIC_CACHE_OPS = 36;
-};
-
-using stochPackage = dd::Package<StochPackageConfig>;
-
 TEST(DDPackageTest, dStochCache) {
   const auto nrQubits = 4U;
-  auto dd = std::make_unique<stochPackage>(nrQubits);
+  auto dd = std::make_unique<
+      dd::Package<dd::StochasticNoiseSimulatorDDPackageConfig>>(nrQubits);
 
   std::vector<dd::mEdge> operations = {};
   operations.emplace_back(dd->makeGateDD(dd::X_MAT, 0));

--- a/test/na/test_nacomputation.cpp
+++ b/test/na/test_nacomputation.cpp
@@ -1,3 +1,4 @@
+#include "Definitions.hpp"
 #include "na/NAComputation.hpp"
 #include "na/NADefinitions.hpp"
 #include "na/operations/NAGlobalOperation.hpp"
@@ -5,9 +6,10 @@
 #include "na/operations/NAShuttlingOperation.hpp"
 #include "operations/OpType.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+#include <memory>
 #include <sstream>
-#include <string>
+#include <vector>
 
 namespace na {
 TEST(NAComputation, General) {

--- a/test/na/test_nadefinitions.cpp
+++ b/test/na/test_nadefinitions.cpp
@@ -2,7 +2,7 @@
 #include "na/NADefinitions.hpp"
 #include "operations/OpType.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <sstream>
 #include <string>
 #include <unordered_map>

--- a/test/na/test_naoperation.cpp
+++ b/test/na/test_naoperation.cpp
@@ -1,9 +1,13 @@
+#include "Definitions.hpp"
+#include "na/NADefinitions.hpp"
 #include "na/operations/NAGlobalOperation.hpp"
 #include "na/operations/NALocalOperation.hpp"
-#include "na/operations/NAOperation.hpp"
 #include "na/operations/NAShuttlingOperation.hpp"
+#include "operations/OpType.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+#include <memory>
+#include <vector>
 
 namespace na {
 TEST(NAOperation, ShuttlingOperation) {

--- a/test/test_operation.cpp
+++ b/test/test_operation.cpp
@@ -1,11 +1,14 @@
-#include "operations/ClassicControlledOperation.hpp"
+#include "Definitions.hpp"
 #include "operations/CompoundOperation.hpp"
+#include "operations/Expression.hpp"
 #include "operations/NonUnitaryOperation.hpp"
-#include "operations/Operation.hpp"
+#include "operations/OpType.hpp"
 #include "operations/StandardOperation.hpp"
 #include "operations/SymbolicOperation.hpp"
 
 #include <gtest/gtest.h>
+#include <sstream>
+#include <vector>
 
 TEST(StandardOperation, CommutesAtQubit) {
   const qc::StandardOperation op1(0, 1, qc::OpType::RY, std::vector{qc::PI_2});

--- a/test/unittests/circuit_optimizer/test_backpropagate_output_permutation.cpp
+++ b/test/unittests/circuit_optimizer/test_backpropagate_output_permutation.cpp
@@ -1,8 +1,7 @@
 #include "CircuitOptimizer.hpp"
 #include "QuantumComputation.hpp"
 
-#include "gtest/gtest.h"
-#include <iostream>
+#include <gtest/gtest.h>
 
 namespace qc {
 TEST(BackpropagateOutputPermutation, FullySpecified) {

--- a/test/unittests/circuit_optimizer/test_collect_blocks.cpp
+++ b/test/unittests/circuit_optimizer/test_collect_blocks.cpp
@@ -1,7 +1,7 @@
 #include "CircuitOptimizer.hpp"
 #include "QuantumComputation.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <iostream>
 
 namespace qc {

--- a/test/unittests/circuit_optimizer/test_defer_measurements.cpp
+++ b/test/unittests/circuit_optimizer/test_defer_measurements.cpp
@@ -4,7 +4,7 @@
 #include "operations/NonUnitaryOperation.hpp"
 #include "operations/OpType.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <iostream>
 
 namespace qc {

--- a/test/unittests/circuit_optimizer/test_elide_permutations.cpp
+++ b/test/unittests/circuit_optimizer/test_elide_permutations.cpp
@@ -1,7 +1,8 @@
 #include "CircuitOptimizer.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/OpType.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <iostream>
 
 namespace qc {
@@ -85,8 +86,8 @@ TEST(ElidePermutations, compoundOperation) {
   EXPECT_TRUE(qc.front()->isCompoundOperation());
   auto& compound = dynamic_cast<CompoundOperation&>(*qc.front());
   EXPECT_EQ(compound.size(), 2);
-  auto reference = StandardOperation(0_pc, 1, X);
-  auto reference2 = StandardOperation(1_pc, 0, X);
+  auto reference = StandardOperation(0, 1, X);
+  auto reference2 = StandardOperation(1, 0, X);
   EXPECT_EQ(*compound.getOps().front(), reference);
   EXPECT_EQ(*compound.getOps().back(), reference2);
   EXPECT_EQ(*qc.back(), reference);
@@ -108,7 +109,7 @@ TEST(ElidePermutations, compoundOperation2) {
 
   EXPECT_EQ(qc.size(), 2);
   EXPECT_TRUE(qc.front()->isStandardOperation());
-  auto reference = StandardOperation(1_pc, 0, X);
+  auto reference = StandardOperation(1, 0, X);
   EXPECT_EQ(*qc.front(), reference);
   EXPECT_TRUE(qc.back()->isStandardOperation());
   EXPECT_EQ(*qc.back(), reference);
@@ -129,7 +130,7 @@ TEST(ElidePermutations, compoundOperation3) {
 
   EXPECT_EQ(qc.size(), 1);
   EXPECT_TRUE(qc.front()->isStandardOperation());
-  auto reference = StandardOperation(1_pc, 0, X);
+  auto reference = StandardOperation(1, 0, X);
   EXPECT_EQ(*qc.front(), reference);
   EXPECT_EQ(qc.outputPermutation[0], 1);
   EXPECT_EQ(qc.outputPermutation[1], 0);

--- a/test/unittests/circuit_optimizer/test_reorder_operations.cpp
+++ b/test/unittests/circuit_optimizer/test_reorder_operations.cpp
@@ -1,7 +1,7 @@
 #include "CircuitOptimizer.hpp"
 #include "QuantumComputation.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <iostream>
 
 namespace qc {

--- a/test/unittests/test_ecc_functionality.cpp
+++ b/test/unittests/test_ecc_functionality.cpp
@@ -1,5 +1,7 @@
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
+#include "dd/Package.hpp"
 #include "dd/Simulation.hpp"
-#include "ecc/Ecc.hpp"
 #include "ecc/Id.hpp"
 #include "ecc/Q18Surface.hpp"
 #include "ecc/Q3Shor.hpp"
@@ -7,9 +9,17 @@
 #include "ecc/Q7Steane.hpp"
 #include "ecc/Q9Shor.hpp"
 #include "ecc/Q9Surface.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
 
-#include "gtest/gtest.h"
-#include <random>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
+#include <vector>
 
 using namespace qc;
 
@@ -162,7 +172,7 @@ protected:
       const std::shared_ptr<qc::QuantumComputation>& qcOriginal,
       const std::shared_ptr<qc::QuantumComputation>& qcMapped,
       bool simulateWithErrors, const std::vector<Qubit>& dataQubits = {},
-      std::size_t insertErrorAfterNGates = 0) {
+      const std::size_t insertErrorAfterNGates = 0) {
     if (!simulateWithErrors) {
       return simulateAndVerifyResults(qcOriginal, qcMapped);
     }
@@ -234,7 +244,7 @@ protected:
 };
 
 TEST_F(DDECCFunctionalityTest, testIdEcc) {
-  size_t insertNoiseAfterNQubits = 1;
+  const size_t insertNoiseAfterNQubits = 1;
 
   std::vector<TestCase> const circuitsExpectToPass = {
       {createIdentityCircuit, false, insertNoiseAfterNQubits},
@@ -252,7 +262,7 @@ TEST_F(DDECCFunctionalityTest, testIdEcc) {
 }
 
 TEST_F(DDECCFunctionalityTest, testQ3Shor) {
-  size_t insertNoiseAfterNQubits = 4;
+  const size_t insertNoiseAfterNQubits = 4;
 
   std::vector<TestCase> const circuitsExpectToPass = {
       {createIdentityCircuit, true, insertNoiseAfterNQubits},
@@ -274,7 +284,7 @@ TEST_F(DDECCFunctionalityTest, testQ3Shor) {
 }
 
 TEST_F(DDECCFunctionalityTest, testQ5LaflammeEcc) {
-  size_t insertNoiseAfterNQubits = 61;
+  const size_t insertNoiseAfterNQubits = 61;
 
   std::vector<TestCase> const circuitsExpectToPass = {
       {createIdentityCircuit, true, insertNoiseAfterNQubits},
@@ -296,7 +306,7 @@ TEST_F(DDECCFunctionalityTest, testQ5LaflammeEcc) {
 }
 
 TEST_F(DDECCFunctionalityTest, testQ7Steane) {
-  size_t insertNoiseAfterNQubits = 57;
+  const size_t insertNoiseAfterNQubits = 57;
 
   std::vector<TestCase> const circuitsExpectToPass = {
       {createIdentityCircuit, true, insertNoiseAfterNQubits},
@@ -314,7 +324,7 @@ TEST_F(DDECCFunctionalityTest, testQ7Steane) {
 }
 
 TEST_F(DDECCFunctionalityTest, testQ9ShorEcc) {
-  size_t insertNoiseAfterNQubits = 7;
+  const size_t insertNoiseAfterNQubits = 7;
 
   std::vector<TestCase> const circuitsExpectToPass = {
       {createIdentityCircuit, true, insertNoiseAfterNQubits},
@@ -338,7 +348,7 @@ TEST_F(DDECCFunctionalityTest, testQ9ShorEcc) {
 }
 
 TEST_F(DDECCFunctionalityTest, testQ9SurfaceEcc) {
-  size_t insertNoiseAfterNQubits = 55;
+  const size_t insertNoiseAfterNQubits = 55;
 
   std::vector<TestCase> const circuitsExpectToPass = {
       {createIdentityCircuit, true, insertNoiseAfterNQubits},
@@ -363,7 +373,7 @@ TEST_F(DDECCFunctionalityTest, testQ9SurfaceEcc) {
 }
 
 TEST_F(DDECCFunctionalityTest, testQ18SurfaceEcc) {
-  size_t insertNoiseAfterNQubits = 47;
+  const size_t insertNoiseAfterNQubits = 47;
 
   std::vector<TestCase> const circuitsExpectToPass{
       {createIdentityCircuit, false, insertNoiseAfterNQubits},

--- a/test/unittests/test_io.cpp
+++ b/test/unittests/test_io.cpp
@@ -1,10 +1,25 @@
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/CompoundOperation.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
+#include "operations/StandardOperation.hpp"
 #include "parsers/qasm3_parser/Exception.hpp"
 
-#include "gtest/gtest.h"
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstddef>
 #include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
 #include <iostream>
+#include <iterator>
+#include <memory>
+#include <sstream>
 #include <string>
+#include <tuple>
+#include <vector>
 
 class IO : public testing::TestWithParam<std::tuple<std::string, qc::Format>> {
 protected:
@@ -13,7 +28,7 @@ protected:
   void SetUp() override { qc = std::make_unique<qc::QuantumComputation>(); }
 
   std::size_t nqubits = 0;
-  unsigned int seed = 0;
+  std::size_t seed = 0;
   std::string output = "tmp.txt";
   std::string output2 = "tmp2.txt";
   std::string output3 = "tmp";

--- a/test/unittests/test_qasm3_parser.cpp
+++ b/test/unittests/test_qasm3_parser.cpp
@@ -9,9 +9,9 @@
 #include "parsers/qasm3_parser/Token.hpp"
 #include "parsers/qasm3_parser/passes/ConstEvalPass.hpp"
 
-#include "gtest/gtest.h"
 #include <cmath>
 #include <cstddef>
+#include <gtest/gtest.h>
 #include <memory>
 #include <sstream>
 #include <string>

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1,10 +1,28 @@
 #include "CircuitOptimizer.hpp"
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
 #include "algorithms/RandomCliffordCircuit.hpp"
+#include "operations/ClassicControlledOperation.hpp"
+#include "operations/CompoundOperation.hpp"
+#include "operations/Control.hpp"
+#include "operations/Expression.hpp"
+#include "operations/NonUnitaryOperation.hpp"
+#include "operations/OpType.hpp"
 
-#include "gtest/gtest.h"
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <gtest/gtest.h>
 #include <iostream>
+#include <memory>
+#include <optional>
 #include <random>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 using namespace qc;
 
@@ -1151,15 +1169,15 @@ TEST_F(QFRFunctionality, OperationEquality) {
       std::make_unique<StandardOperation>(0, qc::X);
   std::unique_ptr<Operation> xp2 =
       std::make_unique<StandardOperation>(0, qc::X);
-  const auto classic0 =
-      ClassicControlledOperation(xp0, controlRegister0, expectedValue0);
-  const auto classic1 =
-      ClassicControlledOperation(xp1, controlRegister0, expectedValue1);
-  const auto classic2 =
-      ClassicControlledOperation(xp2, controlRegister1, expectedValue0);
+  const auto classic0 = ClassicControlledOperation(
+      std::move(xp0), controlRegister0, expectedValue0);
+  const auto classic1 = ClassicControlledOperation(
+      std::move(xp1), controlRegister0, expectedValue1);
+  const auto classic2 = ClassicControlledOperation(
+      std::move(xp2), controlRegister1, expectedValue0);
   std::unique_ptr<Operation> zp = std::make_unique<StandardOperation>(0, qc::Z);
-  const auto classic3 =
-      ClassicControlledOperation(zp, controlRegister0, expectedValue0);
+  const auto classic3 = ClassicControlledOperation(
+      std::move(zp), controlRegister0, expectedValue0);
   EXPECT_FALSE(classic0.equals(x));
   EXPECT_NE(classic0, x);
   EXPECT_TRUE(classic0.equals(classic0));
@@ -1588,7 +1606,8 @@ TEST_F(QFRFunctionality, addControlClassicControlledOperation) {
   std::unique_ptr<Operation> xp = std::make_unique<StandardOperation>(0, qc::X);
   const auto controlRegister = qc::QuantumRegister{0, 1U};
   const auto expectedValue = 0U;
-  auto op = ClassicControlledOperation(xp, controlRegister, expectedValue);
+  auto op =
+      ClassicControlledOperation(std::move(xp), controlRegister, expectedValue);
 
   op.addControl(1);
   op.addControl(2);
@@ -1653,7 +1672,7 @@ TEST_F(QFRFunctionality, addControlTwice) {
   EXPECT_THROW(op->addControl(control), QFRException);
 
   auto classicControlledOp =
-      ClassicControlledOperation(op, qc::QuantumRegister{0, 1U}, 0U);
+      ClassicControlledOperation(std::move(op), qc::QuantumRegister{0, 1U}, 0U);
   EXPECT_THROW(classicControlledOp.addControl(control), QFRException);
 
   auto symbolicOp = SymbolicOperation(Targets{1}, OpType::X);
@@ -1670,7 +1689,7 @@ TEST_F(QFRFunctionality, addTargetAsControl) {
   EXPECT_THROW(op->addControl(control), QFRException);
 
   auto classicControlledOp =
-      ClassicControlledOperation(op, qc::QuantumRegister{0, 1U}, 0U);
+      ClassicControlledOperation(std::move(op), qc::QuantumRegister{0, 1U}, 0U);
   EXPECT_THROW(classicControlledOp.addControl(control), QFRException);
 
   auto symbolicOp = SymbolicOperation(Targets{1}, OpType::X);

--- a/test/unittests/test_symbolic.cpp
+++ b/test/unittests/test_symbolic.cpp
@@ -1,8 +1,10 @@
+#include "Definitions.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/Control.hpp"
 #include "operations/Expression.hpp"
-#include "operations/SymbolicOperation.hpp"
+#include "operations/OpType.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <memory>
 
 using namespace qc;

--- a/test/zx/test_expression.cpp
+++ b/test/zx/test_expression.cpp
@@ -1,10 +1,11 @@
 #include "operations/Expression.hpp"
 #include "zx/Rational.hpp"
 #include "zx/Utils.hpp"
+#include "zx/ZXDefinitions.hpp"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+#include <iostream>
 #include <stdexcept>
-#include <variant>
 
 class ExpressionTest : public ::testing::Test {
 public:

--- a/test/zx/test_rational.cpp
+++ b/test/zx/test_rational.cpp
@@ -1,8 +1,7 @@
 #include "zx/Rational.hpp"
 #include "zx/ZXDefinitions.hpp"
 
-#include "gtest/gtest.h"
-#include <iostream>
+#include <gtest/gtest.h>
 
 class RationalTest : public ::testing::Test {};
 

--- a/test/zx/test_simplify.cpp
+++ b/test/zx/test_simplify.cpp
@@ -1,7 +1,11 @@
+#include "operations/Expression.hpp"
 #include "zx/Simplify.hpp"
+#include "zx/ZXDefinitions.hpp"
 #include "zx/ZXDiagram.hpp"
 
-#include "gtest/gtest.h"
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <vector>
 
 using zx::fullReduceApproximate;
 

--- a/test/zx/test_zx.cpp
+++ b/test/zx/test_zx.cpp
@@ -3,8 +3,13 @@
 #include "zx/ZXDefinitions.hpp"
 #include "zx/ZXDiagram.hpp"
 
-#include "gtest/gtest.h"
 #include <array>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <optional>
+#include <sstream>
+#include <utility>
 
 class ZXDiagramTest : public ::testing::Test {
 public:

--- a/test/zx/test_zx_functionality.cpp
+++ b/test/zx/test_zx_functionality.cpp
@@ -1,13 +1,22 @@
+#include "Definitions.hpp"
+#include "Permutation.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/CompoundOperation.hpp"
+#include "operations/Expression.hpp"
+#include "operations/OpType.hpp"
+#include "operations/StandardOperation.hpp"
 #include "zx/FunctionalityConstruction.hpp"
 #include "zx/Simplify.hpp"
 #include "zx/ZXDefinitions.hpp"
 #include "zx/ZXDiagram.hpp"
 
-#include "gtest/gtest.h"
 #include <array>
-#include <iostream>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <memory>
 #include <sstream>
+#include <string>
+#include <utility>
 
 class ZXFunctionalityTest : public ::testing::Test {
 public:


### PR DESCRIPTION
## Description

This PR aims to fix all the new warnings that were introduced in clang-tidy versions 18, which have been enabled with the switch to the `mqt-workflows@v1.0.0`.

The first commit, which should later be reverted, just triggers a full clang-tidy run on the whole codebase.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
