### PR TITLE
🐍⬆️ update image for Linux wheel builds to `manylinux_2_28`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - .github/workflows/cd.yml
+      - .github/workflows/cd.yml # trigger
 
 jobs:
   python-packaging:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,11 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - .github/workflows/cd.yml # trigger
+      - .github/workflows/cd.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   python-packaging:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,6 +276,10 @@ test-command = "python -c \"from mqt import core\""
 test-skip = "cp38-macosx_arm64"
 build-frontend = "build[uv]"
 free-threaded-support = true
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+manylinux-ppc64le-image = "manylinux_2_28"
+manylinux-s390x-image = "manylinux_2_28"
 
 [tool.cibuildwheel.linux]
 environment = { DEPLOY = "ON" }


### PR DESCRIPTION
## Description

CentOS 7, which the default `manylinux2014` image is based on, reached end-of-life in June 2024. 
The only meaningful platforms left that do not provide a recent enough `glibc` version are some `Amazon Linux 2` platforms, which are not really relevant for the MQT.

This PR moves the Linux wheel builds to the more recent `manylinux_2_28` images, which offers many performance improvements and optimizations.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
