### PR TITLE
🧱 switch to new coverage collection workflows

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -25,11 +25,9 @@ flag_management:
       paths:
         - "include"
         - "src"
-      after_n_builds: 1
     - name: python
       paths:
         - "src/mqt/**/*.py"
-      after_n_builds: 11
       statuses:
         - type: project
           threshold: 0.5%

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.0.0
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.0.1
 
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,9 @@ jobs:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.0.0
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@improve-coverage-configuration
     with:
       cmake-args-macos: -DMQT_CORE_WITH_GMP=ON
-    secrets:
-      token: ${{ secrets.CODECOV_TOKEN }}
 
   cpp-linter:
     name: 🇨‌ Lint
@@ -38,9 +36,7 @@ jobs:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.0.0
-    secrets:
-      token: ${{ secrets.CODECOV_TOKEN }}
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@improve-coverage-configuration
 
   code-ql:
     name: 📝 CodeQL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.0.0
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.0.1
 
   cpp-tests:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@improve-coverage-configuration
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.0.1
     with:
       cmake-args-macos: -DMQT_CORE_WITH_GMP=ON
 
@@ -28,7 +28,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.0.0
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.0.1
     with:
       cmake-args: -DBUILD_MQT_CORE_BENCHMARKS=ON
 
@@ -36,13 +36,13 @@ jobs:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@improve-coverage-configuration
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.0.1
 
   code-ql:
     name: 📝 CodeQL
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.0.0
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.0.1
 
   required-checks-pass: # This job does nothing and is only used for branch protection
     name: 🚦 Check


### PR DESCRIPTION
## Description

This PR switches to the new coverage collection workflow proposed in https://github.com/cda-tum/mqt-workflows/pull/2. The workflow now aggregates all coverage reports on the GitHub side before uploading to Codecov. It also uses Codecov's OIDC instead of TOKEN upload.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
