### PR TITLE
🔧 use separate build directories per Python version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -55,7 +55,6 @@ def _run_tests(
     env = {}
     if os.environ.get("CI", None) and sys.platform == "win32":
         env["CMAKE_GENERATOR"] = "Ninja"
-        env["SKBUILD_CMAKE_ARGS"] = "--fresh"
 
     if shutil.which("cmake") is None and shutil.which("cmake3") is None:
         session.install("cmake")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,14 +75,14 @@ minimum-version = "build-system.requires"
 # Set the wheel install directory
 wheel.install-dir = "mqt/core"
 
+# Explicitly set the package directory
+wheel.packages = ["src/mqt"]
+
 # Set required Ninja version
 ninja.version = ">=1.10"
 
 # Setuptools-style build caching in a local directory
-build-dir = "build/{build_type}"
-
-# Explicitly set the package directory
-wheel.packages = ["src/mqt"]
+build-dir = "build/{wheel_tag}/{build_type}"
 
 # Only build the Python bindings target
 build.targets = ["ir"]
@@ -293,7 +293,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
 [tool.cibuildwheel.windows]
 before-build = "uv pip install delvewheel>=1.7.3"
 repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --namespace-pkg mqt"
-environment = { CMAKE_GENERATOR = "Ninja", SKBUILD_CMAKE_ARGS="--fresh" }
+environment = { CMAKE_GENERATOR = "Ninja" }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"


### PR DESCRIPTION
## Description

Revert to using separate build directories for the Python builds and rather rely on the caching performance of ccache between builds.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
