### PR TITLE
:sparkles: Add `customGate` flag and optimizer functionality to flatten only custom gates

### DIFF
--- a/include/mqt-core/CircuitOptimizer.hpp
+++ b/include/mqt-core/CircuitOptimizer.hpp
@@ -51,8 +51,8 @@ public:
 
   static void reorderOperations(QuantumComputation& qc);
 
-  static void flattenOperations(QuantumComputation& qc);
-  static void flattenOperations(QuantumComputation& qc, bool customGatesOnly);
+  static void flattenOperations(QuantumComputation& qc,
+                                bool customGatesOnly = false);
 
   static void cancelCNOTs(QuantumComputation& qc);
 

--- a/include/mqt-core/CircuitOptimizer.hpp
+++ b/include/mqt-core/CircuitOptimizer.hpp
@@ -52,6 +52,7 @@ public:
   static void reorderOperations(QuantumComputation& qc);
 
   static void flattenOperations(QuantumComputation& qc);
+  static void flattenOperations(QuantumComputation& qc, bool customGatesOnly);
 
   static void cancelCNOTs(QuantumComputation& qc);
 

--- a/include/mqt-core/operations/CompoundOperation.hpp
+++ b/include/mqt-core/operations/CompoundOperation.hpp
@@ -17,12 +17,18 @@ namespace qc {
 class CompoundOperation final : public Operation {
 private:
   std::vector<std::unique_ptr<Operation>> ops;
+  bool customGate;
 
 public:
   explicit CompoundOperation();
 
+  explicit CompoundOperation(bool isCustom);
+
   explicit CompoundOperation(
       std::vector<std::unique_ptr<Operation>>&& operations);
+
+  explicit CompoundOperation(
+      std::vector<std::unique_ptr<Operation>>&& operations, bool isCustom);
 
   CompoundOperation(const CompoundOperation& co);
 
@@ -35,6 +41,8 @@ public:
   [[nodiscard]] bool isNonUnitaryOperation() const override;
 
   [[nodiscard]] inline bool isSymbolicOperation() const override;
+
+  [[nodiscard]] bool isCustomGate() const;
 
   void addControl(Control c) override;
 

--- a/include/mqt-core/operations/CompoundOperation.hpp
+++ b/include/mqt-core/operations/CompoundOperation.hpp
@@ -20,15 +20,11 @@ private:
   bool customGate;
 
 public:
-  explicit CompoundOperation();
-
-  explicit CompoundOperation(bool isCustom);
+  explicit CompoundOperation(bool isCustom = false);
 
   explicit CompoundOperation(
-      std::vector<std::unique_ptr<Operation>>&& operations);
-
-  explicit CompoundOperation(
-      std::vector<std::unique_ptr<Operation>>&& operations, bool isCustom);
+      std::vector<std::unique_ptr<Operation>>&& operations,
+      bool isCustom = false);
 
   CompoundOperation(const CompoundOperation& co);
 

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -1197,10 +1197,6 @@ Iterator flattenCompoundOperation(std::vector<std::unique_ptr<Operation>>& ops,
   return it;
 }
 
-void CircuitOptimizer::flattenOperations(QuantumComputation& qc) {
-  flattenOperations(qc, false);
-}
-
 void CircuitOptimizer::flattenOperations(QuantumComputation& qc,
                                          bool customGatesOnly) {
   auto it = qc.begin();

--- a/src/CircuitOptimizer.cpp
+++ b/src/CircuitOptimizer.cpp
@@ -1198,10 +1198,20 @@ Iterator flattenCompoundOperation(std::vector<std::unique_ptr<Operation>>& ops,
 }
 
 void CircuitOptimizer::flattenOperations(QuantumComputation& qc) {
+  flattenOperations(qc, false);
+}
+
+void CircuitOptimizer::flattenOperations(QuantumComputation& qc,
+                                         bool customGatesOnly) {
   auto it = qc.begin();
   while (it != qc.end()) {
     if ((*it)->isCompoundOperation()) {
-      it = flattenCompoundOperation(qc.ops, it);
+      auto& op = dynamic_cast<qc::CompoundOperation&>(**it);
+      if (!customGatesOnly || op.isCustomGate()) {
+        it = flattenCompoundOperation(qc.ops, it);
+      } else {
+        ++it;
+      }
     } else {
       ++it;
     }

--- a/src/operations/CompoundOperation.cpp
+++ b/src/operations/CompoundOperation.cpp
@@ -19,10 +19,9 @@
 #include <vector>
 
 namespace qc {
-CompoundOperation::CompoundOperation(bool isCustom) {
+CompoundOperation::CompoundOperation(bool isCustom) : customGate(isCustom) {
   name = "Compound operation:";
   type = Compound;
-  customGate = isCustom;
 }
 
 CompoundOperation::CompoundOperation() : CompoundOperation(false) {}

--- a/src/operations/CompoundOperation.cpp
+++ b/src/operations/CompoundOperation.cpp
@@ -39,7 +39,7 @@ CompoundOperation::CompoundOperation(
     : CompoundOperation(std::move(operations), false) {}
 
 CompoundOperation::CompoundOperation(const CompoundOperation& co)
-    : Operation(co), ops(co.ops.size()) {
+    : Operation(co), ops(co.ops.size()), customGate(co.customGate) {
   for (std::size_t i = 0; i < co.ops.size(); ++i) {
     ops[i] = co.ops[i]->clone();
   }
@@ -52,6 +52,7 @@ CompoundOperation& CompoundOperation::operator=(const CompoundOperation& co) {
     for (std::size_t i = 0; i < co.ops.size(); ++i) {
       ops[i] = co.ops[i]->clone();
     }
+    customGate = co.customGate;
   }
   return *this;
 }

--- a/src/operations/CompoundOperation.cpp
+++ b/src/operations/CompoundOperation.cpp
@@ -24,18 +24,12 @@ CompoundOperation::CompoundOperation(bool isCustom) : customGate(isCustom) {
   type = Compound;
 }
 
-CompoundOperation::CompoundOperation() : CompoundOperation(false) {}
-
 CompoundOperation::CompoundOperation(
     std::vector<std::unique_ptr<Operation>>&& operations, bool isCustom)
     : CompoundOperation(isCustom) {
   // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
   ops = std::move(operations);
 }
-
-CompoundOperation::CompoundOperation(
-    std::vector<std::unique_ptr<Operation>>&& operations)
-    : CompoundOperation(std::move(operations), false) {}
 
 CompoundOperation::CompoundOperation(const CompoundOperation& co)
     : Operation(co), ops(co.ops.size()), customGate(co.customGate) {

--- a/src/operations/CompoundOperation.cpp
+++ b/src/operations/CompoundOperation.cpp
@@ -19,17 +19,24 @@
 #include <vector>
 
 namespace qc {
-CompoundOperation::CompoundOperation() {
+CompoundOperation::CompoundOperation(bool isCustom) {
   name = "Compound operation:";
   type = Compound;
+  customGate = isCustom;
+}
+
+CompoundOperation::CompoundOperation() : CompoundOperation(false) {}
+
+CompoundOperation::CompoundOperation(
+    std::vector<std::unique_ptr<Operation>>&& operations, bool isCustom)
+    : CompoundOperation(isCustom) {
+  // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+  ops = std::move(operations);
 }
 
 CompoundOperation::CompoundOperation(
     std::vector<std::unique_ptr<Operation>>&& operations)
-    : CompoundOperation() {
-  // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
-  ops = std::move(operations);
-}
+    : CompoundOperation(std::move(operations), false) {}
 
 CompoundOperation::CompoundOperation(const CompoundOperation& co)
     : Operation(co), ops(co.ops.size()) {
@@ -60,6 +67,8 @@ bool CompoundOperation::isNonUnitaryOperation() const {
 }
 
 bool CompoundOperation::isCompoundOperation() const { return true; }
+
+bool CompoundOperation::isCustomGate() const { return customGate; }
 
 bool CompoundOperation::isSymbolicOperation() const {
   return std::any_of(ops.begin(), ops.end(),

--- a/src/parsers/QASM3Parser.cpp
+++ b/src/parsers/QASM3Parser.cpp
@@ -645,7 +645,7 @@ public:
         index++;
       }
 
-      auto op = std::make_unique<qc::CompoundOperation>();
+      auto op = std::make_unique<qc::CompoundOperation>(true);
       for (const auto& nestedGate : compoundGate->body) {
         if (auto barrierStatement =
                 std::dynamic_pointer_cast<BarrierStatement>(nestedGate);

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1220,10 +1220,10 @@ TEST_F(QFRFunctionality, FlattenCustomOnly) {
   qc2.push_back(opCompound);
   std::cout << qc2 << "\n";
 
-  qc::CircuitOptimizer::flattenOperations(qc, true);
+  qc::CircuitOptimizer::flattenOperations(qc2, true);
   std::cout << qc2 << "\n";
 
-  for (const auto& g : qc) {
+  for (const auto& g : qc2) {
     EXPECT_FALSE(g->isCompoundOperation());
   }
 

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -8,6 +8,7 @@
 #include "operations/Expression.hpp"
 #include "operations/NonUnitaryOperation.hpp"
 #include "operations/OpType.hpp"
+#include "operations/StandardOperation.hpp"
 
 #include <algorithm>
 #include <array>

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1216,9 +1216,8 @@ TEST_F(QFRFunctionality, FlattenCustomOnly) {
   std::vector<std::unique_ptr<Operation>> opsCompound;
   opsCompound.push_back(std::make_unique<StandardOperation>(0, qc::X));
   opsCompound.push_back(std::make_unique<StandardOperation>(0, qc::Z));
-  const CompoundOperation opCompound(std::move(opsCompound), true);
   QuantumComputation qc2(nqubits);
-  qc2.push_back(opCompound);
+  qc2.emplace_back<CompoundOperation>(std::move(opsCompound), true);
   std::cout << qc2 << "\n";
 
   qc::CircuitOptimizer::flattenOperations(qc2, true);

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1192,6 +1192,52 @@ TEST_F(QFRFunctionality, FlattenRecursive) {
   EXPECT_TRUE(gate2->getControls().empty());
 }
 
+TEST_F(QFRFunctionality, FlattenCustomOnly) {
+  const std::size_t nqubits = 1U;
+
+  // create a nested compound operation
+  QuantumComputation op(nqubits);
+  op.x(0);
+  op.z(0);
+  QuantumComputation op2(nqubits);
+  op2.emplace_back(op.asCompoundOperation());
+  QuantumComputation qc(nqubits);
+  qc.emplace_back(op2.asCompoundOperation());
+  std::cout << qc << "\n";
+
+  qc::CircuitOptimizer::flattenOperations(qc, true);
+  std::cout << qc << "\n";
+
+  ASSERT_EQ(qc.getNops(), 1U);
+  auto& gate = qc.at(0);
+  EXPECT_EQ(gate->getType(), qc::Compound);
+
+  std::vector<std::unique_ptr<Operation>> opsCompound;
+  opsCompound.push_back(std::make_unique<StandardOperation>(0, qc::X));
+  opsCompound.push_back(std::make_unique<StandardOperation>(0, qc::Z));
+  CompoundOperation opCompound(std::move(opsCompound), true);
+  QuantumComputation qc2(nqubits);
+  qc2.push_back(opCompound);
+  std::cout << qc2 << "\n";
+
+  qc::CircuitOptimizer::flattenOperations(qc, true);
+  std::cout << qc2 << "\n";
+
+  for (const auto& g : qc) {
+    EXPECT_FALSE(g->isCompoundOperation());
+  }
+
+  ASSERT_EQ(qc2.getNops(), 2U);
+  auto& gate3 = qc2.at(0);
+  EXPECT_EQ(gate3->getType(), qc::X);
+  EXPECT_EQ(gate3->getTargets().at(0), 0U);
+  EXPECT_TRUE(gate3->getControls().empty());
+  auto& gate4 = qc2.at(1);
+  EXPECT_EQ(gate4->getType(), qc::Z);
+  EXPECT_EQ(gate4->getTargets().at(0), 0U);
+  EXPECT_TRUE(gate4->getControls().empty());
+}
+
 TEST_F(QFRFunctionality, OperationEquality) {
   const auto x = StandardOperation(0, qc::X);
   const auto z = StandardOperation(0, qc::Z);

--- a/test/unittests/test_qfr_functionality.cpp
+++ b/test/unittests/test_qfr_functionality.cpp
@@ -1215,7 +1215,7 @@ TEST_F(QFRFunctionality, FlattenCustomOnly) {
   std::vector<std::unique_ptr<Operation>> opsCompound;
   opsCompound.push_back(std::make_unique<StandardOperation>(0, qc::X));
   opsCompound.push_back(std::make_unique<StandardOperation>(0, qc::Z));
-  CompoundOperation opCompound(std::move(opsCompound), true);
+  const CompoundOperation opCompound(std::move(opsCompound), true);
   QuantumComputation qc2(nqubits);
   qc2.push_back(opCompound);
   std::cout << qc2 << "\n";


### PR DESCRIPTION
## Description

This pull request adds the `customGate` flag to the `CompoundOperation` class. This flag is set for `CompoundOperations` that were constructed from custom gate calls.

The pull request also provides new functionality to the `flattenOperations` optimizer. Now, a second parameter can be used to indicate that only custom gates should be flattened. It makes sense to put this functionality here as outside of the `CircuitOptimizer` class, certain protected members cannot be accessed anymore.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
