### PR TITLE
Generalize concept of removing OpTypes

### DIFF
--- a/include/mqt-core/CircuitOptimizer.hpp
+++ b/include/mqt-core/CircuitOptimizer.hpp
@@ -28,6 +28,9 @@ public:
 
   static void removeIdentities(QuantumComputation& qc);
 
+  static void removeOperation(qc::QuantumComputation& qc,
+                              const std::set<OpType>& opTypes, size_t opSize);
+
   static void removeDiagonalGatesBeforeMeasure(QuantumComputation& qc);
 
   static void removeFinalMeasurements(QuantumComputation& qc);

--- a/include/mqt-core/CircuitOptimizer.hpp
+++ b/include/mqt-core/CircuitOptimizer.hpp
@@ -2,10 +2,12 @@
 
 #include "Definitions.hpp"
 #include "QuantumComputation.hpp"
+#include "operations/OpType.hpp"
 #include "operations/Operation.hpp"
 
 #include <cstddef>
 #include <memory>
+#include <set>
 
 namespace qc {
 

--- a/include/mqt-core/CircuitOptimizer.hpp
+++ b/include/mqt-core/CircuitOptimizer.hpp
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 #include <memory>
-#include <set>
+#include <unordered_set>
 
 namespace qc {
 
@@ -31,7 +31,8 @@ public:
   static void removeIdentities(QuantumComputation& qc);
 
   static void removeOperation(qc::QuantumComputation& qc,
-                              const std::set<OpType>& opTypes, size_t opSize);
+                              const std::unordered_set<OpType>& opTypes,
+                              size_t opSize);
 
   static void removeDiagonalGatesBeforeMeasure(QuantumComputation& qc);
 

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -28,7 +28,7 @@
 namespace qc {
 void CircuitOptimizer::removeIdentities(QuantumComputation& qc) {
   // delete the identities from circuit
-  CircuitOptimizer::removeOperation(qc, {I}, 1);
+  CircuitOptimizer::removeOperation(qc, {I}, 0);
 }
 
 void CircuitOptimizer::removeOperation(qc::QuantumComputation& qc,

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -45,8 +45,6 @@ void CircuitOptimizer::removeOperation(
       auto cit = compOp->cbegin();
       while (cit != compOp->cend()) {
         const auto* cop = cit->get();
-        // Please check: not sure if this generalizes to compound operations
-        // correctly
         if (opTypes.find(cop->getType()) != opTypes.end() &&
             (opSize == 0 || cop->getUsedQubits().size() == opSize)) {
           cit = compOp->erase(cit);

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -46,7 +46,7 @@ void CircuitOptimizer::removeOperation(
       while (cit != compOp->cend()) {
         const auto* cop = cit->get();
         if (opTypes.find(cop->getType()) != opTypes.end() &&
-            (opSize == 0 || cop->getUsedQubits().size() == opSize)) {
+            (opSize == 0 || cop->getNqubits() == opSize)) {
           cit = compOp->erase(cit);
         } else {
           ++cit;

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -31,9 +31,9 @@ void CircuitOptimizer::removeIdentities(QuantumComputation& qc) {
   CircuitOptimizer::removeOperation(qc, {I}, 0);
 }
 
-void CircuitOptimizer::removeOperation(qc::QuantumComputation& qc,
-                                       const std::set<OpType>& opTypes,
-                                       size_t opSize) {
+void CircuitOptimizer::removeOperation(
+    qc::QuantumComputation& qc, const std::unordered_set<OpType>& opTypes,
+    const size_t opSize) {
   // opSize = 0 means that the operation can have any number of qubits
   auto it = qc.ops.begin();
   while (it != qc.ops.end()) {

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -28,16 +28,27 @@
 namespace qc {
 void CircuitOptimizer::removeIdentities(QuantumComputation& qc) {
   // delete the identities from circuit
+  CircuitOptimizer::removeOperation(qc, {I}, 1);
+}
+
+void CircuitOptimizer::removeOperation(qc::QuantumComputation& qc,
+                                       const std::set<OpType>& opTypes,
+                                       size_t opSize) {
+  // opSize = 0 means that the operation can have any number of qubits
   auto it = qc.ops.begin();
   while (it != qc.ops.end()) {
-    if ((*it)->getType() == I) {
+    if (opTypes.find((*it)->getType()) != opTypes.end() &&
+        (opSize == 0 || it->get()->getNqubits() == opSize)) {
       it = qc.ops.erase(it);
     } else if ((*it)->isCompoundOperation()) {
       auto* compOp = dynamic_cast<qc::CompoundOperation*>((*it).get());
       auto cit = compOp->cbegin();
       while (cit != compOp->cend()) {
         const auto* cop = cit->get();
-        if (cop->getType() == qc::I) {
+        // Please check: not sure if this generalizes to compound operations
+        // correctly
+        if (opTypes.find(cop->getType()) != opTypes.end() &&
+            (opSize == 0 || cop->getUsedQubits().size() == opSize)) {
           cit = compOp->erase(cit);
         } else {
           ++cit;

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -335,7 +335,7 @@ TEST_F(QFRFunctionality, removeGateInCompoundOperation) {
   qc.emplace_back(compound.asOperation());
   std::cout << "-----------------------------\n";
   qc.print(std::cout);
-  CircuitOptimizer::removeOperation(qc, {Y}, 0);
+  CircuitOptimizer::removeOperation(qc, {Y}, 1);
   std::cout << "-----------------------------\n";
   qc.print(std::cout);
   EXPECT_EQ(qc.getNops(), 1);

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -325,6 +325,25 @@ TEST_F(QFRFunctionality, removeMoves) {
   EXPECT_EQ(qc.getNops(), 2);
 }
 
+TEST_F(QFRFunctionality, removeGateInCompoundOperation) {
+  const std::size_t nqubits = 1;
+  QuantumComputation qc(nqubits);
+  QuantumComputation compound(nqubits);
+  compound.x(0);
+  compound.y(0);
+  compound.z(0);
+  qc.emplace_back(compound.asOperation());
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  CircuitOptimizer::removeOperation(qc, {Y}, 0);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  EXPECT_EQ(qc.getNops(), 1);
+  EXPECT_EQ(qc.front()->getType(), Compound);
+  auto* compoundOp = dynamic_cast<CompoundOperation*>(qc.front().get());
+  EXPECT_EQ(compoundOp->size(), 2);
+}
+
 TEST_F(QFRFunctionality, eliminateInverseInCompoundOperation) {
   const std::size_t nqubits = 1;
   QuantumComputation qc(nqubits);

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -266,6 +266,65 @@ TEST_F(QFRFunctionality, eliminateCompoundOperation) {
   EXPECT_TRUE(qc.empty());
 }
 
+TEST_F(QFRFunctionality, removeIdentities) {
+  const std::size_t nqubits = 1;
+  QuantumComputation qc(nqubits);
+  qc.i(0);
+  qc.i(0);
+  qc.x(0);
+  qc.i(0);
+  qc.i(0);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  CircuitOptimizer::removeIdentities(qc);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  EXPECT_EQ(qc.getNops(), 1);
+}
+
+TEST_F(QFRFunctionality, removeSingleQubitGates) {
+  const std::size_t nqubits = 1;
+  QuantumComputation qc(nqubits);
+  qc.x(0);
+  qc.x(0);
+  qc.y(0);
+  qc.i(0);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  CircuitOptimizer::removeOperation(qc, {X, Y}, 1);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  EXPECT_EQ(qc.getNops(), 1);
+}
+
+TEST_F(QFRFunctionality, removeMultiQubitGates) {
+  const std::size_t nqubits = 2;
+  QuantumComputation qc(nqubits);
+  qc.x(0);
+  qc.cx(0, 1);
+  qc.cy(1, 1);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  CircuitOptimizer::removeOperation(qc, {X, Y}, 2);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  EXPECT_EQ(qc.getNops(), 2);
+}
+
+TEST_F(QFRFunctionality, removeMoves) {
+  const std::size_t nqubits = 2;
+  QuantumComputation qc(nqubits);
+  qc.x(0);
+  qc.move(0, 1);
+  qc.cy(1, 1);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  CircuitOptimizer::removeOperation(qc, {Move}, 0);
+  std::cout << "-----------------------------\n";
+  qc.print(std::cout);
+  EXPECT_EQ(qc.getNops(), 2);
+}
+
 TEST_F(QFRFunctionality, eliminateInverseInCompoundOperation) {
   const std::size_t nqubits = 1;
   QuantumComputation qc(nqubits);


### PR DESCRIPTION
## Description

To not only remove Identities but also other Operations I wrote a function that generalizes that concept and allows one to remove arbitrary operation types.

## Checklist:


- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
