### PR TITLE
🩹fix loading circuits from `PathLike` objects

### DIFF
--- a/src/mqt/core/__init__.py
+++ b/src/mqt/core/__init__.py
@@ -39,9 +39,9 @@ def load(input_circuit: CircuitInputType) -> QuantumComputation:
                 msg = f"File {input_circuit} does not exist."
                 raise FileNotFoundError(msg)
             # otherwise, we assume that this is a QASM string
-            return QuantumComputation.from_qasm(input_circuit)
+            return QuantumComputation.from_qasm(str(input_circuit))
 
-        return QuantumComputation(input_circuit)
+        return QuantumComputation(str(input_circuit))
 
     try:
         from .plugins.qiskit import qiskit_to_mqt

--- a/test/python/test_load.py
+++ b/test/python/test_load.py
@@ -48,6 +48,27 @@ def test_loading_file() -> None:
     Path("test.qasm").unlink()
 
 
+def test_loading_file_from_path() -> None:
+    """Test whether importing a simple QASM file works."""
+    qasm = "qreg q[2];\ncreg c[2];\nh q[0];\ncx q[0], q[1];\nmeasure q -> c;\n"
+    path = Path("test.qasm")
+    with path.open("w", encoding=locale.getpreferredencoding(False)) as f:
+        f.write(qasm)
+
+    # load the file
+    qc = load(path)
+    print(qc)
+
+    # check the result
+    assert isinstance(qc, QuantumComputation)
+    qc_qasm = qc.qasm2_str()
+
+    assert qasm in qc_qasm
+
+    # remove the file
+    path.unlink()
+
+
 def test_loading_nonexistent_file() -> None:
     """Test whether trying to load a non-existent file raises an error."""
     try:


### PR DESCRIPTION
## Description

This PR fixes a small oversight in the `mqt.core.load` method, where the method would not work if being passed a `PathLike` object that is not a string (e.g., a `Path`).
The changes in the PR make sure that such an object is appropriately converted to a string before being passed to the constructor.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
