### PR TITLE
🩹 fix endless loop on unsupported operations in OpenQASM gate declarations

### DIFF
--- a/src/ir/parsers/qasm3_parser/Parser.cpp
+++ b/src/ir/parsers/qasm3_parser/Parser.cpp
@@ -144,12 +144,7 @@ std::shared_ptr<Statement> Parser::parseStatement() {
     return parseMeasureStatement();
   }
 
-  if (auto quantumStatement = parseQuantumStatement();
-      quantumStatement != nullptr) {
-    return quantumStatement;
-  }
-
-  error(current(), "Expected statement, got '" + current().toString() + "'.");
+  return parseQuantumStatement();
 }
 
 std::shared_ptr<QuantumStatement> Parser::parseQuantumStatement() {
@@ -173,7 +168,8 @@ std::shared_ptr<QuantumStatement> Parser::parseQuantumStatement() {
     return parseBarrierStatement();
   }
 
-  return nullptr;
+  error(current(),
+        "Expected quantum statement, got '" + current().toString() + "'.");
 }
 
 void Parser::parseInclude() {

--- a/test/ir/test_qasm3_parser.cpp
+++ b/test/ir/test_qasm3_parser.cpp
@@ -1322,7 +1322,7 @@ TEST_F(Qasm3ParserTest, ImportQasmGateExpectStatement) {
         try {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Expected statement, got '+'.");
+          EXPECT_EQ(e.message, "Expected quantum statement, got '+'.");
           throw;
         }
       },
@@ -1512,6 +1512,25 @@ TEST_F(Qasm3ParserTest, ImportQasmNegativeTypeDesignator) {
           const auto qc = QuantumComputation::fromQASM(testfile);
         } catch (const qasm3::CompilerError& e) {
           EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
+          throw;
+        }
+      },
+      qasm3::CompilerError);
+}
+
+TEST_F(Qasm3ParserTest, ImportQasmRegisterDeclarationInDefinition) {
+  const std::string testfile = "qubit[1] q;"
+                               "gate test a {"
+                               "qubit[2] crash;"
+                               "x a;}"
+                               "test q[0];";
+
+  EXPECT_THROW(
+      {
+        try {
+          const auto qc = QuantumComputation::fromQASM(testfile);
+        } catch (const qasm3::CompilerError& e) {
+          EXPECT_EQ(e.message, "Expected quantum statement, got 'qubit'.");
           throw;
         }
       },


### PR DESCRIPTION
## Description

This PR fixes an endless loop in the OpenQASM parser upon encountering unexpected statements in gate declarations.
WIth this PR, the parser actually errors out with an appropriate error message instead of looping forever.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
