### PR TITLE
🚸 rename algorithms target and adapt nox config

### DIFF
--- a/eval/CMakeLists.txt
+++ b/eval/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_executable(mqt-core-dd-eval eval_dd_package.cpp)
-target_link_libraries(mqt-core-dd-eval PRIVATE MQT::CoreDD MQT::CoreAlgo MQT::CoreCircuitOptimizer
-                                               MQT::ProjectOptions MQT::ProjectWarnings)
+target_link_libraries(
+  mqt-core-dd-eval PRIVATE MQT::CoreDD MQT::CoreAlgorithms MQT::CoreCircuitOptimizer
+                           MQT::ProjectOptions MQT::ProjectWarnings)

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,7 +68,7 @@ def _run_tests(
 
     session.install(*BUILD_REQUIREMENTS, *install_args, env=env)
     install_arg = f"-ve.[{','.join(_extras)}]"
-    session.install("--no-build-isolation", install_arg, *install_args, env=env)
+    session.install("--no-build-isolation", "--reinstall-package", "mqt.core", install_arg, *install_args, env=env)
     session.run("pytest", *run_args, *posargs, env=env)
 
 
@@ -100,7 +100,7 @@ def docs(session: nox.Session) -> None:
     serve = args.builder == "html" and session.interactive
     extra_installs = ["sphinx-autobuild"] if serve else []
     session.install(*BUILD_REQUIREMENTS, *extra_installs)
-    session.install("--no-build-isolation", "-ve.[docs]")
+    session.install("--no-build-isolation", "-ve.[docs]", "--reinstall-package", "mqt.core")
     session.chdir("docs")
 
     if args.builder == "linkcheck":

--- a/src/algorithms/CMakeLists.txt
+++ b/src/algorithms/CMakeLists.txt
@@ -3,50 +3,51 @@
 # https://github.com/cda-tum/mqt-core for more information.
 #
 
-if(NOT TARGET ${MQT_CORE_TARGET_NAME}-algo)
+if(NOT TARGET ${MQT_CORE_TARGET_NAME}-algorithms)
   # collect headers and source files
   file(GLOB_RECURSE ALGO_HEADERS ${MQT_CORE_INCLUDE_BUILD_DIR}/algorithms/**.hpp)
   file(GLOB_RECURSE ALGO_SOURCES **.cpp)
 
   # add algo package library
-  add_library(${MQT_CORE_TARGET_NAME}-algo ${ALGO_HEADERS} ${ALGO_SOURCES})
+  add_library(${MQT_CORE_TARGET_NAME}-algorithms ${ALGO_HEADERS} ${ALGO_SOURCES})
 
   # add link libraries
   target_link_libraries(
-    ${MQT_CORE_TARGET_NAME}-algo
+    ${MQT_CORE_TARGET_NAME}-algorithms
     PUBLIC MQT::CoreIR
     PRIVATE MQT::ProjectOptions MQT::ProjectWarnings)
 
   # set include directories
   target_include_directories(
-    ${MQT_CORE_TARGET_NAME}-algo PUBLIC $<BUILD_INTERFACE:${MQT_CORE_INCLUDE_BUILD_DIR}>
-                                        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+    ${MQT_CORE_TARGET_NAME}-algorithms PUBLIC $<BUILD_INTERFACE:${MQT_CORE_INCLUDE_BUILD_DIR}>
+                                              $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
   # add MQT alias
-  add_library(MQT::CoreAlgo ALIAS ${MQT_CORE_TARGET_NAME}-algo)
+  add_library(MQT::CoreAlgorithms ALIAS ${MQT_CORE_TARGET_NAME}-algorithms)
 
   # set versioning information
   set_target_properties(
-    ${MQT_CORE_TARGET_NAME}-algo
+    ${MQT_CORE_TARGET_NAME}-algorithms
     PROPERTIES VERSION ${PROJECT_VERSION}
                SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
-               EXPORT_NAME CoreAlgo)
+               EXPORT_NAME CoreAlgorithms)
 
   # generate export header
   include(GenerateExportHeader)
-  generate_export_header(${MQT_CORE_TARGET_NAME}-algo BASE_NAME mqt_core_algo)
+  generate_export_header(${MQT_CORE_TARGET_NAME}-algorithms BASE_NAME mqt_core_algorithms)
   if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(${MQT_CORE_TARGET_NAME}-algo PUBLIC MQT_CORE_ALGO_STATIC_DEFINE)
+    target_compile_definitions(${MQT_CORE_TARGET_NAME}-algorithms
+                               PUBLIC MQT_CORE_ALGO_STATIC_DEFINE)
   endif()
 
   # install export header
   if(MQT_CORE_INSTALL)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mqt_core_algo_export.h
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mqt_core_algorithms_export.h
             DESTINATION ${MQT_CORE_INCLUDE_INSTALL_DIR})
   endif()
 
   # add to list of MQT core targets
   set(MQT_CORE_TARGETS
-      ${MQT_CORE_TARGETS} ${MQT_CORE_TARGET_NAME}-algo
+      ${MQT_CORE_TARGETS} ${MQT_CORE_TARGET_NAME}-algorithms
       PARENT_SCOPE)
 endif()

--- a/test/circuit_optimizer/CMakeLists.txt
+++ b/test/circuit_optimizer/CMakeLists.txt
@@ -2,5 +2,5 @@ if(TARGET MQT::CoreCircuitOptimizer)
   file(GLOB_RECURSE CIRCUIT_OPTIMIZER_TEST_SOURCES *.cpp)
   package_add_test(mqt-core-circuit-optimizer-test MQT::CoreCircuitOptimizer
                    ${CIRCUIT_OPTIMIZER_TEST_SOURCES})
-  target_link_libraries(mqt-core-circuit-optimizer-test PRIVATE MQT::CoreAlgo)
+  target_link_libraries(mqt-core-circuit-optimizer-test PRIVATE MQT::CoreAlgorithms)
 endif()


### PR DESCRIPTION
## Description

This PR is a follow-up to #668 and renames the `MQT::CoreAlgo` target (and associated concepts) to `MQT::CoreAlgorithms` to also match the corresponding folder name.

It also slightly adjusts the noxfile to make sure that the local package is always rebuilt.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
