### PR TITLE
♻️ move `--reinstall-package` from `noxfile` to `pyproject.toml` configuration

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -69,7 +69,7 @@ def _run_tests(
 
     session.install(*BUILD_REQUIREMENTS, *install_args, env=env)
     install_arg = f"-ve.[{','.join(_extras)}]"
-    session.install("--no-build-isolation", "--reinstall-package", "mqt.core", install_arg, *install_args, env=env)
+    session.install("--no-build-isolation", install_arg, *install_args, env=env)
     session.run("pytest", *run_args, *posargs, env=env)
 
 
@@ -101,7 +101,7 @@ def docs(session: nox.Session) -> None:
     serve = args.builder == "html" and session.interactive
     extra_installs = ["sphinx-autobuild"] if serve else []
     session.install(*BUILD_REQUIREMENTS, *extra_installs)
-    session.install("--no-build-isolation", "-ve.[docs]", "--reinstall-package", "mqt.core")
+    session.install("--no-build-isolation", "-ve.[docs]")
 
     if args.builder == "linkcheck":
         session.run("sphinx-build", "-b", "linkcheck", "docs", "docs/_build/linkcheck", *posargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,3 +298,7 @@ environment = { CMAKE_GENERATOR = "Ninja", SKBUILD_CMAKE_ARGS="--fresh" }
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
+
+
+[tool.uv]
+reinstall-package = ["mqt-core"]


### PR DESCRIPTION
## Description

This small PR moves the `--reinstall-package` configuration from the `noxfile` to the `tool.uv` table in the `pyproject.toml` file. This makes the `noxfile` a little more `uv` agnostic and simplifies the overall configuration. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
