### PR TITLE
⚗️ upload to Test PyPI for pushes on `main`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,13 +11,19 @@ permissions:
   id-token: write
 
 jobs:
+  # Builds the sdist and wheels on all supported platforms and uploads the resulting
+  # wheels as GitHub artifacts `dev-cibw-*`, `test-cibw-*`, or `cibw-*`, depending on
+  # whether the workflow is triggered from a PR, a push to main, or a release, respectively.
   python-packaging:
     name: 🐍 Packaging
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.4
     with:
+      # Do not include local version information on pushes to main to facilitate TestPyPI uploads.
       no-local-version: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+      # Do not build emulated wheels on pushes to main to reduce runner load for CD.
       build-emulated-wheels: ${{ github.ref != 'refs/heads/main' || github.event_name != 'push' }}
 
+  # Downloads the previously generated artifacts and deploys to TestPyPI on pushes to main
   deploy-test-pypi:
     name: 🚀 Deploy to Test PyPI
     runs-on: ubuntu-latest
@@ -37,6 +43,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           attestations: true
 
+  # Downloads the previously generated artifacts and deploys to PyPI on published releases.
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'
     name: 🚀 Deploy to PyPI

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,6 +24,7 @@ jobs:
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.4
     with:
       no-local-version: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+      build-emulated-wheels: ${{ github.ref != 'refs/heads/main' || github.event_name != 'push' }}
 
   deploy-test-pypi:
     name: 🚀 Deploy to Test PyPI

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,11 +1,18 @@
 name: CD
 on:
+  push:
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:
   pull_request:
     paths:
       - .github/workflows/cd.yml
+
+permissions:
+  attestations: write
+  contents: read
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -15,6 +22,27 @@ jobs:
   python-packaging:
     name: 🐍 Packaging
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.4
+    with:
+      no-local-version: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+
+  deploy-test-pypi:
+    name: 🚀 Deploy to Test PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: test-pypi
+      url: https://test.pypi.org/p/mqt.core
+    needs: [python-packaging]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: test-cibw-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          attestations: true
 
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'
@@ -23,10 +51,6 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/mqt.core
-    permissions:
-      id-token: write
-      attestations: write
-      contents: read
     needs: [python-packaging]
     steps:
       - uses: actions/download-artifact@v4
@@ -39,3 +63,5 @@ jobs:
         with:
           subject-path: "dist/*"
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,22 +1,14 @@
 name: CD
 on:
-  push:
-    branches: [main]
+  workflow_call:
   release:
     types: [published]
   workflow_dispatch:
-  pull_request:
-    paths:
-      - .github/workflows/cd.yml
 
 permissions:
   attestations: write
   contents: read
   id-token: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 
 jobs:
   python-packaging:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.4
 
+  cd:
+    name: 🚀 CD
+    needs: change-detection
+    if: fromJSON(needs.change-detection.outputs.run-cd)
+    uses: ./.github/workflows/cd.yml
+
   required-checks-pass: # This job does nothing and is only used for branch protection
     name: 🚦 Check
     if: always()
@@ -53,6 +59,7 @@ jobs:
       - cpp-linter
       - python-tests
       - code-ql
+      - cd
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
@@ -74,5 +81,9 @@ jobs:
             ${{
               fromJSON(needs.change-detection.outputs.run-code-ql)
               && '' || 'code-ql,'
+            }}
+            ${{
+              fromJSON(needs.change-detection.outputs.run-cd)
+              && '' || 'cd,'
             }}
           jobs: ${{ toJSON(needs) }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,3 +294,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
 before-build = "uv pip install delvewheel>=1.7.3"
 repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --namespace-pkg mqt"
 environment = { CMAKE_GENERATOR = "Ninja", SKBUILD_CMAKE_ARGS="--fresh" }
+
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_arm64"
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }


### PR DESCRIPTION
## Description

This PR updates the CD workflow so that anytime it runs on a push to `main`, it uploads the resulting package to Test PyPI. This allows to battle test the packages before official releases.
This will be especially important in the context of #662.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
