### PR TITLE
🚸 Better QASM parser exceptions

### DIFF
--- a/include/mqt-core/parsers/qasm3_parser/Exception.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/Exception.hpp
@@ -13,6 +13,7 @@ class CompilerError final : public std::exception {
 public:
   std::string message;
   std::shared_ptr<DebugInfo> debugInfo;
+  mutable std::string cachedMessage;
 
   CompilerError(std::string msg, std::shared_ptr<DebugInfo> debug)
       : message(std::move(msg)), debugInfo(std::move(debug)) {}
@@ -31,27 +32,44 @@ public:
 
     return ss.str();
   }
+
+  [[nodiscard]] const char* what() const noexcept override {
+    cachedMessage = toString();
+    return cachedMessage.c_str();
+  }
 };
 } // namespace qasm3
 
 class ConstEvalError final : public std::exception {
 public:
   std::string message;
+  mutable std::string cachedMessage;
 
   explicit ConstEvalError(std::string msg) : message(std::move(msg)) {}
 
   [[nodiscard]] std::string toString() const {
     return "Constant Evaluation: " + message;
   }
+
+  [[nodiscard]] const char* what() const noexcept override {
+    cachedMessage = toString();
+    return cachedMessage.c_str();
+  }
 };
 
 class TypeCheckError final : public std::exception {
 public:
   std::string message;
+  mutable std::string cachedMessage;
 
   explicit TypeCheckError(std::string msg) : message(std::move(msg)) {}
 
   [[nodiscard]] std::string toString() const {
     return "Type Check Error: " + message;
+  }
+
+  [[nodiscard]] const char* what() const noexcept override {
+    cachedMessage = toString();
+    return cachedMessage.c_str();
   }
 };

--- a/include/mqt-core/parsers/qasm3_parser/Parser.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/Parser.hpp
@@ -71,8 +71,6 @@ class Parser {
   std::shared_ptr<DebugInfo> includeDebugInfo{nullptr};
 
   [[noreturn]] void error(const Token& token, const std::string& msg) {
-    std::cerr << "Error at line " << token.line << ", column " << token.col
-              << ": " << msg << '\n';
     throw CompilerError(msg, makeDebugInfo(token));
   }
 

--- a/include/mqt-core/parsers/qasm3_parser/passes/ConstEvalPass.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/passes/ConstEvalPass.hpp
@@ -123,7 +123,7 @@ public:
     try {
       statement.accept(this);
     } catch (const ConstEvalError& e) {
-      throw CompilerError(e.toString(), statement.debugInfo);
+      throw CompilerError(e.what(), statement.debugInfo);
     }
   }
 

--- a/include/mqt-core/parsers/qasm3_parser/passes/TypeCheckPass.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/passes/TypeCheckPass.hpp
@@ -78,7 +78,7 @@ public:
       statement.accept(this);
 
       if (hasError) {
-        throw CompilerError("Type check failed.", statement.debugInfo);
+        throw TypeCheckError("Type check failed.");
       }
     } catch (const TypeCheckError& e) {
       throw CompilerError(e.what(), statement.debugInfo);

--- a/include/mqt-core/parsers/qasm3_parser/passes/TypeCheckPass.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/passes/TypeCheckPass.hpp
@@ -81,7 +81,7 @@ public:
         throw CompilerError("Type check failed.", statement.debugInfo);
       }
     } catch (const TypeCheckError& e) {
-      throw CompilerError(e.toString(), statement.debugInfo);
+      throw CompilerError(e.what(), statement.debugInfo);
     }
   }
 

--- a/src/parsers/QASM3Parser.cpp
+++ b/src/parsers/QASM3Parser.cpp
@@ -179,7 +179,7 @@ public:
         typeCheckPass.processStatement(*statement);
         statement->accept(this);
       } catch (CompilerError& e) {
-        std::cerr << e.toString() << '\n';
+        std::cerr << e.what() << '\n';
         throw;
       }
     }

--- a/test/unittests/test_qasm3_parser.cpp
+++ b/test/unittests/test_qasm3_parser.cpp
@@ -989,7 +989,7 @@ TEST_F(Qasm3ParserTest, ImportQasmAssignmentUnknownIdentifier) {
         try {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
           throw;
         }
       },
@@ -1007,7 +1007,7 @@ TEST_F(Qasm3ParserTest, ImportQasmAssignmentConstVar) {
         try {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
           throw;
         }
       },
@@ -1325,7 +1325,7 @@ TEST_F(Qasm3ParserTest, ImportQasmTypeMismatchAssignment) {
         try {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
           throw;
         }
       },
@@ -1341,7 +1341,7 @@ TEST_F(Qasm3ParserTest, ImportQasmTypeMismatchBinaryExpr) {
         try {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
           throw;
         }
       },
@@ -1373,7 +1373,7 @@ TEST_F(Qasm3ParserTest, ImportQasmUnaryTypeMismatchLogicalNot) {
         try {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
           throw;
         }
       },
@@ -1389,7 +1389,7 @@ TEST_F(Qasm3ParserTest, ImportQasmUnaryTypeMismatchBitwiseNot) {
         try {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
           throw;
         }
       },
@@ -1404,7 +1404,7 @@ TEST_F(Qasm3ParserTest, ImportQasmBinaryTypeMismatch) {
         try {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
           throw;
         }
       },
@@ -1420,7 +1420,7 @@ TEST_F(Qasm3ParserTest, ImportQasmAssignmentIndexType) {
         try {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
           throw;
         }
       },
@@ -1435,7 +1435,7 @@ TEST_F(Qasm3ParserTest, ImportQasmUnknownIdentifier) {
         try {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
           throw;
         }
       },
@@ -1450,7 +1450,7 @@ TEST_F(Qasm3ParserTest, ImportQasmUnknownQubit) {
         try {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
           throw;
         }
       },
@@ -1465,7 +1465,7 @@ TEST_F(Qasm3ParserTest, ImportQasmNegativeTypeDesignator) {
         try {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
           throw;
         }
       },


### PR DESCRIPTION
## Description

This PR augments the QASM parser exceptions with a proper overload of the `std::exception::what()` method so that they print proper error messages when raised. This came up in the light of https://github.com/cda-tum/mqt-ddvis/issues/259

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
