### PR TITLE
♻️ optimize `isDynamic` check and move to `QuantumComputation` class

### DIFF
--- a/include/mqt-core/circuit_optimizer/CircuitOptimizer.hpp
+++ b/include/mqt-core/circuit_optimizer/CircuitOptimizer.hpp
@@ -40,8 +40,6 @@ public:
 
   static void deferMeasurements(QuantumComputation& qc);
 
-  static bool isDynamicCircuit(QuantumComputation& qc);
-
   static void flattenOperations(QuantumComputation& qc,
                                 bool customGatesOnly = false);
 

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -344,9 +344,15 @@ public:
 
   [[nodiscard]] std::string getQubitRegister(Qubit physicalQubitIndex) const;
   [[nodiscard]] std::string getClassicalRegister(Bit classicalIndex) const;
-  static Qubit getHighestLogicalQubitIndex(const Permutation& permutation);
+  [[nodiscard]] static Qubit
+  getHighestLogicalQubitIndex(const Permutation& permutation);
   [[nodiscard]] Qubit getHighestLogicalQubitIndex() const {
     return getHighestLogicalQubitIndex(initialLayout);
+  };
+  [[nodiscard]] static Qubit
+  getHighestPhysicalQubitIndex(const Permutation& permutation);
+  [[nodiscard]] Qubit getHighestPhysicalQubitIndex() const {
+    return getHighestPhysicalQubitIndex(initialLayout);
   };
   [[nodiscard]] std::pair<std::string, Qubit>
   getQubitRegisterAndIndex(Qubit physicalQubitIndex) const;
@@ -879,6 +885,16 @@ public:
    * qubit.
    */
   void reorderOperations();
+
+  /**
+   * @brief Check whether the quantum computation contains dynamic circuit
+   * primitives
+   * @details Dynamic circuit primitives are mid-circuit measurements, resets,
+   * or classical control flow operations. This method traverses the whole
+   * circuit once until it finds a dynamic operation.
+   * @return Whether the quantum computation contains dynamic circuit primitives
+   */
+  [[nodiscard]] bool isDynamic() const;
 
   /**
    * Pass-Through

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -1246,8 +1246,7 @@ bool isDynamicCircuit(const std::unique_ptr<Operation>* op,
                        [&measured](const auto& q) { return measured[q]; });
   }
 
-  if (it->isNonUnitaryOperation()) {
-    assert(it->getType() == qc::Measure);
+  if (it->getType() == qc::Measure) {
     for (const auto& b : it->getTargets()) {
       measured[b] = true;
     }

--- a/test/algorithms/CMakeLists.txt
+++ b/test/algorithms/CMakeLists.txt
@@ -1,5 +1,5 @@
-if(TARGET MQT::CoreAlgo)
+if(TARGET MQT::CoreAlgorithms)
   file(GLOB_RECURSE ALGO_TEST_SOURCES *.cpp)
-  package_add_test(mqt-core-algo-test MQT::CoreAlgo ${ALGO_TEST_SOURCES})
-  target_link_libraries(mqt-core-algo-test PRIVATE MQT::CoreDD MQT::CoreCircuitOptimizer)
+  package_add_test(mqt-core-algorithms-test MQT::CoreAlgorithms ${ALGO_TEST_SOURCES})
+  target_link_libraries(mqt-core-algorithms-test PRIVATE MQT::CoreDD MQT::CoreCircuitOptimizer)
 endif()

--- a/test/circuit_optimizer/test_defer_measurements.cpp
+++ b/test/circuit_optimizer/test_defer_measurements.cpp
@@ -31,13 +31,13 @@ TEST(DeferMeasurements, basicTest) {
   qc.classicControlled(qc::X, 1, {0, 1U}, 1U);
   std::cout << qc << "\n";
 
-  EXPECT_TRUE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_TRUE(qc.isDynamic());
 
   EXPECT_NO_THROW(CircuitOptimizer::deferMeasurements(qc););
 
   std::cout << qc << "\n";
 
-  EXPECT_FALSE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_FALSE(qc.isDynamic());
 
   ASSERT_EQ(qc.getNqubits(), 2);
   ASSERT_EQ(qc.getNindividualOps(), 3);
@@ -96,13 +96,13 @@ TEST(DeferMeasurements, measurementBetweenMeasurementAndClassic) {
   qc.classicControlled(qc::X, 1, {0, 1U}, 1U);
   std::cout << qc << "\n";
 
-  EXPECT_TRUE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_TRUE(qc.isDynamic());
 
   EXPECT_NO_THROW(CircuitOptimizer::deferMeasurements(qc););
 
   std::cout << qc << "\n";
 
-  EXPECT_FALSE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_FALSE(qc.isDynamic());
 
   ASSERT_EQ(qc.getNqubits(), 2);
   ASSERT_EQ(qc.getNindividualOps(), 4);
@@ -172,13 +172,13 @@ TEST(DeferMeasurements, twoClassic) {
 
   std::cout << qc << "\n";
 
-  EXPECT_TRUE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_TRUE(qc.isDynamic());
 
   EXPECT_NO_THROW(CircuitOptimizer::deferMeasurements(qc););
 
   std::cout << qc << "\n";
 
-  EXPECT_FALSE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_FALSE(qc.isDynamic());
 
   ASSERT_EQ(qc.getNqubits(), 2);
   ASSERT_EQ(qc.getNindividualOps(), 5);
@@ -253,13 +253,13 @@ TEST(DeferMeasurements, correctOrder) {
   qc.classicControlled(qc::X, 1, {0, 1U}, 1U);
   std::cout << qc << "\n";
 
-  EXPECT_TRUE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_TRUE(qc.isDynamic());
 
   EXPECT_NO_THROW(CircuitOptimizer::deferMeasurements(qc););
 
   std::cout << qc << "\n";
 
-  EXPECT_FALSE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_FALSE(qc.isDynamic());
 
   ASSERT_EQ(qc.getNqubits(), 2);
   ASSERT_EQ(qc.getNindividualOps(), 4);
@@ -328,13 +328,13 @@ TEST(DeferMeasurements, twoClassicCorrectOrder) {
   qc.classicControlled(qc::Z, 1, {0, 1U}, 1U);
   std::cout << qc << "\n";
 
-  EXPECT_TRUE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_TRUE(qc.isDynamic());
 
   EXPECT_NO_THROW(CircuitOptimizer::deferMeasurements(qc););
 
   std::cout << qc << "\n";
 
-  EXPECT_FALSE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_FALSE(qc.isDynamic());
 
   ASSERT_EQ(qc.getNqubits(), 2);
   ASSERT_EQ(qc.getNindividualOps(), 5);
@@ -401,7 +401,7 @@ TEST(DeferMeasurements, errorOnImplicitReset) {
   qc.classicControlled(qc::X, 0, {0, 1U}, 1U);
   std::cout << qc << "\n";
 
-  EXPECT_TRUE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_TRUE(qc.isDynamic());
 
   EXPECT_THROW(CircuitOptimizer::deferMeasurements(qc), qc::QFRException);
 }
@@ -429,7 +429,7 @@ TEST(DeferMeasurements, isDynamicOnRepeatedMeasurements) {
   qc.h(0);
   qc.measure(0, 1);
 
-  EXPECT_TRUE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_TRUE(qc.isDynamic());
 }
 
 } // namespace qc

--- a/test/circuit_optimizer/test_eliminate_resets.cpp
+++ b/test/circuit_optimizer/test_eliminate_resets.cpp
@@ -22,7 +22,7 @@ TEST(EliminateResets, eliminateResetsBasicTest) {
 
   std::cout << qc << "\n";
 
-  EXPECT_TRUE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_TRUE(qc.isDynamic());
 
   EXPECT_NO_THROW(CircuitOptimizer::eliminateResets(qc););
 
@@ -78,7 +78,7 @@ TEST(EliminateResets, eliminateResetsClassicControlled) {
   qc.classicControlled(qc::X, 0, {0, 1U}, 1U);
   std::cout << qc << "\n";
 
-  EXPECT_TRUE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_TRUE(qc.isDynamic());
 
   EXPECT_NO_THROW(CircuitOptimizer::eliminateResets(qc););
 
@@ -128,7 +128,7 @@ TEST(EliminateResets, eliminateResetsMultipleTargetReset) {
 
   std::cout << qc << "\n";
 
-  EXPECT_TRUE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_TRUE(qc.isDynamic());
 
   EXPECT_NO_THROW(CircuitOptimizer::eliminateResets(qc););
 
@@ -176,7 +176,7 @@ TEST(EliminateResets, eliminateResetsCompoundOperation) {
 
   std::cout << qc << "\n";
 
-  EXPECT_TRUE(CircuitOptimizer::isDynamicCircuit(qc));
+  EXPECT_TRUE(qc.isDynamic());
 
   EXPECT_NO_THROW(CircuitOptimizer::eliminateResets(qc););
 

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -1131,3 +1131,14 @@ TEST_F(QFRFunctionality, OperationReorderingBarrier) {
   const auto target2 = (*it)->getTargets().at(0);
   EXPECT_EQ(target2, 1);
 }
+
+TEST_F(QFRFunctionality, isDynamicCompoundOperation) {
+  QuantumComputation qc(1, 1);
+  QuantumComputation compound(1, 1);
+  compound.measure(0, 0);
+  compound.x(0);
+  compound.measure(0, 0);
+  qc.emplace_back(compound.asCompoundOperation());
+  std::cout << qc << "\n";
+  EXPECT_TRUE(qc.isDynamic());
+}


### PR DESCRIPTION
## Description

This PR optimizes the `isDynamic`(Circuit) check by simplifying the overall implementation and making the function `const`.
Furthermore, the function is moved from the `CircuitOptimizer` to the `QuantumComputation` class itself.

Last, but not least, this PR fixes an issue in the CMake configuration that would prevent the algorithm tests to run properly.
## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
