### PR TITLE
🏷️ providing a convenient `CircuitInputType`

### DIFF
--- a/src/mqt/core/load.py
+++ b/src/mqt/core/load.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 from os import PathLike
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from . import QuantumComputation
 
 if TYPE_CHECKING:
     from qiskit.circuit import QuantumCircuit
 
+    CircuitInputType = Union[QuantumComputation, str, PathLike[str], QuantumCircuit]
 
-def load(input_circuit: QuantumComputation | str | PathLike[str] | QuantumCircuit) -> QuantumComputation:
+
+def load(input_circuit: CircuitInputType) -> QuantumComputation:
     """Load a quantum circuit from any supported format as a :class:`~mqt.core.QuantumComputation`.
 
     Args:
@@ -48,3 +50,5 @@ def load(input_circuit: QuantumComputation | str | PathLike[str] | QuantumCircui
 
 
 __all__ = ["load"]
+if TYPE_CHECKING:
+    __all__ += ["CircuitInputType"]


### PR DESCRIPTION
## Description

This PR provides a convenient type that summarizes the default circuit inputs to the `load` method.
Special care is taken that this type is only defined in type checking environments and does not require importing optional dependencies that might not be available at runtime (such as qiskit).

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
