### PR TITLE
Moved symmetric matrix to datastructures

### DIFF
--- a/include/mqt-core/datastructures/SymmetricMatrix.hpp
+++ b/include/mqt-core/datastructures/SymmetricMatrix.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+/**
+ * @brief Symmetric matrix class with same number of rows and columns that
+ * allows access by row and column but uses less memory than a full matrix
+ */
+template <typename dataType> class SymmetricMatrix {
+private:
+  std::vector<std::vector<dataType>> data;
+  uint32_t size = 0;
+
+public:
+  // Constructors
+  SymmetricMatrix() = default;
+  explicit SymmetricMatrix(const uint32_t size) : size(size) {
+    data.resize(size);
+    for (uint32_t i = 0; i < size; ++i) {
+      data[i].resize(i + 1);
+    }
+  }
+
+  SymmetricMatrix(const uint32_t size, const dataType value) : size(size) {
+    data.resize(size);
+    for (uint32_t i = 0; i < size; ++i) {
+      data[i].resize(i + 1, value);
+    }
+  }
+
+  [[nodiscard]] dataType& operator()(const uint32_t row, const uint32_t col) {
+    if (row < col) {
+      return data[col][row];
+    }
+    return data[row][col];
+  }
+
+  [[nodiscard]] dataType operator()(const uint32_t row,
+                                    const uint32_t col) const {
+    if (row < col) {
+      return data[col][row];
+    }
+    return data[row][col];
+  }
+
+  [[nodiscard]] uint32_t getSize() const { return size; }
+};

--- a/include/mqt-core/datastructures/SymmetricMatrix.hpp
+++ b/include/mqt-core/datastructures/SymmetricMatrix.hpp
@@ -27,14 +27,14 @@ public:
     }
   }
 
-  [[nodiscard]] const T& operator()(const size_t row, const size_t col) {
+  [[nodiscard]] const T& operator()(const size_t row, const size_t col) const {
     if (row < col) {
       return data[col][row];
     }
     return data[row][col];
   }
 
-  [[nodiscard]] T operator()(const size_t row, const size_t col) const {
+  [[nodiscard]] T& operator()(const size_t row, const size_t col) {
     if (row < col) {
       return data[col][row];
     }

--- a/include/mqt-core/datastructures/SymmetricMatrix.hpp
+++ b/include/mqt-core/datastructures/SymmetricMatrix.hpp
@@ -1,47 +1,45 @@
 #pragma once
 
-#include <cstdint>
+#include <cstddef>
 #include <vector>
 /**
  * @brief Symmetric matrix class with same number of rows and columns that
  * allows access by row and column but uses less memory than a full matrix
  */
-template <typename dataType> class SymmetricMatrix {
+template <typename T> class SymmetricMatrix {
 private:
-  std::vector<std::vector<dataType>> data;
-  uint32_t size = 0;
+  std::vector<std::vector<T>> data;
 
 public:
   // Constructors
   SymmetricMatrix() = default;
-  explicit SymmetricMatrix(const uint32_t size) : size(size) {
+  explicit SymmetricMatrix(const size_t size) {
     data.resize(size);
-    for (uint32_t i = 0; i < size; ++i) {
+    for (size_t i = 0; i < size; ++i) {
       data[i].resize(i + 1);
     }
   }
 
-  SymmetricMatrix(const uint32_t size, const dataType value) : size(size) {
+  SymmetricMatrix(const size_t size, const T& value) {
     data.resize(size);
-    for (uint32_t i = 0; i < size; ++i) {
+    for (size_t i = 0; i < size; ++i) {
       data[i].resize(i + 1, value);
     }
   }
 
-  [[nodiscard]] dataType& operator()(const uint32_t row, const uint32_t col) {
+  [[nodiscard]] const T& operator()(const size_t row, const size_t col) {
     if (row < col) {
       return data[col][row];
     }
     return data[row][col];
   }
 
-  [[nodiscard]] dataType operator()(const uint32_t row,
-                                    const uint32_t col) const {
+  [[nodiscard]] T operator()(const size_t row, const size_t col) const {
     if (row < col) {
       return data[col][row];
     }
     return data[row][col];
   }
 
-  [[nodiscard]] uint32_t getSize() const { return size; }
+  [[nodiscard]] size_t size() const { return data.size(); }
 };

--- a/test/datastructures/test_symmetric_matrix.cpp
+++ b/test/datastructures/test_symmetric_matrix.cpp
@@ -32,4 +32,17 @@ TEST(SymmetricMatrix, DifferentDataTypes) {
   EXPECT_EQ(m3(0, 1), '1');
 }
 
+TEST(SymmetricMatrix, Assignment) {
+  SymmetricMatrix<int> m(3);
+  m(0, 1) = 1;
+  m(1, 2) = 2;
+  m(0, 2) = 3;
+  EXPECT_EQ(m(0, 1), 1);
+  EXPECT_EQ(m(1, 0), 1);
+  EXPECT_EQ(m(1, 2), 2);
+  EXPECT_EQ(m(2, 1), 2);
+  EXPECT_EQ(m(0, 2), 3);
+  EXPECT_EQ(m(2, 0), 3);
+}
+
 } // namespace qc

--- a/test/datastructures/test_symmetric_matrix.cpp
+++ b/test/datastructures/test_symmetric_matrix.cpp
@@ -1,0 +1,34 @@
+#include "datastructures/SymmetricMatrix.hpp"
+
+#include <gtest/gtest.h>
+#include <string>
+
+namespace qc {
+
+TEST(SymmetricMatrix, Constructors) {
+  SymmetricMatrix<int> const m(3);
+  EXPECT_EQ(m.getSize(), 3);
+  SymmetricMatrix<int> m2(3, 1);
+  EXPECT_EQ(m2.getSize(), 3);
+  for (unsigned i = 0; i < m2.getSize(); ++i) {
+    for (unsigned j = 0; j <= i; ++j) {
+      EXPECT_EQ(m2(i, j), 1);
+      EXPECT_EQ(m2(j, i), 1);
+    }
+  }
+}
+
+TEST(SymmetricMatrix, DifferentDataTypes) {
+  SymmetricMatrix<double> const m(3);
+  EXPECT_EQ(m.getSize(), 3);
+  SymmetricMatrix<std::string> const m2(3, "1");
+  EXPECT_EQ(m2.getSize(), 3);
+  EXPECT_EQ(m2(0, 2), m2(2, 0));
+  EXPECT_EQ(m2(0, 2), "1");
+  SymmetricMatrix<char> const m3(3, '1');
+  EXPECT_EQ(m3.getSize(), 3);
+  EXPECT_EQ(m3(0, 1), m3(1, 0));
+  EXPECT_EQ(m3(0, 1), '1');
+}
+
+} // namespace qc

--- a/test/datastructures/test_symmetric_matrix.cpp
+++ b/test/datastructures/test_symmetric_matrix.cpp
@@ -1,5 +1,6 @@
 #include "datastructures/SymmetricMatrix.hpp"
 
+#include <cstddef>
 #include <gtest/gtest.h>
 #include <string>
 
@@ -7,11 +8,11 @@ namespace qc {
 
 TEST(SymmetricMatrix, Constructors) {
   SymmetricMatrix<int> const m(3);
-  EXPECT_EQ(m.getSize(), 3);
+  EXPECT_EQ(m.size(), 3);
   SymmetricMatrix<int> m2(3, 1);
-  EXPECT_EQ(m2.getSize(), 3);
-  for (unsigned i = 0; i < m2.getSize(); ++i) {
-    for (unsigned j = 0; j <= i; ++j) {
+  EXPECT_EQ(m2.size(), 3);
+  for (size_t i = 0; i < m2.size(); ++i) {
+    for (size_t j = 0; j <= i; ++j) {
       EXPECT_EQ(m2(i, j), 1);
       EXPECT_EQ(m2(j, i), 1);
     }
@@ -20,13 +21,13 @@ TEST(SymmetricMatrix, Constructors) {
 
 TEST(SymmetricMatrix, DifferentDataTypes) {
   SymmetricMatrix<double> const m(3);
-  EXPECT_EQ(m.getSize(), 3);
+  EXPECT_EQ(m.size(), 3);
   SymmetricMatrix<std::string> const m2(3, "1");
-  EXPECT_EQ(m2.getSize(), 3);
+  EXPECT_EQ(m2.size(), 3);
   EXPECT_EQ(m2(0, 2), m2(2, 0));
   EXPECT_EQ(m2(0, 2), "1");
   SymmetricMatrix<char> const m3(3, '1');
-  EXPECT_EQ(m3.getSize(), 3);
+  EXPECT_EQ(m3.size(), 3);
   EXPECT_EQ(m3(0, 1), m3(1, 0));
   EXPECT_EQ(m3(0, 1), '1');
 }


### PR DESCRIPTION
## Description

Moved the datastructure "Symmtric Matrix" from qmap to mqt-core as it might be useful also in other situations.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
