### PR TITLE
🩹 make sure to activate the venv in RtD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,6 +22,7 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv venv
+    - source .venv/bin/activate
     # Install the project and its documentation dependencies
     - uv pip install .[docs] readthedocs-sphinx-ext
     # Run the html builder

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,7 +22,7 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv venv
-    - source .venv/bin/activate
+    - . .venv/bin/activate
     # Install the project and its documentation dependencies
     - uv pip install .[docs] readthedocs-sphinx-ext
     # Run the html builder

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,17 +22,16 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv venv
-    - . .venv/bin/activate
     # Install the project and its documentation dependencies
     - uv pip install .[docs] readthedocs-sphinx-ext
     # Run the html builder
-    - .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+    - . .venv/bin/activate && .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
     # Run the htmlzip builder and create a zip file
-    - .venv/bin/python -m sphinx -T -b dirhtml -d docs/_build/doctrees -D language=en docs docs/_build/dirhtml
+    - . .venv/bin/activate && .venv/bin/python -m sphinx -T -b dirhtml -d docs/_build/doctrees -D language=en docs docs/_build/dirhtml
     - mkdir -p $READTHEDOCS_OUTPUT/htmlzip
     - zip -r $READTHEDOCS_OUTPUT/htmlzip/html.zip docs/_build/dirhtml/*
     # Run the latex builder and create a pdf file
-    - .venv/bin/python -m sphinx -T -b latex -d docs/_build/doctrees -D language=en docs docs/_build/latex
+    - . .venv/bin/activate && .venv/bin/python -m sphinx -T -b latex -d docs/_build/doctrees -D language=en docs docs/_build/latex
     - cd docs/_build/latex && latexmk -pdf -f -dvi- -ps- -interaction=nonstopmode -jobname=$READTHEDOCS_PROJECT
     - mkdir -p $READTHEDOCS_OUTPUT/pdf
     - cp docs/_build/latex/$READTHEDOCS_PROJECT.pdf $READTHEDOCS_OUTPUT/pdf/$READTHEDOCS_PROJECT.pdf


### PR DESCRIPTION
## Description

This PR makes sure that the virtual environment in the RtD build is activated so that the installed console-scripts become available.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
