### PR TITLE
Improvements for Trace Computation

### DIFF
--- a/include/mqt-core/dd/DDpackageConfig.hpp
+++ b/include/mqt-core/dd/DDpackageConfig.hpp
@@ -6,8 +6,6 @@
 
 namespace dd {
 struct DDPackageConfig {
-  // Note the order of parameters here must be the *same* as in the template
-  // definition.
   static constexpr std::size_t UT_VEC_NBUCKET = 32768U;
   static constexpr std::size_t UT_VEC_INITIAL_ALLOCATION_SIZE = 2048U;
   static constexpr std::size_t UT_MAT_NBUCKET = 32768U;

--- a/include/mqt-core/dd/DDpackageConfig.hpp
+++ b/include/mqt-core/dd/DDpackageConfig.hpp
@@ -22,6 +22,8 @@ struct DDPackageConfig {
   static constexpr std::size_t CT_MAT_MAT_MULT_NBUCKET = 16384U;
   static constexpr std::size_t CT_VEC_KRON_NBUCKET = 4096U;
   static constexpr std::size_t CT_MAT_KRON_NBUCKET = 4096U;
+  static constexpr std::size_t CT_DM_TRACE_NBUCKET = 1U;
+  static constexpr std::size_t CT_MAT_TRACE_NBUCKET = 4096U;
   static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 4096U;
   static constexpr std::size_t CT_DM_NOISE_NBUCKET = 1U;
   static constexpr std::size_t UT_DM_NBUCKET = 1U;
@@ -63,6 +65,8 @@ struct DensityMatrixSimulatorDDPackageConfig : public dd::DDPackageConfig {
   static constexpr std::size_t UT_MAT_INITIAL_ALLOCATION_SIZE = 1U;
   static constexpr std::size_t CT_VEC_KRON_NBUCKET = 1U;
   static constexpr std::size_t CT_MAT_KRON_NBUCKET = 1U;
+  static constexpr std::size_t CT_DM_TRACE_NBUCKET = 4096U;
+  static constexpr std::size_t CT_MAT_TRACE_NBUCKET = 1U;
   static constexpr std::size_t CT_VEC_INNER_PROD_NBUCKET = 1U;
   static constexpr std::size_t STOCHASTIC_CACHE_OPS = 1U;
   static constexpr std::size_t CT_VEC_ADD_MAG_NBUCKET = 1U;

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -2008,13 +2008,14 @@ private:
    * This optimization allows the full trace
    * computation to scale linearly with respect to the number of nodes.
    * However, the partial trace computation still scales with the number of
-   * paths in the DD when bottom qubits are to be eliminated.
+   * paths to the lowest level in the DD that should be traced out.
    *
-   * Normalization is continuously applied, dividing by two at each level
-   * marked for elimination, thereby ensuring that the result is mapped to the
-   * interval [0,1].
-   * @note Normalization is only applied to matrix nodes, as the trace
-   * of density matrices equals 1 by definition.
+   * For matrices, normalization is continuously applied, dividing by two at
+   * each level marked for elimination, thereby ensuring that the result is
+   * mapped to the interval [0,1] (as opposed to the interval [0,2^N]).
+   *
+   * For density matrices, such normalization is not applied as the trace of
+   * density matrices is always 1 by definition.
    */
   template <class Node>
   CachedEdge<Node> trace(const Edge<Node>& a,

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -1964,7 +1964,6 @@ public:
     return {r.p, cn.lookup(r.w)};
   }
 
-  // Normalized trace function
   template <class Node>
   ComplexValue trace(const Edge<Node>& a, const std::size_t numQubits) {
     if (a.isIdentity()) {
@@ -1997,6 +1996,13 @@ public:
   }
 
 private:
+  /**
+      Computes the normalized (partial) trace using a compute table to store
+     results for eliminated nodes. This allows the full trace computation to
+     scale linearly with respect to the number of nodes. However, the partial
+     trace computation still scales with the number of paths in the DD if the
+     bottom qubits are to be eliminated.
+      **/
   template <class Node>
   CachedEdge<Node> trace(const Edge<Node>& a,
                          const std::vector<bool>& eliminate, std::size_t level,

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -2041,14 +2041,14 @@ private:
       // Lookup nodes marked for elimination in the compute table if all
       // lower-level qubits are eliminated as well: if the trace has already
       // been computed, return the result
-      auto& computeTable = getTraceComputeTable<Node>();
       const auto eliminateAll = std::all_of(
           eliminate.begin(),
           eliminate.begin() +
               static_cast<std::vector<bool>::difference_type>(level),
           [](bool e) { return e; });
       if (eliminateAll) {
-        if (const auto* r = computeTable.lookup(a.p); r) {
+        if (const auto* r = getTraceComputeTable<Node>().lookup(a.p);
+            r != nullptr) {
           return {r->p, r->w * aWeight};
         }
       }
@@ -2066,7 +2066,7 @@ private:
       // Insert result into compute table if all lower-level qubits are
       // eliminated as well
       if (eliminateAll) {
-        computeTable.insert(a.p, {r.p, r.w});
+        getTraceComputeTable<Node>().insert(a.p, r);
       }
       r.w = r.w * aWeight;
       return r;
@@ -2084,7 +2084,6 @@ private:
                                 eliminate.begin(), eliminate.end(), true)) -
                             alreadyEliminated));
     auto r = makeDDNode(adjustedV, edge);
-    // nodes that were not eliminated are not added to the compute table
     r.w = r.w * aWeight;
     return r;
   }

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -5,6 +5,7 @@
 #include "dd/CachedEdge.hpp"
 #include "dd/Complex.hpp"
 #include "dd/ComplexNumbers.hpp"
+#include "dd/ComplexValue.hpp"
 #include "dd/ComputeTable.hpp"
 #include "dd/DDDefinitions.hpp"
 #include "dd/DDpackageConfig.hpp"
@@ -1949,6 +1950,30 @@ public:
     }
     const auto eliminate = std::vector<bool>(numQubits, true);
     return trace(a, eliminate, numQubits).w;
+  }
+
+  template <class Node>
+  ComplexValue trace2(const Edge<Node>& a, const std::size_t numQubits) {
+    const auto aWeight = static_cast<ComplexValue>(a.w);
+    if (aWeight.approximatelyZero()) {
+      return ComplexValue{0., 0.};
+    }
+
+    if (a.isIdentity()) {
+      return aWeight * std::pow(2, numQubits);
+    }
+
+    if (a.isTerminal()) {
+      return ComplexValue(a.w);
+    }
+
+    if (numQubits <= 0) {
+      throw std::invalid_argument("Number of Qubits is incorrect");
+    }
+    auto l = trace2(a.p->e[0], numQubits - 1);
+    auto r = trace2(a.p->e[3], numQubits - 1);
+    auto w = aWeight * (l + r);
+    return w;
   }
 
   /**

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -1953,13 +1953,17 @@ public:
   }
 
   template <class Node>
-  ComplexValue trace2(const Edge<Node>& a, const std::size_t numQubits) {
+  ComplexValue trace2(const Edge<Node>& a, const std::size_t numQubits,
+                      bool normalize = false) {
     const auto aWeight = static_cast<ComplexValue>(a.w);
     if (aWeight.approximatelyZero()) {
       return ComplexValue{0., 0.};
     }
 
     if (a.isIdentity()) {
+      if (normalize) {
+        return aWeight;
+      }
       return aWeight * std::pow(2, numQubits);
     }
 
@@ -1970,9 +1974,12 @@ public:
     if (numQubits <= 0) {
       throw std::invalid_argument("Number of Qubits is incorrect");
     }
-    auto l = trace2(a.p->e[0], numQubits - 1);
-    auto r = trace2(a.p->e[3], numQubits - 1);
+    auto l = trace2(a.p->e[0], numQubits - 1, normalize);
+    auto r = trace2(a.p->e[3], numQubits - 1, normalize);
     auto w = aWeight * (l + r);
+    if (normalize) {
+      w = w / 2;
+    }
     return w;
   }
 

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -1972,7 +1972,6 @@ public:
   ComplexValue trace(const Edge<Node>& a, const std::size_t numQubits) {
     if (a.isIdentity()) {
       return static_cast<ComplexValue>(a.w);
-      ;
     }
     const auto eliminate = std::vector<bool>(numQubits, true);
     return trace(a, eliminate, numQubits).w;

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -1118,7 +1118,7 @@ public:
     auto tmp0 = conjugateTranspose(measZeroDd);
     auto tmp1 = multiply(e, densityFromMatrixEdge(tmp0), false);
     auto tmp2 = multiply(densityFromMatrixEdge(measZeroDd), tmp1, true);
-    auto densityMatrixTrace = trace(tmp2, nrQubits);
+    auto densityMatrixTrace = trace(tmp2, nrQubits) * std::pow(2, nrQubits);
 
     std::uniform_real_distribution<fp> dist(0., 1.);
     if (const auto threshold = dist(mt); threshold > densityMatrixTrace.r) {
@@ -1127,7 +1127,7 @@ public:
       tmp1 = multiply(e, densityFromMatrixEdge(tmp0), false);
       tmp2 = multiply(densityFromMatrixEdge(measOneDd), tmp1, true);
       measuredResult = '1';
-      densityMatrixTrace = trace(tmp2, nrQubits);
+      densityMatrixTrace = trace(tmp2, nrQubits) * std::pow(2, nrQubits);
     }
 
     incRef(tmp2);

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -2003,8 +2003,8 @@ private:
   /**
    * @brief Computes the normalized (partial) trace using a compute table to
    * store results for eliminated nodes.
-   * @details At each level, perform lookup and store results in the compute
-   * table only if all lower level qubits are eliminated as well.
+   * @details At each level, perform a lookup and store results in the compute
+   * table only if all lower-level qubits are eliminated as well.
    *
    * This optimization allows the full trace
    * computation to scale linearly with respect to the number of nodes.
@@ -2039,14 +2039,15 @@ private:
     const auto v = a.p->v;
     if (eliminate[v]) {
       // Lookup nodes marked for elimination in the compute table if all
-      // lower level qubits are eliminated as well: if the trace has already
+      // lower-level qubits are eliminated as well: if the trace has already
       // been computed, return the result
       auto& computeTable = getTraceComputeTable<Node>();
-      if (std::all_of(
-              eliminate.begin(),
-              eliminate.begin() +
-                  static_cast<std::vector<bool>::difference_type>(level),
-              [](bool e) { return e; })) {
+      const auto eliminateAll = std::all_of(
+          eliminate.begin(),
+          eliminate.begin() +
+              static_cast<std::vector<bool>::difference_type>(level),
+          [](bool e) { return e; });
+      if (eliminateAll) {
         if (const auto* r = computeTable.lookup(a.p); r) {
           return {r->p, r->w * aWeight};
         }
@@ -2062,13 +2063,9 @@ private:
         r.w = r.w / 2.0;
       }
 
-      // Insert result into compute table if all lower level qubits are
+      // Insert result into compute table if all lower-level qubits are
       // eliminated as well
-      if (std::all_of(
-              eliminate.begin(),
-              eliminate.begin() +
-                  static_cast<std::vector<bool>::difference_type>(level),
-              [](bool e) { return e; })) {
+      if (eliminateAll) {
         computeTable.insert(a.p, {r.p, r.w});
       }
       r.w = r.w * aWeight;

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -316,6 +316,28 @@ TEST(DDPackageTest, NonIdentityTrace2) {
   ASSERT_EQ(fullTrace, 4.);
 }
 
+TEST(DDPackageTest, IdentityTrace2Normalized) {
+  std::size_t numQubits = 4;
+  auto matrixDim = std::pow(2, numQubits);
+  auto dd = std::make_unique<dd::Package<>>(numQubits);
+  auto fullTrace = dd->trace2(dd->makeIdent(), numQubits);
+  auto fullTraceNormalized = dd->trace2(dd->makeIdent(), numQubits, true);
+  auto normalizedTrace = fullTrace / matrixDim;
+  ASSERT_EQ(fullTraceNormalized, normalizedTrace);
+}
+
+TEST(DDPackageTest, NonIdentityTrace2Normalized) {
+  std::size_t numQubits = 4;
+  auto matrixDim = std::pow(2, numQubits);
+  auto dd = std::make_unique<dd::Package<>>(numQubits);
+  auto cxGate = dd->makeGateDD(dd::X_MAT, 1_pc, 0);
+  auto cxGateKron = dd->kronecker(cxGate, cxGate, 2);
+  auto fullTrace = dd->trace2(cxGateKron, numQubits);
+  auto fullTraceNormalized = dd->trace2(cxGateKron, numQubits, true);
+  auto normalizedTrace = fullTrace / matrixDim;
+  ASSERT_EQ(fullTraceNormalized, normalizedTrace);
+}
+
 TEST(DDPackageTest, StateGenerationManipulation) {
   const std::size_t nqubits = 6;
   auto dd = std::make_unique<dd::Package<>>(nqubits);

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -317,8 +317,13 @@ TEST(DDPackageTest, PartialSWapMatTrace) {
   EXPECT_EQ(fullTrace.r, fullTraceOriginal.r);
 }
 
-TEST(DDPackageTest, PartialTraceKeepOuterQubits) {
-  std::size_t numQubits = 8;
+TEST(DDPackageTest, PartialTraceKeepInnerQubits) {
+  // Check that the partial trace computation is correct when tracing out the
+  // outer qubits only. This test shows that we should avoid storing
+  // non-eliminated nodes in the compute table, as this would prevent their
+  // proper elimination in subsequent trace calls.
+
+  const std::size_t numQubits = 8;
   auto dd = std::make_unique<dd::Package<>>(numQubits);
   auto dd2 = std::make_unique<dd::Package<>>(numQubits);
   const auto swapGate = dd->makeTwoQubitGateDD(dd::SWAP_MAT, 0, 1);
@@ -343,8 +348,8 @@ TEST(DDPackageTest, PartialTraceKeepOuterQubits) {
 }
 
 TEST(DDPackageTest, TraceComplexity) {
-  // Check that the trace computation scales with the number of nodes instead of
-  // paths in the DD due to the usage of a compute table
+  // Check that the full trace computation scales with the number of nodes
+  // instead of paths in the DD due to the usage of a compute table
   for (std::size_t numQubits = 1; numQubits <= 10; ++numQubits) {
     auto dd = std::make_unique<dd::Package<>>(numQubits);
     auto& computeTable = dd->getTraceComputeTable<dd::mNode>();

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -302,6 +302,20 @@ TEST(DDPackageTest, PartialNonIdentityTrace) {
   EXPECT_EQ(ptr.w * ptr.w, 1.);
 }
 
+TEST(DDPackageTest, IdentityTrace2) {
+  auto dd = std::make_unique<dd::Package<>>(4);
+  auto fullTrace = dd->trace2(dd->makeIdent(), 4);
+  ASSERT_EQ(fullTrace, 16.);
+}
+
+TEST(DDPackageTest, NonIdentityTrace2) {
+  auto dd = std::make_unique<dd::Package<>>(4);
+  auto cxGate = dd->makeGateDD(dd::X_MAT, 1_pc, 0);
+  auto cxGateKron = dd->kronecker(cxGate, cxGate, 2);
+  auto fullTrace = dd->trace2(cxGateKron, 4);
+  ASSERT_EQ(fullTrace, 4.);
+}
+
 TEST(DDPackageTest, StateGenerationManipulation) {
   const std::size_t nqubits = 6;
   auto dd = std::make_unique<dd::Package<>>(nqubits);

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -371,7 +371,7 @@ TEST(DDPackageTest, KeepBottomQubitsPartialTraceComplexity) {
   }
 
   const std::size_t maxNodeVal = 6;
-  std::array<std::size_t, maxNodeVal> lookupValues;
+  std::array<std::size_t, maxNodeVal> lookupValues{};
 
   for (std::size_t i = 0; i < maxNodeVal; ++i) {
     // Store the number of lookups performed so far for the six bottom qubits
@@ -401,7 +401,7 @@ TEST(DDPackageTest, PartialTraceComplexity) {
   hKron = dd->kronecker(hKron, dd->makeIdent(), 1);
 
   const std::size_t maxNodeVal = 6;
-  std::array<std::size_t, maxNodeVal + 1> lookupValues;
+  std::array<std::size_t, maxNodeVal + 1> lookupValues{};
   for (std::size_t i = 1; i <= maxNodeVal; ++i) {
     // Store the number of lookups performed so far for levels 1 through 6
     lookupValues[i] = uniqueTable.getStats(i).lookups;

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -323,18 +323,12 @@ TEST(DDPackageTest, PartialTraceKeepInnerQubits) {
 
   const std::size_t numQubits = 8;
   auto dd = std::make_unique<dd::Package<>>(numQubits);
-  auto dd2 = std::make_unique<dd::Package<>>(numQubits);
   const auto swapGate = dd->makeTwoQubitGateDD(dd::SWAP_MAT, 0, 1);
   auto swapKron = swapGate;
   for (std::size_t i = 0; i < 3; ++i) {
     swapKron = dd->kronecker(swapKron, swapGate, 2);
   }
-  const auto swapGate2 = dd2->makeTwoQubitGateDD(dd::SWAP_MAT, 0, 1);
-  auto swapKron2 = swapGate2;
-  for (std::size_t i = 0; i < 3; ++i) {
-    swapKron2 = dd2->kronecker(swapKron2, swapGate2, 2);
-  }
-  auto fullTraceOriginal = dd2->trace(swapKron2, numQubits);
+  auto fullTraceOriginal = dd->trace(swapKron, numQubits);
   auto ptr = dd->partialTrace(
       swapKron, {true, true, false, false, false, false, true, true});
   auto fullTrace = dd->trace(ptr, 4);


### PR DESCRIPTION
## Description

This PR introduces improvements for the trace computation: 

1. Adds a compute table for storing results of eliminated nodes during (partial) trace computation
- this allows the full trace computation to scale linearly with the number of nodes
- however, the partial trace computation still scales with the number of paths in the DD if the bottom qubits are to be eliminated:  non-eliminated nodes cannot be stored in the compute table, as this would prevent their proper elimination in subsequent trace calls
2. Normalizes the result

Fixes #336 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
