### PR TITLE
Change namespace to na and extend Point class

### DIFF
--- a/include/mqt-core/na/NADefinitions.hpp
+++ b/include/mqt-core/na/NADefinitions.hpp
@@ -41,6 +41,26 @@ struct Point {
   [[nodiscard]] auto operator==(const Point& other) const -> bool {
     return x == other.x && y == other.y;
   }
+  [[maybe_unused]] [[nodiscard]] auto
+  getEuclidianDistance(const Point& c) const {
+    const auto delta = *this - c;
+    return delta.length();
+  }
+
+  [[maybe_unused]] [[nodiscard]] std::int64_t
+  getManhattanDistanceX(const Point& c) const {
+    if (x > c.x) {
+      return x - c.x;
+    }
+    return c.x - x;
+  }
+  [[maybe_unused]] [[nodiscard]] std::int64_t
+  getManhattanDistanceY(const Point& c) const {
+    if (y > c.y) {
+      return y - c.y;
+    }
+    return c.y - y;
+  }
 };
 /// More specific operation type including the number of control qubits
 struct FullOpType {

--- a/include/mqt-core/operations/AodOperation.hpp
+++ b/include/mqt-core/operations/AodOperation.hpp
@@ -16,15 +16,15 @@
 #include <tuple>
 #include <vector>
 
-namespace qc {
+namespace na {
 
 enum class Dimension : std::uint8_t { X = 0, Y = 1 };
 struct SingleOperation {
   Dimension dir;
-  fp start;
-  fp end;
+  qc::fp start;
+  qc::fp end;
 
-  SingleOperation(Dimension dir, fp start, fp end)
+  SingleOperation(Dimension dir, qc::fp start, qc::fp end)
       : dir(dir), start(start), end(end) {}
 
   [[nodiscard]] std::string toQASMString() const {
@@ -33,7 +33,7 @@ struct SingleOperation {
     return ss.str();
   }
 };
-class AodOperation : public Operation {
+class AodOperation : public qc::Operation {
   std::vector<SingleOperation> operations;
 
   static std::vector<Dimension>
@@ -41,33 +41,37 @@ class AodOperation : public Operation {
 
 public:
   AodOperation() = default;
-  AodOperation(OpType type, std::vector<Qubit> targets,
+  AodOperation(qc::OpType type, std::vector<qc::Qubit> targets,
                const std::vector<Dimension>& dirs,
-               const std::vector<fp>& starts, const std::vector<fp>& ends);
-  AodOperation(OpType type, std::vector<Qubit> targets,
-               const std::vector<uint32_t>& dirs, const std::vector<fp>& starts,
-               const std::vector<fp>& ends);
-  AodOperation(const std::string& type, std::vector<Qubit> targets,
-               const std::vector<uint32_t>& dirs, const std::vector<fp>& starts,
-               const std::vector<fp>& ends);
-  AodOperation(OpType type, std::vector<Qubit> targets,
-               const std::vector<std::tuple<Dimension, fp, fp>>& operations);
-  AodOperation(OpType type, std::vector<Qubit> targets,
+               const std::vector<qc::fp>& starts,
+               const std::vector<qc::fp>& ends);
+  AodOperation(qc::OpType type, std::vector<qc::Qubit> targets,
+               const std::vector<uint32_t>& dirs,
+               const std::vector<qc::fp>& starts,
+               const std::vector<qc::fp>& ends);
+  AodOperation(const std::string& type, std::vector<qc::Qubit> targets,
+               const std::vector<uint32_t>& dirs,
+               const std::vector<qc::fp>& starts,
+               const std::vector<qc::fp>& ends);
+  AodOperation(
+      qc::OpType type, std::vector<qc::Qubit> targets,
+      const std::vector<std::tuple<Dimension, qc::fp, qc::fp>>& operations);
+  AodOperation(qc::OpType type, std::vector<qc::Qubit> targets,
                std::vector<SingleOperation> operations);
 
   [[nodiscard]] std::unique_ptr<Operation> clone() const override {
     return std::make_unique<AodOperation>(*this);
   }
 
-  void addControl([[maybe_unused]] Control c) override {}
+  void addControl([[maybe_unused]] qc::Control c) override {}
   void clearControls() override {}
-  void removeControl([[maybe_unused]] Control c) override {}
-  Controls::iterator removeControl(Controls::iterator it) override {
+  void removeControl([[maybe_unused]] qc::Control c) override {}
+  qc::Controls::iterator removeControl(qc::Controls::iterator it) override {
     return it;
   }
 
-  [[nodiscard]] std::vector<fp> getEnds(Dimension dir) const {
-    std::vector<fp> ends;
+  [[nodiscard]] std::vector<qc::fp> getEnds(Dimension dir) const {
+    std::vector<qc::fp> ends;
     for (const auto& op : operations) {
       if (op.dir == dir) {
         ends.push_back(op.end);
@@ -76,8 +80,8 @@ public:
     return ends;
   }
 
-  [[nodiscard]] std::vector<fp> getStarts(Dimension dir) const {
-    std::vector<fp> starts;
+  [[nodiscard]] std::vector<qc::fp> getStarts(Dimension dir) const {
+    std::vector<qc::fp> starts;
     for (const auto& op : operations) {
       if (op.dir == dir) {
         starts.push_back(op.start);
@@ -86,7 +90,7 @@ public:
     return starts;
   }
 
-  [[nodiscard]] fp getMaxDistance(Dimension dir) const {
+  [[nodiscard]] qc::fp getMaxDistance(Dimension dir) const {
     const auto distances = getDistances(dir);
     if (distances.empty()) {
       return 0;
@@ -94,8 +98,8 @@ public:
     return *std::max_element(distances.begin(), distances.end());
   }
 
-  [[nodiscard]] std::vector<fp> getDistances(Dimension dir) const {
-    std::vector<fp> params;
+  [[nodiscard]] std::vector<qc::fp> getDistances(Dimension dir) const {
+    std::vector<qc::fp> params;
     for (const auto& op : operations) {
       if (op.dir == dir) {
         params.push_back(std::abs(op.end - op.start));
@@ -104,10 +108,10 @@ public:
     return params;
   }
 
-  void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
-                    const RegisterNames& creg, size_t indent,
+  void dumpOpenQASM(std::ostream& of, const qc::RegisterNames& qreg,
+                    const qc::RegisterNames& creg, size_t indent,
                     bool openQASM3) const override;
 
   void invert() override;
 };
-} // namespace qc
+} // namespace na

--- a/src/operations/AodOperation.cpp
+++ b/src/operations/AodOperation.cpp
@@ -14,11 +14,11 @@
 #include <utility>
 #include <vector>
 
-namespace qc {
-AodOperation::AodOperation(OpType s, std::vector<Qubit> qubits,
+namespace na {
+AodOperation::AodOperation(qc::OpType s, std::vector<qc::Qubit> qubits,
                            const std::vector<uint32_t>& dirs,
-                           const std::vector<fp>& start,
-                           const std::vector<fp>& end)
+                           const std::vector<qc::fp>& start,
+                           const std::vector<qc::fp>& end)
     : AodOperation(s, std::move(qubits), convertToDimension(dirs), start, end) {
 }
 
@@ -31,10 +31,10 @@ AodOperation::convertToDimension(const std::vector<uint32_t>& dirs) {
   return dirsEnum;
 }
 
-AodOperation::AodOperation(const OpType s, std::vector<Qubit> qubits,
+AodOperation::AodOperation(const qc::OpType s, std::vector<qc::Qubit> qubits,
                            const std::vector<Dimension>& dirs,
-                           const std::vector<fp>& start,
-                           const std::vector<fp>& end) {
+                           const std::vector<qc::fp>& start,
+                           const std::vector<qc::fp>& end) {
   assert(dirs.size() == start.size() && start.size() == end.size());
   type = s;
   targets = std::move(qubits);
@@ -45,16 +45,17 @@ AodOperation::AodOperation(const OpType s, std::vector<Qubit> qubits,
   }
 }
 
-AodOperation::AodOperation(const std::string& type, std::vector<Qubit> targets,
+AodOperation::AodOperation(const std::string& type,
+                           std::vector<qc::Qubit> targets,
                            const std::vector<uint32_t>& dirs,
-                           const std::vector<fp>& start,
-                           const std::vector<fp>& end)
-    : AodOperation(OP_NAME_TO_TYPE.at(type), std::move(targets),
+                           const std::vector<qc::fp>& start,
+                           const std::vector<qc::fp>& end)
+    : AodOperation(qc::OP_NAME_TO_TYPE.at(type), std::move(targets),
                    convertToDimension(dirs), start, end) {}
 
 AodOperation::AodOperation(
-    OpType s, std::vector<Qubit> targets,
-    const std::vector<std::tuple<Dimension, fp, fp>>& operations) {
+    qc::OpType s, std::vector<qc::Qubit> targets,
+    const std::vector<std::tuple<Dimension, qc::fp, qc::fp>>& operations) {
   type = s;
   this->targets = std::move(targets);
   name = toString(type);
@@ -64,7 +65,7 @@ AodOperation::AodOperation(
   }
 }
 
-AodOperation::AodOperation(OpType s, std::vector<Qubit> t,
+AodOperation::AodOperation(qc::OpType s, std::vector<qc::Qubit> t,
                            std::vector<SingleOperation> ops)
     : operations(std::move(ops)) {
   type = s;
@@ -72,11 +73,11 @@ AodOperation::AodOperation(OpType s, std::vector<Qubit> t,
   name = toString(type);
 }
 
-void AodOperation::dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
-                                [[maybe_unused]] const RegisterNames& creg,
+void AodOperation::dumpOpenQASM(std::ostream& of, const qc::RegisterNames& qreg,
+                                [[maybe_unused]] const qc::RegisterNames& creg,
                                 size_t indent, bool /*openQASM3*/) const {
-  of << std::setprecision(std::numeric_limits<fp>::digits10);
-  of << std::string(indent * OUTPUT_INDENT_SIZE, ' ');
+  of << std::setprecision(std::numeric_limits<qc::fp>::digits10);
+  of << std::string(indent * qc::OUTPUT_INDENT_SIZE, ' ');
   of << name;
   // write AOD operations
   of << " (";
@@ -95,15 +96,15 @@ void AodOperation::dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
 }
 
 void AodOperation::invert() {
-  if (type == OpType::AodMove) {
+  if (type == qc::OpType::AodMove) {
     for (auto& op : operations) {
       std::swap(op.start, op.end);
     }
-  } else if (type == OpType::AodActivate) {
-    type = OpType::AodDeactivate;
-  } else if (type == OpType::AodDeactivate) {
-    type = OpType::AodActivate;
+  } else if (type == qc::OpType::AodActivate) {
+    type = qc::OpType::AodDeactivate;
+  } else if (type == qc::OpType::AodDeactivate) {
+    type = qc::OpType::AodActivate;
   }
 }
 
-} // namespace qc
+} // namespace na

--- a/test/na/test_nadefinitions.cpp
+++ b/test/na/test_nadefinitions.cpp
@@ -23,6 +23,16 @@ TEST(NADefinitions, Point) {
   EXPECT_EQ(Point(1, 2) + p, Point(0, 4));
 }
 
+TEST(NADefinitions, PointDistances) {
+  const Point p1(0, 0);
+  const Point p2(3, 4);
+  EXPECT_EQ(p1.getEuclidianDistance(p2), 5);
+  EXPECT_EQ(p1.getManhattanDistanceX(p2), 3);
+  EXPECT_EQ(p1.getManhattanDistanceY(p2), 4);
+  EXPECT_EQ(p2.getManhattanDistanceX(p1), 3);
+  EXPECT_EQ(p2.getManhattanDistanceY(p1), 4);
+}
+
 TEST(NADefinitions, OpType) {
   constexpr FullOpType t{qc::OpType::X, 1};
   EXPECT_EQ(t.type, qc::OpType::X);

--- a/test/test_operation.cpp
+++ b/test/test_operation.cpp
@@ -147,46 +147,46 @@ TEST(StandardOperation, Move) {
 
 TEST(AodOperation, Activate) {
   // activate at position 0, dimension X, start 0.0, end 1.0
-  const qc::AodOperation activate(qc::OpType::AodActivate, {0},
-                                  {qc::Dimension::X}, {0.0}, {1.0});
+  const na::AodOperation activate(qc::OpType::AodActivate, {0},
+                                  {na::Dimension::X}, {0.0}, {1.0});
   EXPECT_EQ(activate.getNqubits(), 1);
-  EXPECT_EQ(activate.getStarts(qc::Dimension::X).at(0), 0.0);
-  EXPECT_EQ(activate.getEnds(qc::Dimension::X).at(0), 1.0);
+  EXPECT_EQ(activate.getStarts(na::Dimension::X).at(0), 0.0);
+  EXPECT_EQ(activate.getEnds(na::Dimension::X).at(0), 1.0);
 }
 
 TEST(AodOperation, Deactivate) {
   // deactivate at position 0,1 dimension Y, start 0.0, end 1.0
-  const qc::AodOperation deactivate(qc::OpType::AodDeactivate, {0, 1},
-                                    {qc::Dimension::Y}, {0.0}, {1.0});
+  const na::AodOperation deactivate(qc::OpType::AodDeactivate, {0, 1},
+                                    {na::Dimension::Y}, {0.0}, {1.0});
   EXPECT_EQ(deactivate.getNqubits(), 2);
-  EXPECT_EQ(deactivate.getStarts(qc::Dimension::Y).at(0), 0.0);
-  EXPECT_EQ(deactivate.getEnds(qc::Dimension::Y).at(0), 1.0);
+  EXPECT_EQ(deactivate.getStarts(na::Dimension::Y).at(0), 0.0);
+  EXPECT_EQ(deactivate.getEnds(na::Dimension::Y).at(0), 1.0);
 }
 
 TEST(AodOperation, Move) {
   // move from 0,1 to 2,3 dimension X, start 0.0, end 1.0 and dimension Y,
   // start 1.0, end 2.0
-  const qc::AodOperation move(qc::OpType::AodMove, {0, 1},
-                              {qc::Dimension::X, qc::Dimension::Y}, {0.0, 1.0},
+  const na::AodOperation move(qc::OpType::AodMove, {0, 1},
+                              {na::Dimension::X, na::Dimension::Y}, {0.0, 1.0},
                               {1.0, 2.0});
   EXPECT_EQ(move.getNqubits(), 2);
-  EXPECT_EQ(move.getStarts(qc::Dimension::X).at(0), 0.0);
-  EXPECT_EQ(move.getEnds(qc::Dimension::X).at(0), 1.0);
-  EXPECT_EQ(move.getStarts(qc::Dimension::Y).at(0), 1.0);
-  EXPECT_EQ(move.getEnds(qc::Dimension::Y).at(0), 2.0);
+  EXPECT_EQ(move.getStarts(na::Dimension::X).at(0), 0.0);
+  EXPECT_EQ(move.getEnds(na::Dimension::X).at(0), 1.0);
+  EXPECT_EQ(move.getStarts(na::Dimension::Y).at(0), 1.0);
+  EXPECT_EQ(move.getEnds(na::Dimension::Y).at(0), 2.0);
 }
 
 TEST(AodOperation, Distances) {
-  const qc::AodOperation move(qc::OpType::AodMove, {0, 1},
-                              {qc::Dimension::X, qc::Dimension::Y}, {0.0, 1.0},
+  const na::AodOperation move(qc::OpType::AodMove, {0, 1},
+                              {na::Dimension::X, na::Dimension::Y}, {0.0, 1.0},
                               {1.0, 3.0});
-  EXPECT_EQ(move.getMaxDistance(qc::Dimension::X), 1.0);
-  EXPECT_EQ(move.getMaxDistance(qc::Dimension::Y), 2.0);
+  EXPECT_EQ(move.getMaxDistance(na::Dimension::X), 1.0);
+  EXPECT_EQ(move.getMaxDistance(na::Dimension::Y), 2.0);
 }
 
 TEST(AodOperation, Qasm) {
-  const qc::AodOperation move(qc::OpType::AodMove, {0, 1},
-                              {qc::Dimension::X, qc::Dimension::Y}, {0.0, 1.0},
+  const na::AodOperation move(qc::OpType::AodMove, {0, 1},
+                              {na::Dimension::X, na::Dimension::Y}, {0.0, 1.0},
                               {1.0, 3.0});
   std::stringstream ss;
   qc::RegisterNames qreg;
@@ -202,19 +202,19 @@ TEST(AodOperation, Constructors) {
   uint32_t const dir1 = 0;
   uint32_t const dir2 = 1;
 
-  const qc::AodOperation move(qc::OpType::AodMove, {0, 1}, {dir1, dir2},
+  const na::AodOperation move(qc::OpType::AodMove, {0, 1}, {dir1, dir2},
                               {0.0, 1.0}, {1.0, 3.0});
-  const qc::AodOperation move2("aod_move", {0, 1}, {dir1}, {0.0}, {1.0});
-  const qc::AodOperation move3(qc::OpType::AodMove, {0},
-                               {std::tuple{qc::Dimension::X, 0.0, 1.0}});
-  qc::SingleOperation const singleOp(qc::Dimension::X, 0.0, 1.0);
-  const qc::AodOperation move4(qc::OpType::AodMove, {0}, {singleOp});
+  const na::AodOperation move2("aod_move", {0, 1}, {dir1}, {0.0}, {1.0});
+  const na::AodOperation move3(qc::OpType::AodMove, {0},
+                               {std::tuple{na::Dimension::X, 0.0, 1.0}});
+  na::SingleOperation const singleOp(na::Dimension::X, 0.0, 1.0);
+  const na::AodOperation move4(qc::OpType::AodMove, {0}, {singleOp});
 
   EXPECT_EQ(0, 0);
 }
 
 TEST(AodOperation, OverrideMethods) {
-  qc::AodOperation move(qc::OpType::AodMove, {0}, {qc::Dimension::X}, {0.0},
+  na::AodOperation move(qc::OpType::AodMove, {0}, {na::Dimension::X}, {0.0},
                         {1.0});
   move.addControl(qc::Control(0, qc::Control::Type::Pos));
   move.removeControl(qc::Control(0, qc::Control::Type::Pos));
@@ -223,19 +223,19 @@ TEST(AodOperation, OverrideMethods) {
 }
 
 TEST(AodOperation, Invert) {
-  qc::AodOperation move(qc::OpType::AodMove, {0}, {qc::Dimension::X}, {0.0},
+  na::AodOperation move(qc::OpType::AodMove, {0}, {na::Dimension::X}, {0.0},
                         {1.0});
   move.invert();
-  EXPECT_EQ(move.getStarts(qc::Dimension::X).at(0), 1.0);
-  EXPECT_EQ(move.getEnds(qc::Dimension::X).at(0), 0.0);
+  EXPECT_EQ(move.getStarts(na::Dimension::X).at(0), 1.0);
+  EXPECT_EQ(move.getEnds(na::Dimension::X).at(0), 0.0);
 
-  qc::AodOperation activate(qc::OpType::AodActivate, {0}, {qc::Dimension::X},
+  na::AodOperation activate(qc::OpType::AodActivate, {0}, {na::Dimension::X},
                             {0.0}, {1.0});
   activate.invert();
   EXPECT_EQ(activate.getType(), qc::OpType::AodDeactivate);
 
-  qc::AodOperation deactivate(qc::OpType::AodDeactivate, {0},
-                              {qc::Dimension::X}, {0.0}, {1.0});
+  na::AodOperation deactivate(qc::OpType::AodDeactivate, {0},
+                              {na::Dimension::X}, {0.0}, {1.0});
   deactivate.invert();
   EXPECT_EQ(deactivate.getType(), qc::OpType::AodActivate);
 }


### PR DESCRIPTION
## Description

This changes the namespace of the recently introduced AodOperations to be consistent with QMAP.
It also adds two methods to the Point class of @ystade which are required by the Hybrid Mapper.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
