### PR TITLE
🐛 Fix stripping of idle qubits

### DIFF
--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -721,23 +721,27 @@ void QuantumComputation::dump(const std::string& filename) const {
 
 void QuantumComputation::dumpOpenQASM(std::ostream& of, bool openQASM3) const {
   // dump initial layout and output permutation
+  // since it might happen that the physical qubit indices are not consecutive,
+  // due to qubit removals, we need to adjust them accordingly.
   Permutation inverseInitialLayout{};
-  for (const auto& q : initialLayout) {
-    inverseInitialLayout.insert({q.second, q.first});
+  std::size_t idx = 0;
+  for (const auto& [physical, logical] : initialLayout) {
+    inverseInitialLayout.emplace(logical, idx++);
   }
   of << "// i";
-  for (const auto& q : inverseInitialLayout) {
-    of << " " << static_cast<std::size_t>(q.second);
+  for (const auto& [logical, physical] : inverseInitialLayout) {
+    of << " " << static_cast<std::size_t>(physical);
   }
   of << "\n";
 
   Permutation inverseOutputPermutation{};
-  for (const auto& q : outputPermutation) {
-    inverseOutputPermutation.insert({q.second, q.first});
+  idx = 0;
+  for (const auto& [physical, logical] : outputPermutation) {
+    inverseOutputPermutation.emplace(logical, idx++);
   }
   of << "// o";
-  for (const auto& q : inverseOutputPermutation) {
-    of << " " << q.second;
+  for (const auto& [logical, physical] : inverseOutputPermutation) {
+    of << " " << physical;
   }
   of << "\n";
 

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -1492,4 +1492,28 @@ TEST_F(QFRFunctionality, TryGettingRegisterForQubitNotInRegister) {
   EXPECT_THROW(std::ignore = qc.getQubitRegister(2), QFRException);
 }
 
+TEST_F(QFRFunctionality, stripIdleQubits) {
+  QuantumComputation qc(3, 2);
+  qc.x(0);
+  qc.x(2);
+  qc.measure(0, 0);
+  qc.measure(2, 1);
+  qc.stripIdleQubits(true);
+
+  const auto* const expected = "// i 0 1\n"
+                               "// o 0 1\n"
+                               "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[1] q_l;\n"
+                               "qubit[1] q_h;\n"
+                               "bit[2] c;\n"
+                               "x q_l[0];\n"
+                               "x q_h[0];\n"
+                               "c[0] = measure q_l[0];\n"
+                               "c[1] = measure q_h[0];\n";
+
+  EXPECT_EQ(qc.toQASM(), expected);
+  const auto qc2 = QuantumComputation::fromQASM(expected);
+  EXPECT_EQ(qc2.toQASM(), expected);
+}
 } // namespace qc


### PR DESCRIPTION
## Description

Fixes #729

This PR builds on the register handling improvements in #807 and fixes the the last remaining part of the problem observed in #729.
When dumping a circuit to QASM that has been stripped of idle qubits, the initial layout and output permutation need to be adjusted so that the resulting circuit can be read in again without problems.
The reason this PR is so small is mainly because a lot of the legwork was already done in #807.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
