### PR TITLE
Layer: Allow Redundant Gates

### DIFF
--- a/include/mqt-core/datastructures/UndirectedGraph.hpp
+++ b/include/mqt-core/datastructures/UndirectedGraph.hpp
@@ -77,8 +77,12 @@ public:
           ++degrees[j];
         }
         ++nEdges;
+        adjacencyMatrix[i][j - i] = e;
+      } else {
+        std::stringstream ss;
+        ss << "The edge (" << i << ", " << j << ") is already in the graph.";
+        throw std::invalid_argument(ss.str());
       }
-      adjacencyMatrix[i][j - i] = e;
     } else {
       if (adjacencyMatrix[j][i - j] == std::nullopt) {
         ++degrees[i];
@@ -86,8 +90,12 @@ public:
           ++degrees[j];
         }
         ++nEdges;
+        adjacencyMatrix[j][i - j] = e;
+      } else {
+        std::stringstream ss;
+        ss << "The edge (" << j << ", " << i << ") is already in the graph.";
+        throw std::invalid_argument(ss.str());
       }
-      adjacencyMatrix[j][i - j] = e;
     }
   }
   [[nodiscard]] auto getNVertices() const -> std::size_t { return nVertices; }

--- a/src/datastructures/Layer.cpp
+++ b/src/datastructures/Layer.cpp
@@ -60,9 +60,9 @@ auto Layer::constructDAG(const QuantumComputation& qc) -> void {
         // lookahead
         if (current->getOperation()->isInverseOf(
                 *lookahead[qubit]->getOperation()) &&
-                (currentGroup[qubit].empty() ||
-                !(currentGroup[qubit][0]->getOperation())
-                   ->commutesAtQubit(*current->getOperation(), qubit))) {
+            (currentGroup[qubit].empty() ||
+             !(currentGroup[qubit][0]->getOperation())
+                  ->commutesAtQubit(*current->getOperation(), qubit))) {
           // here: the current operation is the inverse of the lookahead
           // add an enabling edge from the lookahead to all operations on this
           // qubit including the destructive ones
@@ -99,11 +99,17 @@ auto Layer::constructDAG(const QuantumComputation& qc) -> void {
           }
           // check whether the current operation commutes with the current
           // group members
-          // NOTE: We treat operations that are already in the group as such that would not commute because redundant operations in a group cause problems later on, e.g., when generating interaction graphs
+          // NOTE: We treat operations that are already in the group as such
+          // that would not commute because redundant operations in a group
+          // cause problems later on, e.g., when generating interaction graphs
           if (!currentGroup[qubit].empty() &&
               (!(currentGroup[qubit][0]->getOperation())
-                   ->commutesAtQubit(*current->getOperation(), qubit) ||
-                   std::find_if(currentGroup[qubit].cbegin(), currentGroup[qubit].cend(), [&current](const auto& vertex){ return *vertex->getOperation() == *current->getOperation(); }) != currentGroup[qubit].cend())) {
+                    ->commutesAtQubit(*current->getOperation(), qubit) ||
+               std::find_if(
+                   currentGroup[qubit].cbegin(), currentGroup[qubit].cend(),
+                   [&current](const auto& vertex) {
+                     return *vertex->getOperation() == *current->getOperation();
+                   }) != currentGroup[qubit].cend())) {
             // here: the current operation does not commute with the current
             // group members and is not the inverse of the lookahead
             // --> start a new group

--- a/src/datastructures/Layer.cpp
+++ b/src/datastructures/Layer.cpp
@@ -59,7 +59,10 @@ auto Layer::constructDAG(const QuantumComputation& qc) -> void {
         // check whether the current operation is the inverse of the
         // lookahead
         if (current->getOperation()->isInverseOf(
-                *lookahead[qubit]->getOperation())) {
+                *lookahead[qubit]->getOperation()) &&
+                (currentGroup[qubit].empty() ||
+                !(currentGroup[qubit][0]->getOperation())
+                   ->commutesAtQubit(*current->getOperation(), qubit))) {
           // here: the current operation is the inverse of the lookahead
           // add an enabling edge from the lookahead to all operations on this
           // qubit including the destructive ones
@@ -96,9 +99,11 @@ auto Layer::constructDAG(const QuantumComputation& qc) -> void {
           }
           // check whether the current operation commutes with the current
           // group members
-          if (!currentGroup[qubit].empty() and
-              !(currentGroup[qubit][0]->getOperation())
-                   ->commutesAtQubit(*current->getOperation(), qubit)) {
+          // NOTE: We treat operations that are already in the group as such that would not commute because redundant operations in a group cause problems later on, e.g., when generating interaction graphs
+          if (!currentGroup[qubit].empty() &&
+              (!(currentGroup[qubit][0]->getOperation())
+                   ->commutesAtQubit(*current->getOperation(), qubit) ||
+                   std::find_if(currentGroup[qubit].cbegin(), currentGroup[qubit].cend(), [&current](const auto& vertex){ return *vertex->getOperation() == *current->getOperation(); }) != currentGroup[qubit].cend())) {
             // here: the current operation does not commute with the current
             // group members and is not the inverse of the lookahead
             // --> start a new group

--- a/src/datastructures/Layer.cpp
+++ b/src/datastructures/Layer.cpp
@@ -4,6 +4,7 @@
 #include "QuantumComputation.hpp"
 #include "operations/OpType.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <sstream>

--- a/test/datastructures/test_undirected_graph.cpp
+++ b/test/datastructures/test_undirected_graph.cpp
@@ -1,6 +1,7 @@
 #include "datastructures/UndirectedGraph.hpp"
 
 #include <gtest/gtest.h>
+#include <stdexcept>
 #include <tuple>
 
 namespace qc {

--- a/test/datastructures/test_undirected_graph.cpp
+++ b/test/datastructures/test_undirected_graph.cpp
@@ -21,12 +21,12 @@ TEST(UndirectedGraph, Numbered) {
   EXPECT_FALSE(g.isAdjacent(1, 0));
   EXPECT_TRUE(g.isAdjacentEdge({1, 2}, {2, 3}));
 
-  EXPECT_THROW(g.addVertex(1), std::invalid_arguement);
-  EXPECT_THROW(g.addEdge(1, 2, 10), std::invalid_arguement);
-  EXPECT_THROW(g.addEdge(2, 1, 10), std::invalid_arguement);
-  EXPECT_THROW(std::ignore = g.getDegree(4), std::invalid_arguement);
-  EXPECT_THROW(std::ignore = g.getEdge(0, 1), std::invalid_arguement);
-  EXPECT_THROW(std::ignore = g.isAdjacent(0, 10), std::invalid_arguement);
-  EXPECT_THROW(std::ignore = g.isAdjacent(10, 1), std::invalid_arguement);
+  EXPECT_THROW(g.addVertex(1), std::invalid_argument);
+  EXPECT_THROW(g.addEdge(1, 2, 10), std::invalid_argument);
+  EXPECT_THROW(g.addEdge(2, 1, 10), std::invalid_argument);
+  EXPECT_THROW(std::ignore = g.getDegree(4), std::invalid_argument);
+  EXPECT_THROW(std::ignore = g.getEdge(0, 1), std::invalid_argument);
+  EXPECT_THROW(std::ignore = g.isAdjacent(0, 10), std::invalid_argument);
+  EXPECT_THROW(std::ignore = g.isAdjacent(10, 1), std::invalid_argument);
 }
 } // namespace qc

--- a/test/datastructures/test_undirected_graph.cpp
+++ b/test/datastructures/test_undirected_graph.cpp
@@ -21,8 +21,12 @@ TEST(UndirectedGraph, Numbered) {
   EXPECT_FALSE(g.isAdjacent(1, 0));
   EXPECT_TRUE(g.isAdjacentEdge({1, 2}, {2, 3}));
 
-  EXPECT_ANY_THROW(g.addVertex(1));
-  EXPECT_ANY_THROW(std::ignore = g.getDegree(4));
-  EXPECT_ANY_THROW(std::ignore = g.getEdge(0, 1));
+  EXPECT_THROW(g.addVertex(1), std::invalid_arguement);
+  EXPECT_THROW(g.addEdge(1, 2, 10), std::invalid_arguement);
+  EXPECT_THROW(g.addEdge(2, 1, 10), std::invalid_arguement);
+  EXPECT_THROW(std::ignore = g.getDegree(4), std::invalid_arguement);
+  EXPECT_THROW(std::ignore = g.getEdge(0, 1), std::invalid_arguement);
+  EXPECT_THROW(std::ignore = g.isAdjacent(0, 10), std::invalid_arguement);
+  EXPECT_THROW(std::ignore = g.isAdjacent(10, 1), std::invalid_arguement);
 }
 } // namespace qc


### PR DESCRIPTION
## Description

Previously, the [`Layer.hpp`](https://github.com/cda-tum/mqt-core/blob/main/include/mqt-core/datastructures/Layer.hpp) class implicitly assumed that the circuit is fully reduced, i.e., redundant gates are removed. The new behaviour is to create new layer group for a gate that is already present in the current group, i.e., to handle them in the same way as they would not commute with the current group. Hence, every gate in a group is unique with respect its type and the qubits it is operating on.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
