### PR TITLE
⚡🔧  Faster `cibuildwheel` and better Windows wheel repair

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@dependabot/github_actions/github-actions-dfafb25d9f
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.1.0
 
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@dependabot/github_actions/github-actions-dfafb25d9f
 
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.1.0
 
   cpp-tests:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.1.0
     with:
       cmake-args-macos: -DMQT_CORE_WITH_GMP=ON
 
@@ -28,7 +28,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.1.0
     with:
       cmake-args: -DBUILD_MQT_CORE_BENCHMARKS=ON
 
@@ -36,13 +36,13 @@ jobs:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.1.0
 
   code-ql:
     name: 📝 CodeQL
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.1.0
 
   required-checks-pass: # This job does nothing and is only used for branch protection
     name: 🚦 Check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,8 +138,7 @@ repos:
       - id: check-readthedocs
 
   # Check the pyproject.toml file
-  - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.18
+  - repo: https://github.com/henryiii/validate-pyproject-schema-store
+    rev: 2024.06.10
     hooks:
       - id: validate-pyproject
-        additional_dependencies: ["validate-pyproject-schema-store[all]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,6 +286,6 @@ before-test = "ccache -s"
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
 
 [tool.cibuildwheel.windows]
-before-build = "pip install delvewheel>=1.4.0"
+before-build = "uv pip install delvewheel>=1.4.0"
 repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --namespace-pkg mqt"
 environment = { CMAKE_GENERATOR = "Ninja" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,8 +279,6 @@ build-frontend = "build[uv]"
 
 [tool.cibuildwheel.linux]
 environment = { DEPLOY = "ON" }
-before-all = "yum install -y ccache"
-before-test = "ccache -s"
 
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,7 +275,7 @@ skip = "*-musllinux_*"
 archs = "auto64"
 test-command = "python -c \"from mqt import core\""
 test-skip = "cp38-macosx_arm64"
-build-frontend = "build"
+build-frontend = "build[uv]"
 
 [tool.cibuildwheel.linux]
 environment = { DEPLOY = "ON" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,6 +284,6 @@ environment = { DEPLOY = "ON" }
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
 
 [tool.cibuildwheel.windows]
-before-build = "pip install delvewheel"
-repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
+before-build = "pip install delvewheel>=1.4.0"
+repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --namespace-pkg mqt"
 environment = { CMAKE_GENERATOR = "Ninja" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,6 +279,8 @@ build-frontend = "build[uv]"
 
 [tool.cibuildwheel.linux]
 environment = { DEPLOY = "ON" }
+before-all = "yum install -y ccache"
+before-test = "ccache -s"
 
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }


### PR DESCRIPTION
## Description

This PR makes use of `cibuildwheel`'s latest addition of a `build[uv]` build frontend option that uses `uv` under the hood to speed up the build process.
Furthermore, it adjusts the Windows repair command to respect namespace packages.

Before and after:

| | Before | After | Improvement |
| Overall Usage | 7h 37m 44s | 6h 53m 29s | -44min |

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
