### PR TITLE
🩹 fix erroneous cast in `AodOperation`

### DIFF
--- a/include/mqt-core/operations/AodOperation.hpp
+++ b/include/mqt-core/operations/AodOperation.hpp
@@ -29,7 +29,7 @@ struct SingleOperation {
 
   [[nodiscard]] std::string toQASMString() const {
     std::stringstream ss;
-    ss << static_cast<char32_t>(dir) << ", " << start << ", " << end << "; ";
+    ss << static_cast<std::size_t>(dir) << ", " << start << ", " << end << "; ";
     return ss.str();
   }
 };


### PR DESCRIPTION
## Description

This fixes a small erroneous cast in the `AodOperation` class that could potentially cause compilation errors on some systems.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
