### PR TITLE
🚨 fix Qiskit 1.2 deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ filterwarnings = [
     'ignore:\s.*Pyarrow.*:DeprecationWarning:',
     'ignore:.*datetime\.datetime\.utcfromtimestamp.*:DeprecationWarning:',
     'ignore:.*Qiskit with Python 3.8.*:DeprecationWarning:',
+    'ignore:.*no need for these schema-conformant objects.*:DeprecationWarning:', # Qiskit itself imports deprecated code (should be resolved in the 1.2.1 release)
 ]
 log_cli_level = "info"
 testpaths = ["test/python"]

--- a/src/mqt/core/plugins/qiskit.py
+++ b/src/mqt/core/plugins/qiskit.py
@@ -83,8 +83,8 @@ def qiskit_to_mqt(circ: QuantumCircuit) -> QuantumComputation:
         for symb_param in symb_params:
             qc.add_variable(symb_param)
 
-    # import initial layout and output permutation in case it is available
-    if (hasattr(circ, "layout") and circ.layout is not None) or circ._layout is not None:  # noqa: SLF001
+    # import initial layout and output permutation if available
+    if circ.layout is not None:
         _import_layouts(qc, circ)
 
     qc.initialize_io_mapping()

--- a/src/mqt/core/plugins/qiskit.py
+++ b/src/mqt/core/plugins/qiskit.py
@@ -70,8 +70,16 @@ def qiskit_to_mqt(circ: QuantumCircuit) -> QuantumComputation:
         )
         qc.global_phase = 0
 
-    for instruction, qargs, cargs in circ.data:
-        symb_params = _emplace_operation(qc, instruction, qargs, cargs, instruction.params, qubit_map, clbit_map)
+    for instruction in circ.data:
+        symb_params = _emplace_operation(
+            qc,
+            instruction.operation,
+            instruction.qubits,
+            instruction.clbits,
+            instruction.operation.params,
+            qubit_map,
+            clbit_map,
+        )
         for symb_param in symb_params:
             qc.add_variable(symb_param)
 
@@ -410,12 +418,12 @@ def _import_definition(
     comp_op = cast(CompoundOperation, qc[-1])
 
     params = []
-    for instruction, q_args, c_args in circ.data:
-        mapped_qargs = [qarg_map[qarg] for qarg in q_args]
-        mapped_cargs = [carg_map[carg] for carg in c_args]
-        instruction_params = instruction.params
+    for instruction in circ.data:
+        mapped_qargs = [qarg_map[qarg] for qarg in instruction.qubits]
+        mapped_cargs = [carg_map[carg] for carg in instruction.clbits]
+        operation = instruction.operation
         new_params = _emplace_operation(
-            comp_op, instruction, mapped_qargs, mapped_cargs, instruction_params, qubit_map, clbit_map
+            comp_op, operation, mapped_qargs, mapped_cargs, operation.params, qubit_map, clbit_map
         )
         params.extend(new_params)
     return params


### PR DESCRIPTION
## Description

Fixes all the deprecation warnings raised by Qiskit 1.2.
A warning filter still has to be applied since Qiskit itself imports deprecated code on the default path. This should be fixed in a follow-up release.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
