### PR TITLE
🔧 adjust how the CD workflow is run

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,7 @@
 name: CD
 on:
-  workflow_call:
+  push:
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     name: 🚀 CD
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cd)
-    uses: ./.github/workflows/cd.yml
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.4
 
   required-checks-pass: # This job does nothing and is only used for branch protection
     name: 🚦 Check


### PR DESCRIPTION
## Description

A small follow-up PR to #666 that adjusts how the continuous deployment job is run.
Hopefully, after merging, this allows to continuously upload to TestPyPI.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
