### PR TITLE
🐛 properly handle timing literals in QASM parser 

### DIFF
--- a/include/mqt-core/ir/parsers/qasm3_parser/Scanner.hpp
+++ b/include/mqt-core/ir/parsers/qasm3_parser/Scanner.hpp
@@ -32,6 +32,8 @@ class Scanner {
     return isNum(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
   }
 
+  [[nodiscard]] static bool hasTimingSuffix(char first, char second);
+
   static char readUtf8Codepoint(std::istream* in);
 
   void nextCh();

--- a/include/mqt-core/ir/parsers/qasm3_parser/Token.hpp
+++ b/include/mqt-core/ir/parsers/qasm3_parser/Token.hpp
@@ -142,14 +142,6 @@ public:
 
     Underscore,
 
-    TimeUnitDt,
-    TimeUnitNs,
-    TimeUnitUs,
-    TimeUnitMys,
-    TimeUnitMs,
-    // might be either TimeUnitS or the `s` gate
-    S,
-
     DoubleQuote,
     SingleQuote,
     BackSlash,
@@ -160,6 +152,7 @@ public:
     StringLiteral,
     IntegerLiteral,
     FloatLiteral,
+    TimingLiteral,
 
     Sin,
     Cos,
@@ -401,18 +394,6 @@ public:
       return "imag";
     case Kind::Underscore:
       return "underscore";
-    case Kind::TimeUnitDt:
-      return "dt";
-    case Kind::TimeUnitNs:
-      return "ns";
-    case Kind::TimeUnitUs:
-      return "us";
-    case Kind::TimeUnitMys:
-      return "mys";
-    case Kind::TimeUnitMs:
-      return "ms";
-    case Kind::S:
-      return "s";
     case Kind::DoubleQuote:
       return "\"";
     case Kind::SingleQuote:
@@ -429,6 +410,8 @@ public:
       return "IntegerLiteral";
     case Kind::FloatLiteral:
       return "FloatLiteral";
+    case Kind::TimingLiteral:
+      return "TimingLiteral";
     case Kind::Sin:
       return "sin";
     case Kind::Cos:
@@ -472,6 +455,9 @@ public:
       break;
     case Kind::FloatLiteral:
       ss << " (" << valReal << ")";
+      break;
+    case Kind::TimingLiteral:
+      ss << " (" << valReal << " [s])";
       break;
     default:
       break;

--- a/src/ir/parsers/qasm3_parser/Parser.cpp
+++ b/src/ir/parsers/qasm3_parser/Parser.cpp
@@ -153,8 +153,7 @@ std::shared_ptr<QuantumStatement> Parser::parseQuantumStatement() {
       current().kind == Token::Kind::Ctrl ||
       current().kind == Token::Kind::NegCtrl ||
       current().kind == Token::Kind::Identifier ||
-      current().kind == Token::Kind::Gphase ||
-      current().kind == Token::Kind::S) {
+      current().kind == Token::Kind::Gphase) {
     // TODO: since we do not support classical function calls yet, we can assume
     // that this is a gate statement
     return parseGateCallStatement();
@@ -385,9 +384,6 @@ std::shared_ptr<GateCallStatement> Parser::parseGateCallStatement() {
     scan();
     identifier = "gphase";
     operandsOptional = true;
-  } else if (current().kind == Token::Kind::S) {
-    scan();
-    identifier = "s";
   } else {
     identifier = expect(Token::Kind::Identifier).str;
   }

--- a/test/ir/test_qasm3_parser.cpp
+++ b/test/ir/test_qasm3_parser.cpp
@@ -2234,3 +2234,10 @@ TEST_F(Qasm3ParserTest, TokenKindTimingLiteralInvalidSuffix) {
   const auto token = scanner.next();
   EXPECT_NE(token.kind, qasm3::Token::Kind::TimingLiteral);
 }
+
+TEST_F(Qasm3ParserTest, TokenKindTimingLiteralMicrosecondsInteger) {
+  qasm3::Scanner scanner(new std::istringstream("1us"));
+  const auto token = scanner.next();
+  EXPECT_EQ(token.kind, qasm3::Token::Kind::TimingLiteral);
+  EXPECT_DOUBLE_EQ(token.valReal, 1.0e-6);
+}


### PR DESCRIPTION
## Description

This PR fixes a bug in the QASM parser that would treat timing literal suffixes as individual tokens, which can lead to strange errors with gate declarations whose name matches a timing literal suffix, e.g., `ms`.
Timing literals are now properly treated and do not lead to clashes.

In the process, it was noticed that the Python import of long QASM strings would fail due to pathlib throwing an `OSError` for too long paths.
This is now fixed by short circuiting if the path is too long.

Fixes #723

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
