### PR TITLE
🚸 make `dd/Package.hpp` export `dd/Package_fwd.hpp`

### DIFF
--- a/include/mqt-core/dd/Benchmark.hpp
+++ b/include/mqt-core/dd/Benchmark.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "dd/Package.hpp"
 #include "dd/Package_fwd.hpp"
 
 #include <chrono>

--- a/include/mqt-core/dd/Benchmark.hpp
+++ b/include/mqt-core/dd/Benchmark.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "dd/Package_fwd.hpp"
+#include "dd/Package.hpp"
 
 #include <chrono>
 #include <cstddef>

--- a/include/mqt-core/dd/Operations.hpp
+++ b/include/mqt-core/dd/Operations.hpp
@@ -5,7 +5,6 @@
 #include "dd/DDDefinitions.hpp"
 #include "dd/GateMatrixDefinitions.hpp"
 #include "dd/Package.hpp"
-#include "dd/Package_fwd.hpp"
 #include "operations/ClassicControlledOperation.hpp"
 #include "operations/CompoundOperation.hpp"
 #include "operations/Control.hpp"

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -14,7 +14,7 @@
 #include "dd/GateMatrixDefinitions.hpp"
 #include "dd/MemoryManager.hpp"
 #include "dd/Node.hpp"
-#include "dd/Package_fwd.hpp"
+#include "dd/Package_fwd.hpp" // IWYU pragma: export
 #include "dd/RealNumber.hpp"
 #include "dd/RealNumberUniqueTable.hpp"
 #include "dd/StochasticNoiseOperationTable.hpp"

--- a/src/dd/FunctionalityConstruction.cpp
+++ b/src/dd/FunctionalityConstruction.cpp
@@ -3,7 +3,6 @@
 #include "QuantumComputation.hpp"
 #include "algorithms/Grover.hpp"
 #include "dd/Package.hpp"
-#include "dd/Package_fwd.hpp"
 
 #include <bitset>
 #include <cmath>

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -6,7 +6,6 @@
 #include "dd/DDDefinitions.hpp"
 #include "dd/GateMatrixDefinitions.hpp"
 #include "dd/Package.hpp"
-#include "dd/Package_fwd.hpp"
 #include "dd/RealNumber.hpp"
 #include "operations/ClassicControlledOperation.hpp"
 #include "operations/NonUnitaryOperation.hpp"

--- a/test/algorithms/eval_dynamic_circuits.cpp
+++ b/test/algorithms/eval_dynamic_circuits.cpp
@@ -7,7 +7,6 @@
 #include "dd/DDDefinitions.hpp"
 #include "dd/Operations.hpp"
 #include "dd/Package.hpp"
-#include "dd/Package_fwd.hpp"
 #include "dd/Simulation.hpp"
 
 #include <bitset>

--- a/test/algorithms/test_entanglement.cpp
+++ b/test/algorithms/test_entanglement.cpp
@@ -2,7 +2,6 @@
 #include "dd/Benchmark.hpp"
 #include "dd/DDDefinitions.hpp"
 #include "dd/Package.hpp"
-#include "dd/Package_fwd.hpp"
 
 #include <cstddef>
 #include <gtest/gtest.h>

--- a/test/algorithms/test_grover.cpp
+++ b/test/algorithms/test_grover.cpp
@@ -2,7 +2,6 @@
 #include "dd/Benchmark.hpp"
 #include "dd/DDDefinitions.hpp"
 #include "dd/Package.hpp"
-#include "dd/Package_fwd.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/test/algorithms/test_qpe.cpp
+++ b/test/algorithms/test_qpe.cpp
@@ -5,7 +5,6 @@
 #include "dd/DDDefinitions.hpp"
 #include "dd/FunctionalityConstruction.hpp"
 #include "dd/Package.hpp"
-#include "dd/Package_fwd.hpp"
 #include "dd/Simulation.hpp"
 
 #include <bitset>

--- a/test/algorithms/test_random_clifford.cpp
+++ b/test/algorithms/test_random_clifford.cpp
@@ -1,5 +1,6 @@
 #include "algorithms/RandomCliffordCircuit.hpp"
 #include "dd/Benchmark.hpp"
+#include "dd/Package.hpp"
 
 #include <cstddef>
 #include <gtest/gtest.h>

--- a/test/algorithms/test_random_clifford.cpp
+++ b/test/algorithms/test_random_clifford.cpp
@@ -1,6 +1,5 @@
 #include "algorithms/RandomCliffordCircuit.hpp"
 #include "dd/Benchmark.hpp"
-#include "dd/Package.hpp"
 
 #include <cstddef>
 #include <gtest/gtest.h>


### PR DESCRIPTION
## Description

This PR slighlty improves the usability of the IWYU features of clang-tidy for the DD package. To this end, it marks the `dd/Package_fwd.hpp` include in the `dd/Package.hpp` header as an export. This way, header need not include both headers, but can only import the `dd/Package.hpp` header to also get the content of the foward declaration header.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
