### PR TITLE
🐛 Fix dynamic circuit detection

### DIFF
--- a/include/mqt-core/circuit_optimizer/CircuitOptimizer.hpp
+++ b/include/mqt-core/circuit_optimizer/CircuitOptimizer.hpp
@@ -3,20 +3,13 @@
 #include "Definitions.hpp"
 #include "ir/QuantumComputation.hpp"
 #include "ir/operations/OpType.hpp"
-#include "ir/operations/Operation.hpp"
 
 #include <cstddef>
-#include <memory>
 #include <unordered_set>
 
 namespace qc {
 
 class CircuitOptimizer {
-protected:
-  static void addToDag(DAG& dag, std::unique_ptr<Operation>* op);
-  static void addNonStandardOperationToDag(DAG& dag,
-                                           std::unique_ptr<Operation>* op);
-
 public:
   CircuitOptimizer() = default;
 

--- a/test/circuit_optimizer/test_defer_measurements.cpp
+++ b/test/circuit_optimizer/test_defer_measurements.cpp
@@ -421,4 +421,15 @@ TEST(DeferMeasurements, preserveOutputPermutationWithoutMeasurements) {
   EXPECT_EQ(qc.outputPermutation.size(), 1);
   EXPECT_EQ(qc.outputPermutation.at(0), 0);
 }
+
+TEST(DeferMeasurements, isDynamicOnRepeatedMeasurements) {
+  QuantumComputation qc(1, 2);
+  qc.h(0);
+  qc.measure(0, 0);
+  qc.h(0);
+  qc.measure(0, 1);
+
+  EXPECT_TRUE(CircuitOptimizer::isDynamicCircuit(qc));
+}
+
 } // namespace qc


### PR DESCRIPTION
## Description

The previous implementation of the `isDynamicCircuit` check would falsely report a circuit to not be dynamic if the circuit contains multiple measurements on one qubit.
This PR fixes the underlying error and refactors the logic of the respective method to handle more cases.

This was discovered while working on https://github.com/cda-tum/mqt-qcec/issues/439

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
