### PR TITLE
🐛 Support `u` gate when parsing OpenQASM 2

### DIFF
--- a/include/mqt-core/parsers/qasm3_parser/StdGates.hpp
+++ b/include/mqt-core/parsers/qasm3_parser/StdGates.hpp
@@ -89,6 +89,7 @@ const std::map<std::string, std::shared_ptr<Gate>> STANDARD_GATES = {
     {"id", std::make_shared<StandardGate>(StandardGate({0, 1, 0, qc::I}))},
     {"u2", std::make_shared<StandardGate>(StandardGate({0, 1, 2, qc::U2}))},
     {"u3", std::make_shared<StandardGate>(StandardGate({0, 1, 3, qc::U}))},
+    {"u", std::make_shared<StandardGate>(StandardGate({0, 1, 3, qc::U}))},
 
     {"x", std::make_shared<StandardGate>(StandardGate({0, 1, 0, qc::X}))},
     {"cx", std::make_shared<StandardGate>(StandardGate({1, 1, 0, qc::X}))},

--- a/test/test_operation.cpp
+++ b/test/test_operation.cpp
@@ -8,6 +8,7 @@
 #include "operations/StandardOperation.hpp"
 #include "operations/SymbolicOperation.hpp"
 
+#include <QuantumComputation.hpp>
 #include <cstdint>
 #include <gtest/gtest.h>
 #include <sstream>
@@ -257,4 +258,30 @@ TEST(AodOperation, Invert) {
                               {na::Dimension::X}, {0.0}, {1.0});
   deactivate.invert();
   EXPECT_EQ(deactivate.getType(), qc::OpType::AodActivate);
+}
+
+TEST(QuantumComputation, fromQASM) {
+  const std::string qasm = R"(
+    // Benchmark was created by MQT Bench on 2024-03-17
+    // For more information about MQT Bench, please visit https://www.cda.cit.tum.de/mqtbench/
+    // MQT Bench version: 1.1.0
+    // Qiskit version: 1.0.2
+
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    qreg eval[1];
+    qreg q[1];
+    creg meas[2];
+    u2(0,-pi) eval[0];
+    u3(0.9272952180016122,0,0) q[0];
+    cx eval[0],q[0];
+    u(-0.9272952180016122,0,0) q[0];
+    cx eval[0],q[0];
+    h eval[0];
+    u(0.9272952180016122,0,0) q[0];
+    barrier eval[0],q[0];
+    measure eval[0] -> meas[0];
+    measure q[0] -> meas[1];
+  )";
+  EXPECT_NO_THROW(std::ignore = qc::QuantumComputation::fromQASM(qasm));
 }

--- a/test/test_operation.cpp
+++ b/test/test_operation.cpp
@@ -8,7 +8,6 @@
 #include "operations/StandardOperation.hpp"
 #include "operations/SymbolicOperation.hpp"
 
-#include <QuantumComputation.hpp>
 #include <cstdint>
 #include <gtest/gtest.h>
 #include <sstream>
@@ -258,30 +257,4 @@ TEST(AodOperation, Invert) {
                               {na::Dimension::X}, {0.0}, {1.0});
   deactivate.invert();
   EXPECT_EQ(deactivate.getType(), qc::OpType::AodActivate);
-}
-
-TEST(QuantumComputation, fromQASM) {
-  const std::string qasm = R"(
-    // Benchmark was created by MQT Bench on 2024-03-17
-    // For more information about MQT Bench, please visit https://www.cda.cit.tum.de/mqtbench/
-    // MQT Bench version: 1.1.0
-    // Qiskit version: 1.0.2
-
-    OPENQASM 2.0;
-    include "qelib1.inc";
-    qreg eval[1];
-    qreg q[1];
-    creg meas[2];
-    u2(0,-pi) eval[0];
-    u3(0.9272952180016122,0,0) q[0];
-    cx eval[0],q[0];
-    u(-0.9272952180016122,0,0) q[0];
-    cx eval[0],q[0];
-    h eval[0];
-    u(0.9272952180016122,0,0) q[0];
-    barrier eval[0],q[0];
-    measure eval[0] -> meas[0];
-    measure q[0] -> meas[1];
-  )";
-  EXPECT_NO_THROW(std::ignore = qc::QuantumComputation::fromQASM(qasm));
 }

--- a/test/unittests/test_qasm3_parser.cpp
+++ b/test/unittests/test_qasm3_parser.cpp
@@ -708,6 +708,52 @@ TEST_F(Qasm3ParserTest, ImportMCXGate) {
   EXPECT_EQ(out, expected);
 }
 
+TEST_F(Qasm3ParserTest, ImportMQTBenchCircuit) {
+  const std::string qasm = R"(
+    // Benchmark was created by MQT Bench on 2024-03-17
+    // For more information about MQT Bench, please visit https://www.cda.cit.tum.de/mqtbench/
+    // MQT Bench version: 1.1.0
+    // Qiskit version: 1.0.2
+
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    qreg eval[1];
+    qreg q[1];
+    creg meas[2];
+    u2(0,-pi) eval[0];
+    u3(0.9272952180016122,0,0) q[0];
+    cx eval[0],q[0];
+    u(-0.9272952180016122,0,0) q[0];
+    cx eval[0],q[0];
+    h eval[0];
+    u(0.9272952180016122,0,0) q[0];
+    barrier eval[0],q[0];
+    measure eval[0] -> meas[0];
+    measure q[0] -> meas[1];
+  )";
+  auto qc = qc::QuantumComputation::fromQASM(qasm);
+
+  const std::string out = qc.toQASM();
+  const std::string expected = "// i 0 1\n"
+                               "// o 0 1\n"
+                               "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[1] eval;\n"
+                               "qubit[1] q;\n"
+                               "bit[2] meas;\n"
+                               "h eval[0];\n"
+                               "ry(0.927295218001612) q[0];\n"
+                               "cx eval[0], q[0];\n"
+                               "ry(-0.927295218001612) q[0];\n"
+                               "cx eval[0], q[0];\n"
+                               "h eval[0];\n"
+                               "ry(0.927295218001612) q[0];\n"
+                               "barrier eval[0], q[0];\n"
+                               "meas[0] = measure eval[0];\n"
+                               "meas[1] = measure q[0];\n";
+  EXPECT_EQ(out, expected);
+}
+
 TEST_F(Qasm3ParserTest, ImportQasm2CPrefixInvalidGate) {
   const std::string testfile = "OPENQASM 2.0;\n"
                                "qubit[5] q;\n"


### PR DESCRIPTION
## Description

🚧 Should probably have opened an issue but I wanted to directly add the failing test.

### What I did

I downloaded a circuit for AE with 2 qubits compiled hardware-agnostically with qiskit from MQT Bench and inserted this circuit as input to `qc::QuantumComputation::fromQASM()`, which should not throw an error but it does, see the respective test 
https://github.com/cda-tum/mqt-core/blob/f91a0526617dbb68e2ce3589a8994f220bc44347/test/test_operation.cpp#L263-L287

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
