### PR TITLE
🚸 Allow creating circuits from compound operations

### DIFF
--- a/include/mqt-core/ir/Permutation.hpp
+++ b/include/mqt-core/ir/Permutation.hpp
@@ -10,33 +10,11 @@
 namespace qc {
 class Permutation : public std::map<Qubit, Qubit> {
 public:
-  [[nodiscard]] Controls apply(const Controls& controls) const {
-    if (empty()) {
-      return controls;
-    }
-    Controls c{};
-    for (const auto& control : controls) {
-      c.emplace(at(control.qubit), control.type);
-    }
-    return c;
-  }
-  [[nodiscard]] Targets apply(const Targets& targets) const {
-    if (empty()) {
-      return targets;
-    }
-    Targets t{};
-    for (const auto& target : targets) {
-      t.emplace_back(at(target));
-    }
-    return t;
-  }
-
-  [[nodiscard]] auto apply(const Qubit qubit) const -> Qubit {
-    if (empty()) {
-      return qubit;
-    }
-    return at(qubit);
-  }
+  [[nodiscard]] auto apply(const Controls& controls) const -> Controls;
+  [[nodiscard]] auto apply(const Targets& targets) const -> Targets;
+  [[nodiscard]] auto apply(Qubit qubit) const -> Qubit;
+  [[nodiscard]] auto maxKey() const -> Qubit;
+  [[nodiscard]] auto maxValue() const -> Qubit;
 };
 } // namespace qc
 

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -344,16 +344,10 @@ public:
 
   [[nodiscard]] std::string getQubitRegister(Qubit physicalQubitIndex) const;
   [[nodiscard]] std::string getClassicalRegister(Bit classicalIndex) const;
-  [[nodiscard]] static Qubit
-  getHighestLogicalQubitIndex(const Permutation& permutation);
-  [[nodiscard]] Qubit getHighestLogicalQubitIndex() const {
-    return getHighestLogicalQubitIndex(initialLayout);
-  };
-  [[nodiscard]] static Qubit
-  getHighestPhysicalQubitIndex(const Permutation& permutation);
-  [[nodiscard]] Qubit getHighestPhysicalQubitIndex() const {
-    return getHighestPhysicalQubitIndex(initialLayout);
-  };
+  /// Returns the highest qubit index used as a value in the initial layout
+  [[nodiscard]] Qubit getHighestLogicalQubitIndex() const;
+  /// Returns the highest qubit index used as a key in the initial layout
+  [[nodiscard]] Qubit getHighestPhysicalQubitIndex() const;
   [[nodiscard]] std::pair<std::string, Qubit>
   getQubitRegisterAndIndex(Qubit physicalQubitIndex) const;
   [[nodiscard]] std::pair<std::string, Bit>

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -765,14 +765,6 @@ public:
   void addQubit(Qubit logicalQubitIndex, Qubit physicalQubitIndex,
                 std::optional<Qubit> outputQubitIndex);
 
-  /**
-   * @brief Ensures unassigned qubits in initial layout are assigned
-   * (deterministic) qubit indices.
-   * @details After this function is called, the initial layout will be
-   * contiguous.
-   */
-  void ensureContiguousInitialLayout();
-
   QuantumComputation instantiate(const VariableAssignment& assignment) {
     QuantumComputation result(*this);
     result.instantiateInplace(assignment);

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -298,14 +298,21 @@ public:
    * @param qasm The OpenQASM 2.0 or 3.0 string
    * @return The constructed QuantumComputation
    */
-  [[nodiscard]] static QuantumComputation fromQASM(const std::string& qasm) {
-    std::stringstream ss{};
-    ss << qasm;
-    QuantumComputation qc{};
-    qc.importOpenQASM3(ss);
-    qc.initializeIOMapping();
-    return qc;
-  }
+  [[nodiscard]] static QuantumComputation fromQASM(const std::string& qasm);
+
+  /**
+   * @brief Construct a QuantumComputation from CompoundOperation object
+   * @details The function creates a copy of each operation in the compound
+   * operation. It uses the largest qubit index in the CompoundOperation for
+   * determining the number of qubits. It adds a single quantum register with
+   * all qubits from 0 to the largest qubit index and a corresponding classical
+   * register with the same size. The initial layout as well as the output
+   * permutation are set to the identity permutation.
+   * @param op The CompoundOperation to convert to a quantum circuit
+   * @return The constructed QuantumComputation
+   */
+  [[nodiscard]] static QuantumComputation
+  fromCompoundOperation(const CompoundOperation& op);
 
   [[nodiscard]] virtual std::size_t getNops() const { return ops.size(); }
   [[nodiscard]] std::size_t getNqubits() const { return nqubits + nancillae; }

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -758,6 +758,14 @@ public:
   void addQubit(Qubit logicalQubitIndex, Qubit physicalQubitIndex,
                 std::optional<Qubit> outputQubitIndex);
 
+  /**
+   * @brief Ensures unassigned qubits in initial layout are assigned
+   * (deterministic) qubit indices.
+   * @details After this function is called, the initial layout will be
+   * contiguous.
+   */
+  void ensureContiguousInitialLayout();
+
   QuantumComputation instantiate(const VariableAssignment& assignment) {
     QuantumComputation result(*this);
     result.instantiateInplace(assignment);
@@ -824,23 +832,27 @@ public:
   static std::ostream& printPermutation(const Permutation& permutation,
                                         std::ostream& os = std::cout);
 
-  void dump(const std::string& filename, Format format);
-  void dump(const std::string& filename);
-  void dump(std::ostream& of, Format format);
-  void dumpOpenQASM2(std::ostream& of) { dumpOpenQASM(of, false); }
-  void dumpOpenQASM3(std::ostream& of) { dumpOpenQASM(of, true); }
-  void dumpOpenQASM(std::ostream& of, bool openQasm3);
+  void dump(const std::string& filename, Format format) const;
+  void dump(const std::string& filename) const;
+  void dump(std::ostream& of, Format format) const;
+  void dumpOpenQASM2(std::ostream& of) const { dumpOpenQASM(of, false); }
+  void dumpOpenQASM3(std::ostream& of) const { dumpOpenQASM(of, true); }
+
+  /**
+   * @brief Dumps the circuit in OpenQASM format to the given output stream
+   * @details One might want to call `ensureContiguousInitialLayout` before
+   * calling this function to ensure full layout information is available.
+   * @param of The output stream to write the OpenQASM representation to
+   * @param openQasm3 Whether to use OpenQASM 3.0 or 2.0
+   */
+  void dumpOpenQASM(std::ostream& of, bool openQasm3) const;
 
   /**
    * @brief Returns the OpenQASM representation of the circuit
    * @param qasm3 Whether to use OpenQASM 3.0 or 2.0
    * @return The OpenQASM representation of the circuit
    */
-  [[nodiscard]] std::string toQASM(const bool qasm3 = true) {
-    std::stringstream ss;
-    dumpOpenQASM(ss, qasm3);
-    return ss.str();
-  }
+  [[nodiscard]] std::string toQASM(bool qasm3 = true) const;
 
   // this convenience method allows to turn a circuit into a compound operation.
   std::unique_ptr<CompoundOperation> asCompoundOperation() {

--- a/src/ir/Permutation.cpp
+++ b/src/ir/Permutation.cpp
@@ -1,0 +1,54 @@
+#include "ir/Permutation.hpp"
+
+#include "Definitions.hpp"
+#include "ir/operations/Control.hpp"
+
+#include <algorithm>
+
+namespace qc {
+[[nodiscard]] auto
+Permutation::apply(const Controls& controls) const -> Controls {
+  if (empty()) {
+    return controls;
+  }
+  Controls c{};
+  for (const auto& control : controls) {
+    c.emplace(at(control.qubit), control.type);
+  }
+  return c;
+}
+[[nodiscard]] auto Permutation::apply(const Targets& targets) const -> Targets {
+  if (empty()) {
+    return targets;
+  }
+  Targets t{};
+  for (const auto& target : targets) {
+    t.emplace_back(at(target));
+  }
+  return t;
+}
+
+[[nodiscard]] auto Permutation::apply(const Qubit qubit) const -> Qubit {
+  if (empty()) {
+    return qubit;
+  }
+  return at(qubit);
+}
+
+[[nodiscard]] auto Permutation::maxKey() const -> Qubit {
+  if (empty()) {
+    return 0;
+  }
+  return crbegin()->first;
+}
+
+[[nodiscard]] auto Permutation::maxValue() const -> Qubit {
+  if (empty()) {
+    return 0;
+  }
+  return std::max_element(
+             cbegin(), cend(),
+             [](const auto& a, const auto& b) { return a.second < b.second; })
+      ->second;
+}
+} // namespace qc

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -861,22 +861,12 @@ std::ostream& QuantumComputation::printRegisters(std::ostream& os) const {
   return os;
 }
 
-Qubit QuantumComputation::getHighestLogicalQubitIndex(
-    const Permutation& permutation) {
-  Qubit maxIndex = 0;
-  for (const auto& [physical, logical] : permutation) {
-    maxIndex = std::max(maxIndex, logical);
-  }
-  return maxIndex;
+Qubit QuantumComputation::getHighestLogicalQubitIndex() const {
+  return initialLayout.maxValue();
 }
 
-Qubit QuantumComputation::getHighestPhysicalQubitIndex(
-    const Permutation& permutation) {
-  Qubit maxIndex = 0;
-  for (const auto& [physical, logical] : permutation) {
-    maxIndex = std::max(maxIndex, physical);
-  }
-  return maxIndex;
+Qubit QuantumComputation::getHighestPhysicalQubitIndex() const {
+  return initialLayout.maxKey();
 }
 
 bool QuantumComputation::physicalQubitIsAncillary(

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -506,18 +506,6 @@ void QuantumComputation::addQubit(const Qubit logicalQubitIndex,
   garbage[logicalQubitIndex] = false;
 }
 
-void QuantumComputation::ensureContiguousInitialLayout() {
-  const auto maxPhysicalQubit = getHighestPhysicalQubitIndex();
-  auto logicalQubitIndex = getHighestLogicalQubitIndex() + 1;
-  for (Qubit physicalQubitIndex = 0; physicalQubitIndex < maxPhysicalQubit;
-       ++physicalQubitIndex) {
-    if (initialLayout.count(physicalQubitIndex) == 0) {
-      addQubit(logicalQubitIndex, physicalQubitIndex, std::nullopt);
-      ++logicalQubitIndex;
-    }
-  }
-}
-
 std::ostream& QuantumComputation::print(std::ostream& os) const {
   os << name << "\n";
   const auto width =

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -1,4 +1,5 @@
 #include "Definitions.hpp"
+#include "ir/Permutation.hpp"
 #include "ir/QuantumComputation.hpp"
 #include "ir/operations/ClassicControlledOperation.hpp"
 #include "ir/operations/CompoundOperation.hpp"
@@ -1141,4 +1142,15 @@ TEST_F(QFRFunctionality, isDynamicCompoundOperation) {
   qc.emplace_back(compound.asCompoundOperation());
   std::cout << qc << "\n";
   EXPECT_TRUE(qc.isDynamic());
+}
+
+TEST_F(QFRFunctionality, emptyPermutation) {
+  const Permutation perm{};
+
+  EXPECT_EQ(perm.size(), 0U);
+  EXPECT_EQ(perm.apply(0U), 0U);
+  EXPECT_EQ(perm.apply(Targets{0U}), Targets{0U});
+  EXPECT_EQ(perm.apply(Controls{0U}), Controls{0U});
+  EXPECT_EQ(perm.maxKey(), 0U);
+  EXPECT_EQ(perm.maxValue(), 0U);
 }


### PR DESCRIPTION
## Description

This PR adds functionality to construct circuits from compound operations. 
In the process, it also improves the QASM dumping functionality by making it `const`.
Last, but not least, it refactors the corresponding IO tests to use more convenient interfaces that are now available.

Fixes #600

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
