### PR TITLE
🚸♻️ convenience methods and updates for DD functionality

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
 FormatStyle: file
 
 Checks: |
-  boost-*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
   clang-analyzer-*,

--- a/include/mqt-core/dd/Operations.hpp
+++ b/include/mqt-core/dd/Operations.hpp
@@ -341,7 +341,7 @@ qc::VectorDD applyClassicControlledOperation(
     return in;
   }
 
-  return applyUnitaryOperation(classic->getOperation(), in, dd, permutation);
+  return applyUnitaryOperation(classic, in, dd, permutation);
 }
 
 template <class Config>

--- a/include/mqt-core/dd/Operations.hpp
+++ b/include/mqt-core/dd/Operations.hpp
@@ -243,7 +243,7 @@ qc::MatrixDD getInverseDD(const qc::Operation* op, Package<Config>& dd,
 }
 
 template <class Config, class Node>
-Edge<Node> applyUnitaryOperation(const qc::Operation* op, Edge<Node> in,
+Edge<Node> applyUnitaryOperation(const qc::Operation* op, const Edge<Node>& in,
                                  Package<Config>& dd,
                                  const qc::Permutation& permutation = {}) {
   static_assert(std::is_same_v<Node, dd::vNode> ||
@@ -299,7 +299,7 @@ qc::VectorDD applyReset(const qc::Operation* op, qc::VectorDD in,
 
 template <class Config>
 qc::VectorDD applyClassicControlledOperation(
-    const qc::Operation* op, qc::VectorDD in, Package<Config>& dd,
+    const qc::Operation* op, const qc::VectorDD& in, Package<Config>& dd,
     std::vector<bool>& measurements, const qc::Permutation& permutation = {}) {
   assert(op->isClassicControlledOperation());
   const auto* classic = dynamic_cast<const qc::ClassicControlledOperation*>(op);

--- a/include/mqt-core/dd/Operations.hpp
+++ b/include/mqt-core/dd/Operations.hpp
@@ -360,10 +360,8 @@ qc::VectorDD applyClassicControlledOperation(const qc::Operation* op,
       return actualValue > expectedValue;
     case qc::ComparisonKind::Geq:
       return actualValue >= expectedValue;
-    default:
-      qc::unreachable();
-      throw qc::QFRException("Unknown comparison kind.");
     }
+    qc::unreachable();
   }();
 
   if (!control) {

--- a/include/mqt-core/dd/Operations.hpp
+++ b/include/mqt-core/dd/Operations.hpp
@@ -294,8 +294,8 @@ applyMeasurement(const qc::Operation* op, qc::VectorDD in, Package<Config>& dd,
   for (size_t j = 0U; j < qubits.size(); ++j) {
     measurements.at(bits.at(j)) =
         dd.measureOneCollapsing(
-            in, static_cast<dd::Qubit>(permutation.at(qubits.at(j))), true,
-            rng) == '1';
+            in, static_cast<dd::Qubit>(permutation.at(qubits.at(j))), rng) ==
+        '1';
   }
   return in;
 }
@@ -312,7 +312,7 @@ qc::VectorDD applyReset(const qc::Operation* op, qc::VectorDD in,
   const auto& qubits = reset->getTargets();
   for (const auto& qubit : qubits) {
     const auto bit = dd.measureOneCollapsing(
-        in, static_cast<dd::Qubit>(permutation.at(qubit)), true, rng);
+        in, static_cast<dd::Qubit>(permutation.at(qubit)), rng);
     // apply an X operation whenever the measured result is one
     if (bit == '1') {
       const auto x = qc::StandardOperation(qubit, qc::X);

--- a/include/mqt-core/dd/Operations.hpp
+++ b/include/mqt-core/dd/Operations.hpp
@@ -196,7 +196,8 @@ qc::MatrixDD getDD(const qc::Operation* op, Package<Config>& dd,
     return id;
   }
 
-  if (const auto* standardOp = dynamic_cast<const qc::StandardOperation*>(op)) {
+  if (op->isStandardOperation()) {
+    const auto* standardOp = dynamic_cast<const qc::StandardOperation*>(op);
     const auto& targets = permutation.apply(op->getTargets());
     const auto& controls = permutation.apply(op->getControls());
 
@@ -210,7 +211,8 @@ qc::MatrixDD getDD(const qc::Operation* op, Package<Config>& dd,
                                   inverse);
   }
 
-  if (const auto* compoundOp = dynamic_cast<const qc::CompoundOperation*>(op)) {
+  if (op->isCompoundOperation()) {
+    const auto* compoundOp = dynamic_cast<const qc::CompoundOperation*>(op);
     auto e = dd.makeIdent();
     if (inverse) {
       for (const auto& operation : *compoundOp) {
@@ -224,8 +226,9 @@ qc::MatrixDD getDD(const qc::Operation* op, Package<Config>& dd,
     return e;
   }
 
-  if (const auto* classicOp =
-          dynamic_cast<const qc::ClassicControlledOperation*>(op)) {
+  if (op->isClassicControlledOperation()) {
+    const auto* classicOp =
+        dynamic_cast<const qc::ClassicControlledOperation*>(op);
     return getDD(classicOp->getOperation(), dd, permutation, inverse);
   }
 
@@ -245,7 +248,6 @@ Edge<Node> applyUnitaryOperation(const qc::Operation* op, Edge<Node> in,
                                  const qc::Permutation& permutation = {}) {
   static_assert(std::is_same_v<Node, dd::vNode> ||
                 std::is_same_v<Node, dd::mNode>);
-  assert(op->isUnitary());
   auto tmp = dd.multiply(getDD(op, dd, permutation), in);
   dd.incRef(tmp);
   dd.decRef(in);

--- a/include/mqt-core/dd/Operations.hpp
+++ b/include/mqt-core/dd/Operations.hpp
@@ -174,23 +174,13 @@ getStandardOperationDD(const qc::StandardOperation* op, Package<Config>& dd,
 // the mapping specified by the permutation, e.g.
 //      if perm[0] = 1 and perm[1] = 0
 //      then cx 0 1 will be translated to cx perm[0] perm[1] == cx 1 0
+// An empty permutation marks the identity permutation.
 
 template <class Config>
 qc::MatrixDD getDD(const qc::Operation* op, Package<Config>& dd,
-                   qc::Permutation& permutation, const bool inverse = false) {
+                   const qc::Permutation& permutation = {},
+                   const bool inverse = false) {
   const auto type = op->getType();
-
-  // if a permutation is provided and the current operation is a SWAP, this
-  // routine just updates the permutation
-  if (!permutation.empty() && type == qc::SWAP && !op->isControlled()) {
-    const auto& targets = op->getTargets();
-
-    const auto target0 = targets[0U];
-    const auto target1 = targets[1U];
-    // update permutation
-    std::swap(permutation.at(target0), permutation.at(target1));
-    return dd.makeIdent();
-  }
 
   if (type == qc::Barrier) {
     return dd.makeIdent();
@@ -207,12 +197,8 @@ qc::MatrixDD getDD(const qc::Operation* op, Package<Config>& dd,
   }
 
   if (const auto* standardOp = dynamic_cast<const qc::StandardOperation*>(op)) {
-    auto targets = op->getTargets();
-    auto controls = op->getControls();
-    if (!permutation.empty()) {
-      targets = permutation.apply(targets);
-      controls = permutation.apply(controls);
-    }
+    const auto& targets = permutation.apply(op->getTargets());
+    const auto& controls = permutation.apply(op->getControls());
 
     if (qc::isTwoQubitGate(type)) {
       assert(targets.size() == 2);
@@ -248,27 +234,15 @@ qc::MatrixDD getDD(const qc::Operation* op, Package<Config>& dd,
 }
 
 template <class Config>
-qc::MatrixDD getDD(const qc::Operation* op, Package<Config>& dd,
-                   const bool inverse = false) {
-  qc::Permutation perm{};
-  return getDD(op, dd, perm, inverse);
-}
-
-template <class Config>
-qc::MatrixDD getInverseDD(const qc::Operation* op, Package<Config>& dd) {
-  return getDD(op, dd, true);
-}
-
-template <class Config>
 qc::MatrixDD getInverseDD(const qc::Operation* op, Package<Config>& dd,
-                          qc::Permutation& permutation) {
+                          const qc::Permutation& permutation = {}) {
   return getDD(op, dd, permutation, true);
 }
 
 template <class Config, class Node>
 Edge<Node> applyUnitaryOperation(const qc::Operation* op, Edge<Node> in,
                                  Package<Config>& dd,
-                                 qc::Permutation& permutation) {
+                                 const qc::Permutation& permutation = {}) {
   static_assert(std::is_same_v<Node, dd::vNode> ||
                 std::is_same_v<Node, dd::mNode>);
   assert(op->isUnitary());
@@ -280,66 +254,63 @@ Edge<Node> applyUnitaryOperation(const qc::Operation* op, Edge<Node> in,
 }
 
 template <class Config>
-qc::VectorDD
-applyMeasurement(const qc::Operation* op, qc::VectorDD in, Package<Config>& dd,
-                 const qc::Permutation& permutation, std::mt19937_64& rng,
-                 std::vector<bool>& measurements) {
+qc::VectorDD applyMeasurement(const qc::Operation* op, qc::VectorDD in,
+                              Package<Config>& dd, std::mt19937_64& rng,
+                              std::vector<bool>& measurements,
+                              const qc::Permutation& permutation = {}) {
   assert(op->getType() == qc::Measure);
   assert(op->isNonUnitaryOperation());
   const auto* measure = dynamic_cast<const qc::NonUnitaryOperation*>(op);
   assert(measure != nullptr);
 
-  const auto& qubits = measure->getTargets();
+  const auto& qubits = permutation.apply(measure->getTargets());
   const auto& bits = measure->getClassics();
   for (size_t j = 0U; j < qubits.size(); ++j) {
     measurements.at(bits.at(j)) =
-        dd.measureOneCollapsing(
-            in, static_cast<dd::Qubit>(permutation.at(qubits.at(j))), rng) ==
-        '1';
+        dd.measureOneCollapsing(in, static_cast<dd::Qubit>(qubits.at(j)),
+                                rng) == '1';
   }
   return in;
 }
 
 template <class Config>
 qc::VectorDD applyReset(const qc::Operation* op, qc::VectorDD in,
-                        Package<Config>& dd, qc::Permutation& permutation,
-                        std::mt19937_64& rng) {
+                        Package<Config>& dd, std::mt19937_64& rng,
+                        const qc::Permutation& permutation = {}) {
   assert(op->getType() == qc::Reset);
   assert(op->isNonUnitaryOperation());
   const auto* reset = dynamic_cast<const qc::NonUnitaryOperation*>(op);
   assert(reset != nullptr);
 
-  const auto& qubits = reset->getTargets();
+  const auto& qubits = permutation.apply(reset->getTargets());
   for (const auto& qubit : qubits) {
-    const auto bit = dd.measureOneCollapsing(
-        in, static_cast<dd::Qubit>(permutation.at(qubit)), rng);
+    const auto bit =
+        dd.measureOneCollapsing(in, static_cast<dd::Qubit>(qubit), rng);
     // apply an X operation whenever the measured result is one
     if (bit == '1') {
       const auto x = qc::StandardOperation(qubit, qc::X);
-      in = applyUnitaryOperation(&x, in, dd, permutation);
+      in = applyUnitaryOperation(&x, in, dd);
     }
   }
   return in;
 }
 
 template <class Config>
-qc::VectorDD applyClassicControlledOperation(const qc::Operation* op,
-                                             qc::VectorDD in,
-                                             Package<Config>& dd,
-                                             qc::Permutation& permutation,
-                                             std::vector<bool>& measurements) {
+qc::VectorDD applyClassicControlledOperation(
+    const qc::Operation* op, qc::VectorDD in, Package<Config>& dd,
+    std::vector<bool>& measurements, const qc::Permutation& permutation = {}) {
   assert(op->isClassicControlledOperation());
   const auto* classic = dynamic_cast<const qc::ClassicControlledOperation*>(op);
   assert(classic != nullptr);
 
-  const auto& controlRegister = classic->getControlRegister();
+  const auto& [regStart, regSize] = classic->getControlRegister();
   const auto& expectedValue = classic->getExpectedValue();
   const auto& comparisonKind = classic->getComparisonKind();
 
   auto actualValue = 0ULL;
   // determine the actual value from measurements
-  for (std::size_t j = 0; j < controlRegister.second; ++j) {
-    if (measurements[controlRegister.first + j]) {
+  for (std::size_t j = 0; j < regSize; ++j) {
+    if (measurements[regStart + j]) {
       actualValue |= 1ULL << j;
     }
   }

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -423,7 +423,7 @@ public:
                                 std::array{vEdge::zero(), rightSubtree});
     }
 
-    vEdge e = makeDDNode(
+    const vEdge e = makeDDNode(
         static_cast<Qubit>(n - 1),
         std::array<vEdge, RADIX>{
             {{leftSubtree.p, {&constants::sqrt2over2, &constants::zero}},
@@ -488,7 +488,7 @@ public:
     const auto level = static_cast<Qubit>(std::log2(length) - 1);
     const auto state =
         makeStateFromVector(stateVector.begin(), stateVector.end(), level);
-    vEdge e{state.p, cn.lookup(state.w)};
+    const vEdge e{state.p, cn.lookup(state.w)};
     incRef(e);
     return e;
   }

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -394,7 +394,7 @@ public:
         break;
       }
     }
-    vEdge e{f.p, cn.lookup(f.w)};
+    const vEdge e{f.p, cn.lookup(f.w)};
     incRef(e);
     return e;
   }

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -569,7 +569,7 @@ public:
     for (; it != controls.end() && it->qubit < target; ++it) {
       for (auto i1 = 0U; i1 < RADIX; ++i1) {
         for (auto i2 = 0U; i2 < RADIX; ++i2) {
-          auto i = i1 * RADIX + i2;
+          const auto i = (i1 * RADIX) + i2;
           if (it->type == qc::Control::Type::Neg) { // neg. control
             edges[0] = em[i];
             edges[3] = (i1 == i2) ? mCachedEdge::one() : mCachedEdge::zero();
@@ -683,19 +683,19 @@ public:
         if (target0 > target1) {
           for (std::size_t i = 0; i < RADIX; ++i) {
             for (std::size_t j = 0; j < RADIX; ++j) {
-              local.at(i * RADIX + j) =
-                  em.at(row * RADIX + i).at(col * RADIX + j);
+              local.at((i * RADIX) + j) =
+                  em.at((row * RADIX) + i).at((col * RADIX) + j);
             }
           }
         } else {
           for (std::size_t i = 0; i < RADIX; ++i) {
             for (std::size_t j = 0; j < RADIX; ++j) {
-              local.at(i * RADIX + j) =
-                  em.at(i * RADIX + row).at(j * RADIX + col);
+              local.at((i * RADIX) + j) =
+                  em.at((i * RADIX) + row).at((j * RADIX) + col);
             }
           }
         }
-        em0.at(row * RADIX + col) =
+        em0.at((row * RADIX) + col) =
             makeDDNode(static_cast<Qubit>(smallerTarget), local);
       }
     }
@@ -999,7 +999,7 @@ private:
   }
 
 public:
-  std::pair<dd::fp, dd::fp>
+  static std::pair<dd::fp, dd::fp>
   determineMeasurementProbabilities(const vEdge& rootEdge, const Qubit index) {
     std::map<const vNode*, fp> measurementProbabilities;
     std::set<const vNode*> visited;
@@ -1442,7 +1442,7 @@ public:
     // conjugate transpose submatrices and rearrange as required
     for (auto i = 0U; i < RADIX; ++i) {
       for (auto j = 0U; j < RADIX; ++j) {
-        e[RADIX * i + j] = conjugateTransposeRec(a.p->e[RADIX * j + i]);
+        e[(RADIX * i) + j] = conjugateTransposeRec(a.p->e[(RADIX * j) + i]);
       }
     }
     // create new top node
@@ -1477,9 +1477,9 @@ public:
   }
 
   dEdge applyOperationToDensity(dEdge& e, const mEdge& operation) {
-    auto tmp0 = conjugateTranspose(operation);
-    auto tmp1 = multiply(e, densityFromMatrixEdge(tmp0), false);
-    auto tmp2 = multiply(densityFromMatrixEdge(operation), tmp1, true);
+    const auto tmp0 = conjugateTranspose(operation);
+    const auto tmp1 = multiply(e, densityFromMatrixEdge(tmp0), false);
+    const auto tmp2 = multiply(densityFromMatrixEdge(operation), tmp1, true);
     incRef(tmp2);
     dEdge::alignDensityEdge(e);
     decRef(e);
@@ -1591,10 +1591,10 @@ private:
     std::array<ResultEdge, n> edge{};
     for (auto i = 0U; i < rows; i++) {
       for (auto j = 0U; j < cols; j++) {
-        auto idx = cols * i + j;
+        auto idx = (cols * i) + j;
         edge[idx] = ResultEdge::zero();
         for (auto k = 0U; k < rows; k++) {
-          const auto xIdx = rows * i + k;
+          const auto xIdx = (rows * i) + k;
           LEdge e1{};
           if (x.p != nullptr && x.p->v == var) {
             e1 = x.p->e[xIdx];
@@ -1606,7 +1606,7 @@ private:
             }
           }
 
-          const auto yIdx = j + cols * k;
+          const auto yIdx = j + (cols * k);
           REdge e2{};
           if (y.p != nullptr && y.p->v == var) {
             e2 = y.p->e[yIdx];
@@ -1703,8 +1703,9 @@ public:
     return innerProduct(x, y).mag2();
   }
 
-  fp fidelityOfMeasurementOutcomes(const vEdge& e, const SparsePVec& probs,
-                                   const qc::Permutation& permutation = {}) {
+  static fp
+  fidelityOfMeasurementOutcomes(const vEdge& e, const SparsePVec& probs,
+                                const qc::Permutation& permutation = {}) {
     if (e.w.approximatelyZero()) {
       return 0.;
     }
@@ -1712,11 +1713,9 @@ public:
                                                   e.p->v + 1U);
   }
 
-  fp fidelityOfMeasurementOutcomesRecursive(const vEdge& e,
-                                            const SparsePVec& probs,
-                                            const std::size_t i,
-                                            const qc::Permutation& permutation,
-                                            const std::size_t nQubits) {
+  static fp fidelityOfMeasurementOutcomesRecursive(
+      const vEdge& e, const SparsePVec& probs, const std::size_t i,
+      const qc::Permutation& permutation, const std::size_t nQubits) {
     const auto top = ComplexNumbers::mag(e.w);
     if (e.isTerminal()) {
       auto idx = i;

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -1897,6 +1897,9 @@ private:
       if (x.isTerminal()) {
         return {y.p, rWeight};
       }
+      if (y.isTerminal()) {
+        return {x.p, rWeight};
+      }
     }
 
     // check if we already computed the product before and return the result

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -303,6 +303,7 @@ public:
           static_cast<Qubit>(p),
           std::array{f, dEdge::zero(), dEdge::zero(), dEdge::zero()});
     }
+    incRef(f);
     return f;
   }
 
@@ -319,6 +320,7 @@ public:
     for (std::size_t p = start; p < n + start; p++) {
       f = makeDDNode(static_cast<Qubit>(p), std::array{f, vEdge::zero()});
     }
+    incRef(f);
     return f;
   }
   // generate computational basis state |i> with n qubits
@@ -339,6 +341,7 @@ public:
         f = makeDDNode(static_cast<Qubit>(p), std::array{vEdge::zero(), f});
       }
     }
+    incRef(f);
     return f;
   }
   // generate general basis state with n qubits
@@ -391,7 +394,9 @@ public:
         break;
       }
     }
-    return {f.p, cn.lookup(f.w)};
+    vEdge e{f.p, cn.lookup(f.w)};
+    incRef(e);
+    return e;
   }
 
   // generate general GHZ state with n qubits
@@ -418,11 +423,13 @@ public:
                                 std::array{vEdge::zero(), rightSubtree});
     }
 
-    return makeDDNode(
+    vEdge e = makeDDNode(
         static_cast<Qubit>(n - 1),
         std::array<vEdge, RADIX>{
             {{leftSubtree.p, {&constants::sqrt2over2, &constants::zero}},
              {rightSubtree.p, {&constants::sqrt2over2, &constants::zero}}}});
+    incRef(e);
+    return e;
   }
 
   // generate general W state with n qubits
@@ -459,6 +466,7 @@ public:
                                   std::array{rightSubtree, vEdge::zero()});
       }
     }
+    incRef(leftSubtree);
     return leftSubtree;
   }
 
@@ -480,7 +488,9 @@ public:
     const auto level = static_cast<Qubit>(std::log2(length) - 1);
     const auto state =
         makeStateFromVector(stateVector.begin(), stateVector.end(), level);
-    return {state.p, cn.lookup(state.w)};
+    vEdge e{state.p, cn.lookup(state.w)};
+    incRef(e);
+    return e;
   }
 
   /**

--- a/include/mqt-core/dd/Simulation.hpp
+++ b/include/mqt-core/dd/Simulation.hpp
@@ -18,7 +18,6 @@ VectorDD simulate(const QuantumComputation* qc, const VectorDD& in,
   // measurements are currently not supported here
   auto permutation = qc->initialLayout;
   auto e = in;
-  dd.incRef(e);
 
   for (const auto& op : *qc) {
     e = applyUnitaryOperation(op.get(), e, dd, permutation);

--- a/include/mqt-core/dd/Simulation.hpp
+++ b/include/mqt-core/dd/Simulation.hpp
@@ -21,12 +21,7 @@ VectorDD simulate(const QuantumComputation* qc, const VectorDD& in,
   dd.incRef(e);
 
   for (const auto& op : *qc) {
-    auto tmp = dd.multiply(getDD(op.get(), dd, permutation), e);
-    dd.incRef(tmp);
-    dd.decRef(e);
-    e = tmp;
-
-    dd.garbageCollect();
+    e = applyUnitaryOperation(op.get(), e, dd, permutation);
   }
 
   // correct permutation if necessary

--- a/include/mqt-core/dd/Simulation.hpp
+++ b/include/mqt-core/dd/Simulation.hpp
@@ -35,6 +35,22 @@ std::map<std::string, std::size_t>
 simulate(const QuantumComputation* qc, const VectorDD& in, Package<Config>& dd,
          std::size_t shots, std::size_t seed = 0U);
 
+/**
+ * Sample from the output distribution of a quantum computation
+ *
+ * This method classically simulates the quantum computation @p qc and samples
+ * @p shots times from the output distribution. The seed for the random number
+ * generator can be set using the @p seed parameter.
+ *
+ * @param qc The quantum computation to simulate
+ * @param shots The number of shots to sample
+ * @param seed The seed for the random number generator
+ * @return A histogram of the measurement results
+ */
+std::map<std::string, std::size_t> sample(const QuantumComputation& qc,
+                                          std::size_t shots = 1024U,
+                                          std::size_t seed = 0U);
+
 template <class Config>
 void extractProbabilityVector(const QuantumComputation* qc, const VectorDD& in,
                               dd::SparsePVec& probVector, Package<Config>& dd);

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -694,29 +694,32 @@ public:
   void classicControlled(const OpType op, const Qubit target,
                          const ClassicalRegister& controlRegister,
                          const std::uint64_t expectedValue = 1U,
+                         const ComparisonKind cmp = ComparisonKind::Eq,
                          const std::vector<fp>& params = {}) {
     classicControlled(op, target, Controls{}, controlRegister, expectedValue,
-                      params);
+                      cmp, params);
   }
   void classicControlled(const OpType op, const Qubit target,
                          const Control control,
                          const ClassicalRegister& controlRegister,
                          const std::uint64_t expectedValue = 1U,
+                         const ComparisonKind cmp = ComparisonKind::Eq,
                          const std::vector<fp>& params = {}) {
     classicControlled(op, target, Controls{control}, controlRegister,
-                      expectedValue, params);
+                      expectedValue, cmp, params);
   }
   void classicControlled(const OpType op, const Qubit target,
                          const Controls& controls,
                          const ClassicalRegister& controlRegister,
                          const std::uint64_t expectedValue = 1U,
+                         const ComparisonKind cmp = ComparisonKind::Eq,
                          const std::vector<fp>& params = {}) {
     checkQubitRange(target, controls);
     checkClassicalRegister(controlRegister);
     std::unique_ptr<Operation> gate =
         std::make_unique<StandardOperation>(controls, target, op, params);
     emplace_back<ClassicControlledOperation>(std::move(gate), controlRegister,
-                                             expectedValue);
+                                             expectedValue, cmp);
   }
 
   /// strip away qubits with no operations applied to them and which do not pop

--- a/include/mqt-core/ir/operations/ClassicControlledOperation.hpp
+++ b/include/mqt-core/ir/operations/ClassicControlledOperation.hpp
@@ -82,6 +82,8 @@ public:
 
   [[nodiscard]] auto getOperation() const { return op.get(); }
 
+  [[nodiscard]] auto getComparisonKind() const { return comparisonKind; }
+
   [[nodiscard]] const Targets& getTargets() const override {
     return op->getTargets();
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,7 @@ isort.required-imports = ["from __future__ import annotations"]
 "test/python/**" = ["T20", "INP001"]
 "docs/**" = ["T20", "INP001"]
 "noxfile.py" = ["T20", "TID251"]
-"*.pyi" = ["D418", "PYI021", "DOC202"]  # pydocstyle
+"*.pyi" = ["D418", "DOC202", "PYI011", "PYI021"]
 "*.ipynb" = [
     "D",    # pydocstyle
     "E402", # Allow imports to appear anywhere in Jupyter notebooks

--- a/src/algorithms/QFT.cpp
+++ b/src/algorithms/QFT.cpp
@@ -1,6 +1,7 @@
 #include "algorithms/QFT.hpp"
 
 #include "Definitions.hpp"
+#include "ir/operations/ClassicControlledOperation.hpp"
 #include "ir/operations/OpType.hpp"
 
 #include <cmath>
@@ -48,7 +49,7 @@ void QFT::createCircuit() {
         } else {
           const auto powerOfTwo = std::pow(2., i - j + 1);
           const auto lambda = PI / powerOfTwo;
-          classicControlled(P, 0, {d, 1U}, 1U, std::vector{lambda});
+          classicControlled(P, 0, {d, 1U}, 1U, Eq, std::vector{lambda});
         }
       }
 

--- a/src/algorithms/QPE.cpp
+++ b/src/algorithms/QPE.cpp
@@ -1,6 +1,7 @@
 #include "algorithms/QPE.hpp"
 
 #include "Definitions.hpp"
+#include "ir/operations/ClassicControlledOperation.hpp"
 #include "ir/operations/OpType.hpp"
 
 #include <cmath>
@@ -102,7 +103,7 @@ void QPE::createCircuit() {
       // hybrid quantum-classical inverse QFT
       for (std::size_t j = 0; j < i; j++) {
         auto iQFTLambda = -PI / static_cast<double>(1ULL << (i - j));
-        classicControlled(P, 1, {j, 1U}, 1U, {iQFTLambda});
+        classicControlled(P, 1, {j, 1U}, 1U, Eq, {iQFTLambda});
       }
       h(1);
 

--- a/src/dd/FunctionalityConstruction.cpp
+++ b/src/dd/FunctionalityConstruction.cpp
@@ -2,16 +2,17 @@
 
 #include "dd/Package.hpp"
 #include "ir/QuantumComputation.hpp"
+#include "ir/operations/OpType.hpp"
 
 #include <cmath>
 #include <cstddef>
 #include <stack>
+#include <utility>
 
 namespace dd {
 template <class Config>
 MatrixDD buildFunctionality(const QuantumComputation* qc, Package<Config>& dd) {
-  const auto nq = qc->getNqubits();
-  if (nq == 0U) {
+  if (qc->getNqubits() == 0U) {
     return MatrixDD::one();
   }
 
@@ -19,6 +20,13 @@ MatrixDD buildFunctionality(const QuantumComputation* qc, Package<Config>& dd) {
   auto e = dd.createInitialMatrix(qc->ancillary);
 
   for (const auto& op : *qc) {
+    // SWAP gates can be executed virtually by changing the permutation
+    if (op->getType() == OpType::SWAP && !op->isControlled()) {
+      const auto& targets = op->getTargets();
+      std::swap(permutation.at(targets[0U]), permutation.at(targets[1U]));
+      continue;
+    }
+
     e = applyUnitaryOperation(op.get(), e, dd, permutation);
   }
   // correct permutation if necessary
@@ -66,14 +74,29 @@ bool buildFunctionalityRecursive(const QuantumComputation* qc,
                                  Package<Config>& dd) {
   // base case
   if (depth == 1U) {
-    auto e = getDD(qc->at(opIdx).get(), dd, permutation);
+    auto e = dd.makeIdent();
+    if (const auto& op = qc->at(opIdx);
+        op->getType() == OpType::SWAP && !op->isControlled()) {
+      const auto& targets = op->getTargets();
+      std::swap(permutation.at(targets[0U]), permutation.at(targets[1U]));
+    } else {
+      e = getDD(qc->at(opIdx).get(), dd, permutation);
+    }
     ++opIdx;
-    if (opIdx == qc->size()) { // only one element was left
+    if (opIdx == qc->size()) {
+      // only one element was left
       s.push(e);
       dd.incRef(e);
       return false;
     }
-    auto f = getDD(qc->at(opIdx).get(), dd, permutation);
+    auto f = dd.makeIdent();
+    if (const auto& op = qc->at(opIdx);
+        op->getType() == OpType::SWAP && !op->isControlled()) {
+      const auto& targets = op->getTargets();
+      std::swap(permutation.at(targets[0U]), permutation.at(targets[1U]));
+    } else {
+      f = getDD(qc->at(opIdx).get(), dd, permutation);
+    }
     s.push(dd.multiply(f, e)); // ! reverse multiplication
     dd.incRef(s.top());
     return (opIdx != qc->size() - 1U);

--- a/src/dd/FunctionalityConstruction.cpp
+++ b/src/dd/FunctionalityConstruction.cpp
@@ -19,13 +19,7 @@ MatrixDD buildFunctionality(const QuantumComputation* qc, Package<Config>& dd) {
   auto e = dd.createInitialMatrix(qc->ancillary);
 
   for (const auto& op : *qc) {
-    auto tmp = dd.multiply(getDD(op.get(), dd, permutation), e);
-
-    dd.incRef(tmp);
-    dd.decRef(e);
-    e = tmp;
-
-    dd.garbageCollect();
+    e = applyUnitaryOperation(op.get(), e, dd, permutation);
   }
   // correct permutation if necessary
   changePermutation(e, permutation, qc->outputPermutation, dd);

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <cstddef>
 #include <map>
+#include <memory>
 #include <random>
 #include <string>
 #include <utility>
@@ -197,8 +198,8 @@ std::map<std::string, std::size_t> sample(const QuantumComputation& qc,
                                           const std::size_t shots,
                                           const std::size_t seed) {
   const auto nqubits = qc.getNqubits();
-  Package<> dd(nqubits);
-  return sample(&qc, dd.makeZeroState(nqubits), dd, shots, seed);
+  auto dd = std::make_unique<dd::Package<>>(nqubits);
+  return sample(&qc, dd->makeZeroState(nqubits), *dd, shots, seed);
 }
 
 template <class Config>

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -81,7 +81,6 @@ simulate(const QuantumComputation* qc, const VectorDD& in, Package<Config>& dd,
     // simulate once and measure all qubits repeatedly
     auto permutation = qc->initialLayout;
     auto e = in;
-    dd.incRef(e);
 
     for (const auto& op : *qc) {
       // simply skip any non-unitary
@@ -135,11 +134,13 @@ simulate(const QuantumComputation* qc, const VectorDD& in, Package<Config>& dd,
   std::map<std::string, std::size_t> counts{};
 
   for (std::size_t i = 0U; i < shots; i++) {
+    // increase reference count of input state so that it is not collected.
+    dd.incRef(in);
+
     std::vector<bool> measurements(qc->getNcbits(), false);
 
     auto permutation = qc->initialLayout;
     auto e = in;
-    dd.incRef(e);
 
     for (const auto& op : *qc) {
       if (op->getType() == Measure) {
@@ -170,6 +171,9 @@ simulate(const QuantumComputation* qc, const VectorDD& in, Package<Config>& dd,
     }
     counts[shot]++;
   }
+
+  // decrease reference count of input state so that it can be collected.
+  dd.decRef(in);
 
   return counts;
 }

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -142,14 +142,11 @@ sample(const QuantumComputation* qc, const VectorDD& in, Package<Config>& dd,
   std::map<std::string, std::size_t> counts{};
 
   for (std::size_t i = 0U; i < shots; i++) {
-    // increase reference count of input state so that it is not collected.
-    dd.incRef(in);
-
     std::vector<bool> measurements(qc->getNcbits(), false);
 
     auto permutation = qc->initialLayout;
     auto e = in;
-
+    dd.incRef(e);
     for (const auto& op : *qc) {
       if (op->isUnitary()) {
         // SWAP gates can be executed virtually by changing the permutation
@@ -191,10 +188,6 @@ sample(const QuantumComputation* qc, const VectorDD& in, Package<Config>& dd,
     }
     counts[shot]++;
   }
-
-  // decrease reference count of input state so that it can be collected.
-  dd.decRef(in);
-
   return counts;
 }
 

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -22,7 +22,7 @@ namespace dd {
 template <class Config>
 std::map<std::string, std::size_t>
 sample(const QuantumComputation* qc, const VectorDD& in, Package<Config>& dd,
-       std::size_t shots, std::size_t seed) {
+       const std::size_t shots, const std::size_t seed) {
   auto isDynamicCircuit = false;
   auto hasMeasurements = false;
   auto measurementsLast = true;
@@ -184,7 +184,9 @@ sample(const QuantumComputation* qc, const VectorDD& in, Package<Config>& dd,
 
     std::string shot(qc->getNcbits(), '0');
     for (size_t bit = 0U; bit < qc->getNcbits(); ++bit) {
-      shot[qc->getNcbits() - bit - 1U] = measurements[bit] ? '1' : '0';
+      if (measurements[bit]) {
+        shot[qc->getNcbits() - bit - 1U] = '1';
+      }
     }
     counts[shot]++;
   }

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -178,6 +178,14 @@ simulate(const QuantumComputation* qc, const VectorDD& in, Package<Config>& dd,
   return counts;
 }
 
+std::map<std::string, std::size_t> sample(const QuantumComputation& qc,
+                                          const std::size_t shots,
+                                          const std::size_t seed) {
+  const auto nqubits = qc.getNqubits();
+  Package<> dd(nqubits);
+  return simulate(&qc, dd.makeZeroState(nqubits), dd, shots, seed);
+}
+
 template <class Config>
 void extractProbabilityVector(const QuantumComputation* qc, const VectorDD& in,
                               SparsePVec& probVector, Package<Config>& dd) {

--- a/src/dd/Simulation.cpp
+++ b/src/dd/Simulation.cpp
@@ -235,7 +235,7 @@ void extractProbabilityVectorRecursive(const QuantumComputation* qc,
       }
       const auto target = targets[0];
       auto [pzero, pone] = dd.determineMeasurementProbabilities(
-          state, static_cast<Qubit>(permutation.at(target)), true);
+          state, static_cast<Qubit>(permutation.at(target)));
 
       // normalize probabilities
       const auto norm = pzero + pone;
@@ -277,7 +277,7 @@ void extractProbabilityVectorRecursive(const QuantumComputation* qc,
 
       // determine probabilities for this measurement
       auto [pzero, pone] = dd.determineMeasurementProbabilities(
-          state, static_cast<Qubit>(permutation.at(target)), true);
+          state, static_cast<Qubit>(permutation.at(target)));
 
       // normalize probabilities
       const auto norm = pzero + pone;

--- a/src/mqt/core/ir/__init__.pyi
+++ b/src/mqt/core/ir/__init__.pyi
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Mutable
 from os import PathLike
 from typing import overload
 
-from .operations import Control, Operation, OpType
+from .operations import ComparisonKind, Control, Operation, OpType
 from .symbolic import Expression, Variable
 
 class Permutation(MutableMapping[int, int]):
@@ -1831,6 +1831,7 @@ class QuantumComputation(MutableSequence[Operation]):
         target: int,
         creg: tuple[int, int],
         expected_value: int = 1,
+        comparison_kind: ComparisonKind = ComparisonKind.eq,
         params: Sequence[float] = (),
     ) -> None:
         """Add a classic-controlled operation to the circuit.
@@ -1840,6 +1841,7 @@ class QuantumComputation(MutableSequence[Operation]):
             target: The target qubit
             creg: The classical register (index and number of bits)
             expected_value: The expected value of the classical register
+            comparison_kind: The kind of comparison to perform
             params: The parameters of the operation
         """
 
@@ -1851,6 +1853,7 @@ class QuantumComputation(MutableSequence[Operation]):
         control: Control | int,
         creg: tuple[int, int],
         expected_value: int = 1,
+        comparison_kind: ComparisonKind = ComparisonKind.eq,
         params: Sequence[float] = (),
     ) -> None:
         """Add a classic-controlled operation to the circuit.
@@ -1861,6 +1864,7 @@ class QuantumComputation(MutableSequence[Operation]):
             control: The control qubit
             creg: The classical register (index and number of bits)
             expected_value: The expected value of the classical register
+            comparison_kind: The kind of comparison to perform
             params: The parameters of the operation
         """
 
@@ -1872,6 +1876,7 @@ class QuantumComputation(MutableSequence[Operation]):
         controls: set[Control | int],
         creg: tuple[int, int],
         expected_value: int = 1,
+        comparison_kind: ComparisonKind = ComparisonKind.eq,
         params: Sequence[float] = (),
     ) -> None:
         """Add a classic-controlled operation to the circuit.
@@ -1882,6 +1887,7 @@ class QuantumComputation(MutableSequence[Operation]):
             controls: The control qubits
             creg: The classical register (index and number of bits)
             expected_value: The expected value of the classical register
+            comparison_kind: The kind of comparison to perform
             params: The parameters of the operation
         """
 

--- a/src/mqt/core/ir/operations.pyi
+++ b/src/mqt/core/ir/operations.pyi
@@ -844,6 +844,23 @@ class SymbolicOperation(StandardOperation):
             assignment: The assignment of the symbolic parameters.
         """
 
+class ComparisonKind:
+    """An Enum-like class that represents the kind of comparison for classic controlled operations."""
+
+    __members__: ClassVar[dict[ComparisonKind, str]]  # readonly
+    eq: ClassVar[ComparisonKind]
+    """Equality comparison."""
+    neq: ClassVar[ComparisonKind]
+    """Inequality comparison."""
+    lt: ClassVar[ComparisonKind]
+    """Less than comparison."""
+    leq: ClassVar[ComparisonKind]
+    """Less than or equal comparison."""
+    gt: ClassVar[ComparisonKind]
+    """Greater than comparison."""
+    geq: ClassVar[ComparisonKind]
+    """Greater than or equal comparison."""
+
 class ClassicControlledOperation(Operation):
     """Classic controlled quantum operation.
 
@@ -855,9 +872,16 @@ class ClassicControlledOperation(Operation):
         operation: The operation that is controlled.
         control_register: The classical register that controls the operation.
         expected_value: The expected value of the classical register.
+        comparison_kind: The kind of comparison (default is equality).
     """
 
-    def __init__(self, operation: Operation, control_register: tuple[int, int], expected_value: int = 1) -> None: ...
+    def __init__(
+        self,
+        operation: Operation,
+        control_register: tuple[int, int],
+        expected_value: int = 1,
+        comparison_kind: ComparisonKind = ...,
+    ) -> None: ...
     @property
     def operation(self) -> Operation:
         """The operation that is classically controlled."""
@@ -876,10 +900,19 @@ class ClassicControlledOperation(Operation):
     def expected_value(self) -> int:
         """The expected value of the classical register.
 
-        The operation is only executed if the value of the classical register matches the expected value.
+        The operation is only executed if the value of the classical register matches the expected value
+        based on the kind of comparison.
         If the classical register is a single bit, the expected value is either 0 or 1.
         Otherwise, the expected value is an integer that is interpreted as a binary number, where
         the least significant bit is at the start index of the classical register.
+        """
+
+    @property
+    def comparison_kind(self) -> ComparisonKind:
+        """The kind of comparison.
+
+        The operation is only executed if the value of the classical register matches the expected value
+        based on the kind of comparison.
         """
 
     def add_control(self, control: Control) -> None:

--- a/src/python/ir/operations/register_classic_controlled_operation.cpp
+++ b/src/python/ir/operations/register_classic_controlled_operation.cpp
@@ -10,16 +10,30 @@
 namespace mqt {
 
 void registerClassicControlledOperation(py::module& m) {
+  py::enum_<qc::ComparisonKind>(m, "ComparisonKind")
+      .value("eq", qc::ComparisonKind::Eq)
+      .value("neq", qc::ComparisonKind::Neq)
+      .value("lt", qc::ComparisonKind::Lt)
+      .value("leq", qc::ComparisonKind::Leq)
+      .value("gt", qc::ComparisonKind::Gt)
+      .value("geq", qc::ComparisonKind::Geq)
+      .export_values()
+      .def("__str__",
+           [](const qc::ComparisonKind& cmp) { return qc::toString(cmp); })
+      .def("__repr__",
+           [](const qc::ComparisonKind& cmp) { return qc::toString(cmp); });
+
   auto ccop = py::class_<qc::ClassicControlledOperation, qc::Operation>(
       m, "ClassicControlledOperation");
 
   ccop.def(
       py::init([](qc::Operation* operation, qc::ClassicalRegister controlReg,
-                  std::uint64_t expectedVal) {
+                  std::uint64_t expectedVal, qc::ComparisonKind cmp) {
         return std::make_unique<qc::ClassicControlledOperation>(
-            operation->clone(), controlReg, expectedVal);
+            operation->clone(), controlReg, expectedVal, cmp);
       }),
-      "operation"_a, "control_register"_a, "expected_value"_a = 1U);
+      "operation"_a, "control_register"_a, "expected_value"_a = 1U,
+      "comparison_kind"_a = qc::ComparisonKind::Eq);
   ccop.def_property_readonly("operation",
                              &qc::ClassicControlledOperation::getOperation,
                              py::return_value_policy::reference_internal);
@@ -27,13 +41,16 @@ void registerClassicControlledOperation(py::module& m) {
       "control_register", &qc::ClassicControlledOperation::getControlRegister);
   ccop.def_property_readonly("expected_value",
                              &qc::ClassicControlledOperation::getExpectedValue);
+  ccop.def_property_readonly(
+      "comparison_kind", &qc::ClassicControlledOperation::getComparisonKind);
   ccop.def("__repr__", [](const qc::ClassicControlledOperation& op) {
     std::stringstream ss;
     const auto& controlReg = op.getControlRegister();
     ss << "ClassicControlledOperation(<...op...>, "
        << "control_register=(" << controlReg.first << ", " << controlReg.second
        << "), "
-       << "expected_value=" << op.getExpectedValue() << ")";
+       << "expected_value=" << op.getExpectedValue() << ", "
+       << "comparison_kind='" << op.getComparisonKind() << "')";
     return ss.str();
   });
 }

--- a/src/python/ir/register_quantum_computation.cpp
+++ b/src/python/ir/register_quantum_computation.cpp
@@ -1,5 +1,6 @@
 #include "Definitions.hpp"
 #include "ir/QuantumComputation.hpp"
+#include "ir/operations/ClassicControlledOperation.hpp"
 #include "ir/operations/Control.hpp"
 #include "ir/operations/Expression.hpp"
 #include "ir/operations/OpType.hpp"
@@ -399,26 +400,32 @@ void registerQuantumComputation(py::module& m) {
   qc.def("barrier", py::overload_cast<const std::vector<qc::Qubit>&>(
                         &qc::QuantumComputation::barrier));
 
-  qc.def("classic_controlled",
-         py::overload_cast<const qc::OpType, const qc::Qubit,
-                           const qc::ClassicalRegister&, const std::uint64_t,
-                           const std::vector<qc::fp>&>(
-             &qc::QuantumComputation::classicControlled),
-         "op"_a, "target"_a, "creg"_a, "expected_value"_a = 1U,
-         "params"_a = std::vector<qc::fp>{});
-  qc.def("classic_controlled",
-         py::overload_cast<const qc::OpType, const qc::Qubit, const qc::Control,
-                           const qc::ClassicalRegister&, const std::uint64_t,
-                           const std::vector<qc::fp>&>(
-             &qc::QuantumComputation::classicControlled),
-         "op"_a, "target"_a, "control"_a, "creg"_a, "expected_value"_a = 1U,
-         "params"_a = std::vector<qc::fp>{});
-  qc.def("classic_controlled",
-         py::overload_cast<const qc::OpType, const qc::Qubit,
-                           const qc::Controls&, const qc::ClassicalRegister&,
-                           const std::uint64_t, const std::vector<qc::fp>&>(
-             &qc::QuantumComputation::classicControlled),
-         "op"_a, "target"_a, "controls"_a, "creg"_a, "expected_value"_a = 1U,
-         "params"_a = std::vector<qc::fp>{});
+  qc.def(
+      "classic_controlled",
+      py::overload_cast<const qc::OpType, const qc::Qubit,
+                        const qc::ClassicalRegister&, const std::uint64_t,
+                        const qc::ComparisonKind, const std::vector<qc::fp>&>(
+          &qc::QuantumComputation::classicControlled),
+      "op"_a, "target"_a, "creg"_a, "expected_value"_a = 1U,
+      "comparison_kind"_a = qc::ComparisonKind::Eq,
+      "params"_a = std::vector<qc::fp>{});
+  qc.def(
+      "classic_controlled",
+      py::overload_cast<const qc::OpType, const qc::Qubit, const qc::Control,
+                        const qc::ClassicalRegister&, const std::uint64_t,
+                        const qc::ComparisonKind, const std::vector<qc::fp>&>(
+          &qc::QuantumComputation::classicControlled),
+      "op"_a, "target"_a, "control"_a, "creg"_a, "expected_value"_a = 1U,
+      "comparison_kind"_a = qc::ComparisonKind::Eq,
+      "params"_a = std::vector<qc::fp>{});
+  qc.def(
+      "classic_controlled",
+      py::overload_cast<const qc::OpType, const qc::Qubit, const qc::Controls&,
+                        const qc::ClassicalRegister&, const std::uint64_t,
+                        const qc::ComparisonKind, const std::vector<qc::fp>&>(
+          &qc::QuantumComputation::classicControlled),
+      "op"_a, "target"_a, "controls"_a, "creg"_a, "expected_value"_a = 1U,
+      "comparison_kind"_a = qc::ComparisonKind::Eq,
+      "params"_a = std::vector<qc::fp>{});
 }
 } // namespace mqt

--- a/test/algorithms/test_bernsteinvazirani.cpp
+++ b/test/algorithms/test_bernsteinvazirani.cpp
@@ -38,81 +38,55 @@ TEST_P(BernsteinVazirani, FunctionTest) {
   auto s = qc::BitString(GetParam());
 
   // construct Bernstein Vazirani circuit
-  auto qc = qc::BernsteinVazirani(s);
+  const auto qc = qc::BernsteinVazirani(s);
   qc.printStatistics(std::cout);
 
   // simulate the circuit
-  auto dd = std::make_unique<dd::Package<>>(qc.getNqubits());
-  const std::size_t shots = 1024;
-  auto measurements =
-      simulate(&qc, dd->makeZeroState(qc.getNqubits()), *dd, shots);
-
-  for (const auto& [state, count] : measurements) {
-    std::cout << state << ": " << count << "\n";
-  }
+  constexpr std::size_t shots = 1024;
+  const auto measurements = dd::sample(qc, shots);
 
   // expect to obtain the hidden bitstring with certainty
-  EXPECT_EQ(measurements[qc.expected], shots);
+  EXPECT_EQ(measurements.at(qc.expected), shots);
 }
 
 TEST_P(BernsteinVazirani, FunctionTestDynamic) {
   // get hidden bitstring
-  auto s = qc::BitString(GetParam());
+  const auto s = qc::BitString(GetParam());
 
   // construct Bernstein Vazirani circuit
-  auto qc = qc::BernsteinVazirani(s, true);
+  const auto qc = qc::BernsteinVazirani(s, true);
   qc.printStatistics(std::cout);
 
   // simulate the circuit
-  auto dd = std::make_unique<dd::Package<>>(qc.getNqubits());
-  const std::size_t shots = 1024;
-  auto measurements =
-      simulate(&qc, dd->makeZeroState(qc.getNqubits()), *dd, shots);
-
-  for (const auto& [state, count] : measurements) {
-    std::cout << state << ": " << count << "\n";
-  }
+  constexpr std::size_t shots = 1024;
+  const auto measurements = dd::sample(qc, shots);
 
   // expect to obtain the hidden bitstring with certainty
-  EXPECT_EQ(measurements[qc.expected], shots);
+  EXPECT_EQ(measurements.at(qc.expected), shots);
 }
 
 TEST_F(BernsteinVazirani, LargeCircuit) {
-  const std::size_t nq = 127;
-  auto qc = qc::BernsteinVazirani(nq);
-  qc.printStatistics(std::cout);
+  constexpr std::size_t nq = 127;
+  const auto qc = qc::BernsteinVazirani(nq);
 
   // simulate the circuit
-  auto dd = std::make_unique<dd::Package<>>(qc.getNqubits());
-  const std::size_t shots = 1024;
-  auto measurements =
-      simulate(&qc, dd->makeZeroState(qc.getNqubits()), *dd, shots);
-
-  for (const auto& [state, count] : measurements) {
-    std::cout << state << ": " << count << "\n";
-  }
+  constexpr std::size_t shots = 1024;
+  const auto measurements = dd::sample(qc, shots);
 
   // expect to obtain the hidden bitstring with certainty
-  EXPECT_EQ(measurements[qc.expected], shots);
+  EXPECT_EQ(measurements.at(qc.expected), shots);
 }
 
 TEST_F(BernsteinVazirani, DynamicCircuit) {
-  const std::size_t nq = 127;
-  auto qc = qc::BernsteinVazirani(nq, true);
-  qc.printStatistics(std::cout);
+  constexpr std::size_t nq = 127;
+  const auto qc = qc::BernsteinVazirani(nq, true);
 
   // simulate the circuit
-  auto dd = std::make_unique<dd::Package<>>(qc.getNqubits());
-  const std::size_t shots = 1024;
-  auto measurements =
-      simulate(&qc, dd->makeZeroState(qc.getNqubits()), *dd, shots);
-
-  for (const auto& [state, count] : measurements) {
-    std::cout << state << ": " << count << "\n";
-  }
+  constexpr std::size_t shots = 1024;
+  const auto measurements = dd::sample(qc, shots);
 
   // expect to obtain the hidden bitstring with certainty
-  EXPECT_EQ(measurements[qc.expected], shots);
+  EXPECT_EQ(measurements.at(qc.expected), shots);
 }
 
 TEST_P(BernsteinVazirani, DynamicEquivalenceSimulation) {
@@ -128,7 +102,7 @@ TEST_P(BernsteinVazirani, DynamicEquivalenceSimulation) {
   qc::CircuitOptimizer::removeFinalMeasurements(bv);
 
   // simulate circuit
-  auto e = simulate(&bv, dd->makeZeroState(bv.getNqubits()), *dd);
+  auto e = dd::simulate(&bv, dd->makeZeroState(bv.getNqubits()), *dd);
 
   // create dynamic BV circuit
   auto dbv = qc::BernsteinVazirani(s, true);
@@ -143,11 +117,9 @@ TEST_P(BernsteinVazirani, DynamicEquivalenceSimulation) {
   qc::CircuitOptimizer::removeFinalMeasurements(dbv);
 
   // simulate circuit
-  auto f = simulate(&dbv, dd->makeZeroState(dbv.getNqubits()), *dd);
+  auto f = dd::simulate(&dbv, dd->makeZeroState(dbv.getNqubits()), *dd);
 
   // calculate fidelity between both results
   auto fidelity = dd->fidelity(e, f);
-  std::cout << "Fidelity of both circuits: " << fidelity << "\n";
-
   EXPECT_NEAR(fidelity, 1.0, 1e-4);
 }

--- a/test/algorithms/test_entanglement.cpp
+++ b/test/algorithms/test_entanglement.cpp
@@ -14,7 +14,12 @@
 class Entanglement : public testing::TestWithParam<std::size_t> {
 protected:
   void TearDown() override {}
-  void SetUp() override {}
+  void SetUp() override {
+    nq = GetParam();
+    dd = std::make_unique<dd::Package<>>(nq);
+  }
+  std::size_t nq{};
+  std::unique_ptr<dd::Package<>> dd;
 };
 
 INSTANTIATE_TEST_SUITE_P(
@@ -28,27 +33,18 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 TEST_P(Entanglement, FunctionTest) {
-  const auto nq = GetParam();
-
-  auto dd = std::make_unique<dd::Package<>>(nq);
-  auto qc = qc::Entanglement(nq);
-  auto e = buildFunctionality(&qc, *dd);
-
+  const auto qc = qc::Entanglement(nq);
+  const auto e = dd::buildFunctionality(&qc, *dd);
   ASSERT_EQ(qc.getNops(), nq);
   const auto r = dd->multiply(e, dd->makeZeroState(nq));
-
   ASSERT_EQ(r.getValueByPath(nq, std::string(nq, '0')), dd::SQRT2_2);
   ASSERT_EQ(r.getValueByPath(nq, std::string(nq, '1')), dd::SQRT2_2);
 }
 
 TEST_P(Entanglement, GHZRoutineFunctionTest) {
-  const auto nq = GetParam();
-
-  auto qc = qc::Entanglement(nq);
-  auto dd = std::make_unique<dd::Package<>>(nq);
-  const dd::VectorDD e = simulate(&qc, dd->makeZeroState(qc.getNqubits()), *dd);
+  const auto qc = qc::Entanglement(nq);
+  const auto e = dd::simulate(&qc, dd->makeZeroState(nq), *dd);
   const auto f = dd->makeGHZState(nq);
-
   EXPECT_EQ(e, f);
 }
 

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -79,7 +79,8 @@ TEST_P(QFT, Functionality) {
   // the final DD should store all 2^n different amplitudes
   // since only positive real values are stored in the complex table
   // this number has to be divided by 4
-  ASSERT_EQ(dd->cn.realCount(), 1ULL << (std::max(2UL, nqubits) - 2));
+  ASSERT_EQ(dd->cn.realCount(),
+            1ULL << (std::max<std::size_t>(2UL, nqubits) - 2));
 
   // top edge weight should equal sqrt(0.5)^n
   EXPECT_NEAR(dd::RealNumber::val(func.w.r),

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -213,7 +213,6 @@ TEST_P(QFT, FunctionalityRecursiveEquality) {
 TEST_P(QFT, DynamicSimulation) {
   // there should be no error constructing the circuit
   ASSERT_NO_THROW({ qc = std::make_unique<qc::QFT>(nqubits, true, true); });
-  auto dd = std::make_unique<dd::Package<>>(nqubits);
   qc->printStatistics(std::cout);
 
   // simulate the circuit

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -123,7 +123,8 @@ TEST_P(QFT, FunctionalityRecursive) {
   // the final DD should store all 2^n different amplitudes
   // since only positive real values are stored in the complex table
   // this number has to be divided by 4
-  ASSERT_EQ(dd->cn.realCount(), 1ULL << (std::max(2UL, nqubits) - 2));
+  ASSERT_EQ(dd->cn.realCount(),
+            1ULL << (std::max<std::size_t>(2UL, nqubits) - 2));
 
   // top edge weight should equal sqrt(0.5)^n
   EXPECT_NEAR(dd::RealNumber::val(func.w.r),
@@ -218,7 +219,7 @@ TEST_P(QFT, DynamicSimulation) {
   const std::size_t unique = measurements.size();
 
   nqubits = GetParam();
-  const auto maxUnique = std::min<std::size_t>(1UL << nqubits, shots);
+  const auto maxUnique = std::min<std::size_t>(1ULL << nqubits, shots);
   const auto ratio =
       static_cast<double>(unique) / static_cast<double>(maxUnique);
 

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -218,7 +218,7 @@ TEST_P(QFT, DynamicSimulation) {
   const std::size_t unique = measurements.size();
 
   nqubits = GetParam();
-  const auto maxUnique = std::min(1UL << nqubits, shots);
+  const auto maxUnique = std::min<std::size_t>(1UL << nqubits, shots);
   const auto ratio =
       static_cast<double>(unique) / static_cast<double>(maxUnique);
 

--- a/test/algorithms/test_qft.cpp
+++ b/test/algorithms/test_qft.cpp
@@ -209,28 +209,28 @@ TEST_P(QFT, FunctionalityRecursiveEquality) {
   EXPECT_EQ(dd->cn.realCount(), INITIAL_COMPLEX_COUNT);
 }
 
-TEST_P(QFT, DynamicSimulation) {
-  // there should be no error constructing the circuit
-  ASSERT_NO_THROW({ qc = std::make_unique<qc::QFT>(nqubits, true, true); });
-  qc->printStatistics(std::cout);
+TEST_P(QFT, SimulationSampling) {
+  const auto dynamic = {false, true};
+  for (const auto dyn : dynamic) {
+    qc = std::make_unique<qc::QFT>(nqubits, false, dyn);
 
-  // simulate the circuit
-  constexpr std::size_t shots = 8192U;
-  const auto measurements = dd::sample(*qc, shots);
-  const std::size_t unique = measurements.size();
+    // simulate the circuit
+    constexpr std::size_t shots = 8192U;
+    const auto measurements = dd::sample(*qc, shots);
 
-  nqubits = GetParam();
-  const auto maxUnique = std::min<std::size_t>(1ULL << nqubits, shots);
-  const auto ratio =
-      static_cast<double>(unique) / static_cast<double>(maxUnique);
+    const std::size_t unique = measurements.size();
+    const auto maxUnique = std::min<std::size_t>(1ULL << nqubits, shots);
+    const auto ratio =
+        static_cast<double>(unique) / static_cast<double>(maxUnique);
 
-  std::cout << "Unique entries " << unique << " out of " << maxUnique
-            << " for a ratio of: " << ratio << "\n";
+    std::cout << "Unique entries " << unique << " out of " << maxUnique
+              << " for a ratio of: " << ratio << "\n";
 
-  // the number of unique entries should be close to the number of shots
-  EXPECT_GE(ratio, 0.7);
-  dd->garbageCollect(true);
-  // number of complex table entries after clean-up should equal initial
-  // number of entries
-  EXPECT_EQ(dd->cn.realCount(), INITIAL_COMPLEX_COUNT);
+    // the number of unique entries should be close to the number of shots
+    EXPECT_GE(ratio, 0.7);
+    dd->garbageCollect(true);
+    // number of complex table entries after clean-up should equal initial
+    // number of entries
+    EXPECT_EQ(dd->cn.realCount(), INITIAL_COMPLEX_COUNT);
+  }
 }

--- a/test/algorithms/test_random_clifford.cpp
+++ b/test/algorithms/test_random_clifford.cpp
@@ -31,9 +31,7 @@ TEST_P(RandomClifford, simulate) {
   auto dd = std::make_unique<dd::Package<>>(nq);
   auto qc = qc::RandomCliffordCircuit(nq, nq * nq, 12345);
   auto in = dd->makeZeroState(nq);
-
-  std::cout << qc << "\n";
-  ASSERT_NO_THROW({ simulate(&qc, in, *dd); });
+  ASSERT_NO_THROW({ dd::simulate(&qc, in, *dd); });
   qc.printStatistics(std::cout);
 }
 
@@ -42,7 +40,6 @@ TEST_P(RandomClifford, buildFunctionality) {
 
   auto dd = std::make_unique<dd::Package<>>(nq);
   auto qc = qc::RandomCliffordCircuit(nq, nq * nq, 12345);
-  std::cout << qc << "\n";
-  ASSERT_NO_THROW({ buildFunctionality(&qc, *dd); });
+  ASSERT_NO_THROW({ dd::buildFunctionality(&qc, *dd); });
   qc.printStatistics(std::cout);
 }

--- a/test/algorithms/test_wstate.cpp
+++ b/test/algorithms/test_wstate.cpp
@@ -17,6 +17,7 @@
 
 class WState : public testing::TestWithParam<qc::Qubit> {};
 
+namespace {
 std::vector<std::string> generateWStateStrings(const std::size_t length) {
   std::vector<std::string> result;
   result.reserve(length);
@@ -27,6 +28,7 @@ std::vector<std::string> generateWStateStrings(const std::size_t length) {
   }
   return result;
 }
+} // namespace
 
 INSTANTIATE_TEST_SUITE_P(
     WState, WState, testing::Range<qc::Qubit>(1U, 128U, 7U),
@@ -40,12 +42,9 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(WState, FunctionTest) {
   const auto nq = GetParam();
-
-  auto qc = qc::WState(nq);
-  auto dd = std::make_unique<dd::Package<>>(qc.getNqubits());
-  const std::size_t shots = 4096U;
-  const auto measurements =
-      simulate(&qc, dd->makeZeroState(qc.getNqubits()), *dd, shots);
+  const auto qc = qc::WState(nq);
+  constexpr std::size_t shots = 4096U;
+  const auto measurements = dd::sample(qc, shots);
   for (const auto& result : generateWStateStrings(nq)) {
     EXPECT_TRUE(measurements.find(result) != measurements.end());
   }
@@ -56,7 +55,8 @@ TEST_P(WState, RoutineFunctionTest) {
 
   auto qc = qc::WState(nq);
   auto dd = std::make_unique<dd::Package<>>(qc.getNqubits());
-  const dd::VectorDD e = simulate(&qc, dd->makeZeroState(qc.getNqubits()), *dd);
+  const dd::VectorDD e =
+      dd::simulate(&qc, dd->makeZeroState(qc.getNqubits()), *dd);
   const auto f = dd->makeWState(nq);
 
   EXPECT_EQ(e, f);

--- a/test/dd/test_dd_functionality.cpp
+++ b/test/dd/test_dd_functionality.cpp
@@ -2,6 +2,7 @@
 #include "circuit_optimizer/CircuitOptimizer.hpp"
 #include "dd/DDDefinitions.hpp"
 #include "dd/FunctionalityConstruction.hpp"
+#include "dd/Node.hpp"
 #include "dd/Operations.hpp"
 #include "dd/Package.hpp"
 #include "dd/Simulation.hpp"
@@ -545,4 +546,11 @@ TEST_F(DDFunctionality, classicControlledOperationConditions) {
       EXPECT_EQ(key, "1");
     }
   }
+}
+
+TEST_F(DDFunctionality, vectorKroneckerWithTerminal) {
+  const auto root = dd::vEdge::one();
+  const auto zeroState = dd->makeZeroState(1);
+  const auto extendedRoot = dd->kronecker(zeroState, root, 0);
+  EXPECT_EQ(zeroState, extendedRoot);
 }

--- a/test/dd/test_dd_noise_functionality.cpp
+++ b/test/dd/test_dd_noise_functionality.cpp
@@ -77,7 +77,6 @@ TEST_F(DDNoiseFunctionalityTest, DetSimulateAdder4TrackAPD) {
   auto dd = std::make_unique<DensityMatrixTestPackage>(qc.getNqubits());
 
   auto rootEdge = dd->makeZeroDensityOperator(qc.getNqubits());
-  dd->incRef(rootEdge);
 
   const auto* const noiseEffects = "APDI";
 
@@ -109,7 +108,6 @@ TEST_F(DDNoiseFunctionalityTest, DetSimulateAdder4TrackD) {
   auto dd = std::make_unique<DensityMatrixTestPackage>(qc.getNqubits());
 
   auto rootEdge = dd->makeZeroDensityOperator(qc.getNqubits());
-  dd->incRef(rootEdge);
 
   const auto* const noiseEffects = "D";
 
@@ -141,7 +139,6 @@ TEST_F(DDNoiseFunctionalityTest, testingMeasure) {
   auto dd = std::make_unique<DensityMatrixTestPackage>(qcOp.getNqubits());
 
   auto rootEdge = dd->makeZeroDensityOperator(qcOp.getNqubits());
-  dd->incRef(rootEdge);
 
   auto deterministicNoiseFunctionality = dd::DeterministicNoiseFunctionality(
       dd, qcOp.getNqubits(), 0.01, 0.02, 0.02, 0.04, {});

--- a/test/dd/test_edge_functionality.cpp
+++ b/test/dd/test_edge_functionality.cpp
@@ -364,7 +364,6 @@ TEST(DensityMatrixFunctionality, GetValueByIndexProperDensityMatrix) {
   const auto nqubits = 1U;
   auto dd = std::make_unique<dd::Package<>>(nqubits);
   auto zero = dd->makeZeroDensityOperator(nqubits);
-  dd->incRef(zero);
   const auto op1 = dd->makeGateDD(dd::H_MAT, 0U);
   const auto op2 = dd->makeGateDD(dd::rzMat(dd::PI_4), 0U);
   auto state = dd->applyOperationToDensity(zero, op1);
@@ -399,7 +398,6 @@ TEST(DensityMatrixFunctionality, GetSparseMatrixConsistency) {
   const auto nqubits = 1U;
   auto dd = std::make_unique<dd::Package<>>(nqubits);
   auto zero = dd->makeZeroDensityOperator(nqubits);
-  dd->incRef(zero);
   const auto op1 = dd->makeGateDD(dd::H_MAT, 0U);
   const auto op2 = dd->makeGateDD(dd::rzMat(dd::PI_4), 0U);
   auto state = dd->applyOperationToDensity(zero, op1);
@@ -430,7 +428,6 @@ TEST(DensityMatrixFunctionality, PrintMatrix) {
   const auto nqubits = 1U;
   auto dd = std::make_unique<dd::Package<>>(nqubits);
   auto zero = dd->makeZeroDensityOperator(nqubits);
-  dd->incRef(zero);
   const auto op1 = dd->makeGateDD(dd::H_MAT, 0U);
   const auto op2 = dd->makeGateDD(dd::rzMat(dd::PI_4), 0U);
   auto state = dd->applyOperationToDensity(zero, op1);

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -428,8 +428,6 @@ TEST(DDPackageTest, StateGenerationManipulation) {
                               {dd::BasisStates::zero, dd::BasisStates::one,
                                dd::BasisStates::plus, dd::BasisStates::minus,
                                dd::BasisStates::left, dd::BasisStates::right});
-  dd->incRef(e);
-  dd->incRef(f);
   dd->vUniqueTable.print();
   dd->decRef(e);
   dd->decRef(f);
@@ -1497,7 +1495,6 @@ TEST(DDPackageTest, dNodeMultiply) {
           nrQubits);
   // Make zero density matrix
   auto state = dd->makeZeroDensityOperator(dd->qubits());
-  dd->incRef(state);
   std::vector<dd::mEdge> operations = {};
   operations.emplace_back(dd->makeGateDD(dd::H_MAT, 0));
   operations.emplace_back(dd->makeGateDD(dd::H_MAT, 1));
@@ -1546,7 +1543,6 @@ TEST(DDPackageTest, dNodeMultiply2) {
           nrQubits);
   // Make zero density matrix
   auto state = dd->makeZeroDensityOperator(dd->qubits());
-  dd->incRef(state);
   std::vector<dd::mEdge> operations = {};
   operations.emplace_back(dd->makeGateDD(dd::H_MAT, 0));
   operations.emplace_back(dd->makeGateDD(dd::H_MAT, 1));
@@ -1588,7 +1584,6 @@ TEST(DDPackageTest, dNodeMulCache1) {
           nrQubits);
   // Make zero density matrix
   auto state = dd->makeZeroDensityOperator(nrQubits);
-  dd->incRef(state);
 
   const auto operation = dd->makeGateDD(dd::H_MAT, 0);
   dd->applyOperationToDensity(state, operation);
@@ -1635,7 +1630,6 @@ TEST(DDPackageTest, dNoiseCache) {
   auto dd = std::make_unique<dd::Package<>>(nrQubits);
   // Make zero density matrix
   const auto initialState = dd->makeZeroDensityOperator(nrQubits);
-  dd->incRef(initialState);
 
   // nothing pre-cached
   const std::vector<dd::Qubit> target = {0};

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -268,8 +268,7 @@ TEST(DDPackageTest, CorruptedBellState) {
 
   ASSERT_THROW(dd->measureAll(bellState, false, mt), std::runtime_error);
 
-  ASSERT_THROW(dd->measureOneCollapsing(bellState, 0, true, mt),
-               std::runtime_error);
+  ASSERT_THROW(dd->measureOneCollapsing(bellState, 0, mt), std::runtime_error);
 }
 
 TEST(DDPackageTest, NegativeControl) {
@@ -1157,28 +1156,7 @@ TEST(DDPackageTest, DestructiveMeasurementOne) {
 
   std::mt19937_64 mt{0}; // NOLINT(cert-msc51-cpp)
 
-  const char m = dd->measureOneCollapsing(plusState, 0, true, mt);
-  const dd::CVec vAfter = plusState.getVector();
-
-  ASSERT_EQ(m, '0');
-  ASSERT_EQ(vAfter[0], dd::SQRT2_2);
-  ASSERT_EQ(vAfter[2], dd::SQRT2_2);
-  ASSERT_EQ(vAfter[1], 0.);
-  ASSERT_EQ(vAfter[3], 0.);
-}
-
-TEST(DDPackageTest, DestructiveMeasurementOneArbitraryNormalization) {
-  auto dd = std::make_unique<dd::Package<>>(4);
-  auto hGate0 = dd->makeGateDD(dd::H_MAT, 0);
-  auto hGate1 = dd->makeGateDD(dd::H_MAT, 1);
-  auto plusMatrix = dd->multiply(hGate0, hGate1);
-  auto zeroState = dd->makeZeroState(2);
-  auto plusState = dd->multiply(plusMatrix, zeroState);
-  dd->incRef(plusState);
-
-  std::mt19937_64 mt{0}; // NOLINT(cert-msc51-cpp)
-
-  const char m = dd->measureOneCollapsing(plusState, 0, false, mt);
+  const char m = dd->measureOneCollapsing(plusState, 0, mt);
   const dd::CVec vAfter = plusState.getVector();
 
   ASSERT_EQ(m, '0');


### PR DESCRIPTION
## Description

This pull request includes several changes aimed at improving code efficiency and readability across the DD package. 

### Utility (functions):

* Introduced new utility functions in `Operations.hpp` for applying unitary operations, measurements, resets, and classically controlled operations on quantum states.
* DD routines for state preparation now automatically increase the respective refcount, so this does not have to be done manually anymore.
* The classic-controlled Operation class now exposes its comparison kind to the QuantumComputation class and to Python.

### Code simplification:

* Simplified the `getDD` function by removing redundant checks and improving the handling of permutations.
* A `sample` method was introduced as a shortcut for simply sampling from the output distribution of a circuit.
* Several tests were simplified and streamlined.

These changes collectively enhance the maintainability and performance of the codebase.
They will require changes in consuming libraries. Especially mqt-ddsim, mqt-qcec, and mqt-ddvis. However, these changes should simplify the overall code in these libraries.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
