### PR TITLE
🔥 drop Python 3.8 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(BUILD_MQT_CORE_BINDINGS)
 
   # top-level call to find Python
   find_package(
-    Python 3.8 REQUIRED
+    Python 3.9 REQUIRED
     COMPONENTS Interpreter Development.Module
     OPTIONAL_COMPONENTS Development.SABIModule)
 endif()

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you have any questions, feel free to create a [discussion](https://github.com
 
 ## Getting Started
 
-`mqt.core` is available via [PyPI](https://pypi.org/project/mqt.core/) for all major operating systems and supports Python 3.8 to 3.12.
+`mqt.core` is available via [PyPI](https://pypi.org/project/mqt.core/) for all major operating systems and supports Python 3.9 to 3.13.
 
 ```console
 (.venv) $ pip install mqt.core

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,6 +9,12 @@ The resulting Python package is available on [PyPI](https://pypi.org/project/mqt
 
 In most practical cases (under 64-bit Linux, MacOS incl. Apple Silicon, and Windows), this requires no compilation and merely downloads and installs a platform-specific pre-built wheel.
 
+:::{attention}
+As of version 2.7.0, support for Python 3.8 has been officially dropped.
+We strongly recommend that users upgrade to a more recent version of Python to ensure compatibility and continue receiving updates and support.
+Thank you for your understanding.
+:::
+
 ## Building from source for performance
 
 In order to get the best performance and enable platform-specific optimizations that cannot be enabled on portable wheels, it is recommended to build the library from source via:

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ nox.options.default_venv_backend = "uv|virtualenv"
 
 nox.options.sessions = ["lint", "tests", "minimums"]
 
-PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+PYTHON_ALL_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 # The following lists all the build requirements for building the package.
 # Note that this includes transitive build dependencies of package dependencies,
@@ -102,18 +102,17 @@ def docs(session: nox.Session) -> None:
     extra_installs = ["sphinx-autobuild"] if serve else []
     session.install(*BUILD_REQUIREMENTS, *extra_installs)
     session.install("--no-build-isolation", "-ve.[docs]", "--reinstall-package", "mqt.core")
-    session.chdir("docs")
 
     if args.builder == "linkcheck":
-        session.run("sphinx-build", "-b", "linkcheck", ".", "_build/linkcheck", *posargs)
+        session.run("sphinx-build", "-b", "linkcheck", "docs", "docs/_build/linkcheck", *posargs)
         return
 
     shared_args = (
         "-n",  # nitpicky mode
         "-T",  # full tracebacks
         f"-b={args.builder}",
-        ".",
-        f"_build/{args.builder}",
+        "docs",
+        f"docs/_build/{args.builder}",
         *posargs,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
   "Programming Language :: C++",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -32,15 +31,14 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
   "Typing :: Typed",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 
 [project.optional-dependencies]
 test = ["pytest>=7.0", "pytest-console-scripts>=1.4", "mqt.core[qiskit, evaluation]"]
 coverage = ["mqt.core[test]", "pytest-cov>=4"]
 evaluation = [
-    "pandas[output_formatting]>=2.0; python_version < '3.9'",
-    "pandas[output-formatting]>=2.1.2; python_version >= '3.9'",
+    "pandas[output-formatting]>=2.1.2",
 ]
 docs = [
     "furo>=2023.08.17",
@@ -139,7 +137,6 @@ filterwarnings = [
     "error",
     'ignore:\s.*Pyarrow.*:DeprecationWarning:',
     'ignore:.*datetime\.datetime\.utcfromtimestamp.*:DeprecationWarning:',
-    'ignore:.*Qiskit with Python 3.8.*:DeprecationWarning:',
     'ignore:.*no need for these schema-conformant objects.*:DeprecationWarning:', # Qiskit itself imports deprecated code (should be resolved in the 1.2.1 release)
 ]
 log_cli_level = "info"
@@ -162,7 +159,7 @@ report.exclude_also = [
 [tool.mypy]
 files = ["src/mqt", "test/python"]
 mypy_path = ["$MYPY_CONFIG_FILE_DIR/src"]
-python_version = "3.8"
+python_version = "3.9"
 warn_unused_configs = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 strict = true
@@ -280,7 +277,6 @@ build = "cp3*"
 skip = "*-musllinux_*"
 archs = "auto64"
 test-command = "python -c \"from mqt import core\""
-test-skip = "cp38-macosx_arm64"
 build-frontend = "build[uv]"
 free-threaded-support = true
 manylinux-x86_64-image = "manylinux_2_28"

--- a/src/mqt/core/plugins/qiskit.py
+++ b/src/mqt/core/plugins/qiskit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import warnings
-from typing import TYPE_CHECKING, List, cast
+from typing import TYPE_CHECKING, cast
 
 from qiskit.circuit import AncillaQubit, AncillaRegister, Clbit, Instruction, ParameterExpression, Qubit
 
@@ -343,7 +343,7 @@ def _add_operation(
     if any(isinstance(parameter, Expression) for parameter in parameters):
         qc.append(SymbolicOperation(controls, target, type_, parameters))
     else:
-        qc.append(StandardOperation(controls, target, type_, cast(List[float], parameters)))
+        qc.append(StandardOperation(controls, target, type_, cast(list[float], parameters)))
     return parameters
 
 
@@ -362,7 +362,7 @@ def _add_two_target_operation(
     if any(isinstance(parameter, Expression) for parameter in parameters):
         qc.append(SymbolicOperation(controls, target1, target2, type_, parameters))
     else:
-        qc.append(StandardOperation(controls, target1, target2, type_, cast(List[float], parameters)))
+        qc.append(StandardOperation(controls, target1, target2, type_, cast(list[float], parameters)))
     return parameters
 
 


### PR DESCRIPTION
## Description

Python 3.8 will reach end of live in October 2024.
Qiskit is already issuing deprecation warnings since a couple of releases when using it on Python 3.8.
This PR officially drops support for Python 3.8 in mqt-core.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
