### PR TITLE
🐛 Fix out-of-bounds error in ZX `EdgeIterator` and needless dummy register in empty circuit construction

### DIFF
--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -216,7 +216,9 @@ public:
   explicit QuantumComputation(const std::size_t nq, const std::size_t nc = 0U,
                               const std::size_t s = 0)
       : seed(s) {
-    addQubitRegister(nq);
+    if (nq > 0) {
+      addQubitRegister(nq);
+    }
     if (nc > 0) {
       addClassicalRegister(nc);
     }

--- a/src/zx/Utils.cpp
+++ b/src/zx/Utils.cpp
@@ -59,9 +59,14 @@ Edges::EdgeIterator::EdgeIterator(
     while (v < edges.size() && !vertices[v].has_value()) {
       ++v;
     }
-    currentPos = edges[v].begin();
-    edgesPos = edges.begin() + static_cast<int>(v);
-    checkNextVertex();
+    if (v < edges.size()) {
+      currentPos = edges[v].begin();
+      edgesPos = edges.begin() + static_cast<int>(v);
+      checkNextVertex();
+    } else {
+      currentPos = edges.back().end();
+      edgesPos = edges.end();
+    }
   } else {
     currentPos = edges.back().end();
     edgesPos = edges.end();

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -1154,3 +1154,8 @@ TEST_F(QFRFunctionality, emptyPermutation) {
   EXPECT_EQ(perm.maxKey(), 0U);
   EXPECT_EQ(perm.maxValue(), 0U);
 }
+
+TEST_F(QFRFunctionality, NoRegisterOnEmptyCircuit) {
+  const qc::QuantumComputation qc(0U);
+  EXPECT_TRUE(qc.getQregs().empty());
+}

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -1156,6 +1156,10 @@ TEST_F(QFRFunctionality, emptyPermutation) {
 }
 
 TEST_F(QFRFunctionality, NoRegisterOnEmptyCircuit) {
-  const qc::QuantumComputation qc(0U);
-  EXPECT_TRUE(qc.getQregs().empty());
+  // This is a regression test. Previously, the following code would throw an
+  // exception because even zero-qubit circuits had an empty register named "q".
+  qc::QuantumComputation qc(0U);
+  qc.addQubitRegister(1U, "p");
+  EXPECT_NO_THROW(qc.addQubitRegister(1U, "q"));
+  EXPECT_EQ(qc.getQregs().size(), 2U);
 }

--- a/test/zx/test_simplify.cpp
+++ b/test/zx/test_simplify.cpp
@@ -579,3 +579,17 @@ TEST_F(SimplifyTest, equivalenceSymbolic) {
   EXPECT_EQ(d1.getNVertices(), 6);
   EXPECT_TRUE(d1.isIdentity());
 }
+
+TEST_F(SimplifyTest, OnlyDeletedVertices) {
+  // This is a regression test. The following code should not throw an
+  // exception. It previously did because the code did not handle the case where
+  // the diagram only contains deleted vertices.
+  zx::ZXDiagram diag = ::makeIdentityDiagram(1, 0);
+  diag.makeAncilla(0);
+  // The following simplifies the diagram to the empty diagram.
+  zx::fullReduce(diag);
+  EXPECT_EQ(diag.getNEdges(), 0);
+  EXPECT_EQ(diag.getNVertices(), 0);
+  // A subsequent simplification should not throw an exception.
+  EXPECT_NO_THROW(zx::fullReduce(diag););
+}


### PR DESCRIPTION
## Description

This PR fixes an out-of-bounds error in the ZX packages `EdgeIterator` that would happen whenever a ZX diagram would only consist of eliminated nodes.

In addition, this PR fixes an oversight in the QuantumComputation constructor where an empty qubit register `"q"` was added even on a zero-qubit circuit.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
