### PR TITLE
✨ add an export header to explicitly manage symbol visibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,7 +123,7 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME})
   # set include directories
   target_include_directories(
     ${MQT_CORE_TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${MQT_CORE_INCLUDE_BUILD_DIR}>
-                                   $<INSTALL_INTERFACE:${MQT_CORE_INCLUDE_INSTALL_DIR}>)
+                                   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
   # add options and warnings to the library
   target_link_libraries(${MQT_CORE_TARGET_NAME} PRIVATE MQT::ProjectOptions MQT::ProjectWarnings)
@@ -136,6 +136,12 @@ if(NOT TARGET ${MQT_CORE_TARGET_NAME})
                SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
                EXPORT_NAME Core)
   list(APPEND MQT_CORE_TARGETS ${MQT_CORE_TARGET_NAME})
+
+  include(GenerateExportHeader)
+  generate_export_header(${MQT_CORE_TARGET_NAME} BASE_NAME mqt_core)
+  if(NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(${MQT_CORE_TARGET_NAME} PUBLIC MQT_CORE_STATIC_DEFINE)
+  endif()
 endif()
 
 # add datastructures package
@@ -208,6 +214,8 @@ if(MQT_CORE_INSTALL)
     DESTINATION ${MQT_CORE_INCLUDE_INSTALL_DIR})
 
   install(DIRECTORY ${MQT_CORE_INCLUDE_BUILD_DIR}/ DESTINATION ${MQT_CORE_INCLUDE_INSTALL_DIR})
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mqt_core_export.h
+          DESTINATION ${MQT_CORE_INCLUDE_INSTALL_DIR})
 
   install(
     EXPORT ${MQT_CORE_TARGETS_EXPORT_NAME}


### PR DESCRIPTION
## Description

This PR adds an Export Header (see https://cmake.org/cmake/help/latest/module/GenerateExportHeader.html) that can be used to manage symbol visibility. This PR does not make use of that feature yet, but can be seen as a preparation towards properly building shared libraries for this project.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
