### PR TITLE
🚸 Add Basic Python Bindings for NAComputation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ ninja.version = ">=1.10"
 build-dir = "build/{wheel_tag}/{build_type}"
 
 # Only build the Python bindings target
-build.targets = ["ir"]
+build.targets = ["ir", "na"]
 
 # Only install the Python package component
 install.components = ["mqt-core_Python"]

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,2 +1,4 @@
 # add the IR bindings package
 add_subdirectory(ir)
+# add the NA bindings package
+add_subdirectory(na)

--- a/src/python/na/CMakeLists.txt
+++ b/src/python/na/CMakeLists.txt
@@ -1,0 +1,23 @@
+if(NOT TARGET na)
+  # collect source files
+  file(GLOB_RECURSE NA_SOURCES **.cpp)
+
+  # declare the Python module
+  pybind11_add_module(
+    # Name of the extension
+    na
+    # Prefer thin LTO if available
+    THIN_LTO
+    # Optimize the bindings for size
+    OPT_SIZE
+    # Source code goes here
+    ${MQT_CORE_INCLUDE_BUILD_DIR}/python/pybind11.hpp
+    ${NA_SOURCES})
+  target_link_libraries(na PRIVATE MQT::CoreNA MQT::ProjectOptions MQT::ProjectWarnings)
+
+  # Install directive for scikit-build-core
+  install(
+    TARGETS na
+    DESTINATION .
+    COMPONENT ${MQT_CORE_TARGET_NAME}_Python)
+endif()

--- a/src/python/na/register_na_computation.cpp
+++ b/src/python/na/register_na_computation.cpp
@@ -20,4 +20,7 @@ void registerNAComputation(py::module& m) {
   qc.def("__str__",
          [](const na::NAComputation& circ) { return circ.toString(); });
 }
+
+PYBIND11_MODULE(na, m, py::mod_gil_not_used()) { registerNAComputation(m); }
+
 } // namespace mqt

--- a/src/python/na/register_na_computation.cpp
+++ b/src/python/na/register_na_computation.cpp
@@ -1,0 +1,23 @@
+#include "na/NAComputation.hpp"
+#include "python/pybind11.hpp"
+
+namespace mqt {
+
+void registerNAComputation(py::module& m) {
+
+  auto qc = py::class_<na::NAComputation>(m, "NAComputation");
+
+  ///---------------------------------------------------------------------------
+  ///                           \n Constructors \n
+  ///---------------------------------------------------------------------------
+
+  qc.def(py::init<>(), "Constructs an empty NAComputation.");
+
+  ///---------------------------------------------------------------------------
+  ///                       \n String Serialization \n
+  ///---------------------------------------------------------------------------
+  ///
+  qc.def("__str__",
+         [](const na::NAComputation& circ) { return circ.toString(); });
+}
+} // namespace mqt


### PR DESCRIPTION
## Description

I need the export functionality of the `NAComputation` to a string in the Python bindings of MQT QMap. This PR creates a binding for that on the Python side.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
