### PR TITLE
➖ simplify dependencies after `uv` update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dynamic = ["version"]
 [project.optional-dependencies]
 evaluation = [
   "pandas[output-formatting]>=2.1.2",
-  "pandas[output-formatting]>=2.2.3; python_version >= '3.13'",
 ]
 qiskit = [
   "qiskit[qasm3-import]>=1.0.0",
@@ -268,11 +267,8 @@ build = [
 ]
 docs = [
   "furo>=2024.8.6",
-  "ipython>=8.29; python_version >= '3.10'",
   "myst-nb>=1.1.2",
-  "myst-parser>=4; python_version >= '3.10'",
   "setuptools-scm>=8.1",
-  "sphinx>=8; python_version >= '3.10'",
   "sphinx-autoapi>=3.3.3",
   "sphinx-copybutton>=0.5.2",
   "sphinx-design>=0.6.1",
@@ -280,10 +276,7 @@ docs = [
   "sphinxcontrib-svg2pdfconverter>=1.2.3",
   "sphinxext-opengraph>=0.9.1",
   "pandas[output-formatting]>=2.1.2",
-  "pandas[output-formatting]>=2.2.3; python_version >= '3.13'",
   "qiskit[qasm3-import,visualization]>=1.0.0",
-  "scipy>=1.14.1; python_version >= '3.13'",
-  "numpy>=2.1; python_version >= '3.13'",
 ]
 test = [
   "pytest>=8.3.3",
@@ -292,8 +285,6 @@ test = [
   "pandas[output-formatting]>=2.1.2",
   "pandas[output-formatting]>=2.2.3; python_version >= '3.13'",
   "qiskit[qasm3-import]>=1.0.0",
-  "scipy>=1.14.1; python_version >= '3.13'",
-  "numpy>=2.1; python_version >= '3.13'",
 ]
 dev = [
   {include-group = "build"},

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "mqt-core"
-version = "2.7.1.dev60+g51e4f92"
+version = "2.7.1.dev62+g3b47bbce"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1342,10 +1342,7 @@ build = [
 ]
 dev = [
     { name = "furo" },
-    { name = "ipython", version = "8.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "myst-nb" },
-    { name = "myst-parser", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "2.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "pandas", extra = ["output-formatting"] },
     { name = "pybind11" },
     { name = "pytest" },
@@ -1353,9 +1350,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "qiskit", extra = ["qasm3-import", "visualization"] },
     { name = "scikit-build-core" },
-    { name = "scipy", version = "1.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "setuptools-scm" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "sphinx-autoapi" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
@@ -1365,15 +1360,10 @@ dev = [
 ]
 docs = [
     { name = "furo" },
-    { name = "ipython", version = "8.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "myst-nb" },
-    { name = "myst-parser", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "2.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "pandas", extra = ["output-formatting"] },
     { name = "qiskit", extra = ["qasm3-import", "visualization"] },
-    { name = "scipy", version = "1.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "setuptools-scm" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "sphinx-autoapi" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
@@ -1382,18 +1372,15 @@ docs = [
     { name = "sphinxext-opengraph" },
 ]
 test = [
-    { name = "numpy", version = "2.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "pandas", extra = ["output-formatting"] },
     { name = "pytest" },
     { name = "pytest-console-scripts" },
     { name = "pytest-cov" },
     { name = "qiskit", extra = ["qasm3-import"] },
-    { name = "scipy", version = "1.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "pandas", extras = ["output-formatting"], marker = "python_full_version >= '3.13' and extra == 'evaluation'", specifier = ">=2.2.3" },
     { name = "pandas", extras = ["output-formatting"], marker = "extra == 'evaluation'", specifier = ">=2.1.2" },
     { name = "qiskit", extras = ["qasm3-import"], marker = "extra == 'qiskit'", specifier = ">=1.0.0" },
 ]
@@ -1406,10 +1393,7 @@ build = [
 ]
 dev = [
     { name = "furo", specifier = ">=2024.8.6" },
-    { name = "ipython", marker = "python_full_version >= '3.10'", specifier = ">=8.29" },
     { name = "myst-nb", specifier = ">=1.1.2" },
-    { name = "myst-parser", marker = "python_full_version >= '3.10'", specifier = ">=4" },
-    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "pandas", extras = ["output-formatting"], specifier = ">=2.1.2" },
     { name = "pandas", extras = ["output-formatting"], marker = "python_full_version >= '3.13'", specifier = ">=2.2.3" },
     { name = "pybind11", specifier = ">=2.13.6" },
@@ -1419,9 +1403,7 @@ dev = [
     { name = "qiskit", extras = ["qasm3-import"], specifier = ">=1.0.0" },
     { name = "qiskit", extras = ["qasm3-import", "visualization"], specifier = ">=1.0.0" },
     { name = "scikit-build-core", specifier = ">=0.10.7" },
-    { name = "scipy", marker = "python_full_version >= '3.13'", specifier = ">=1.14.1" },
     { name = "setuptools-scm", specifier = ">=8.1" },
-    { name = "sphinx", marker = "python_full_version >= '3.10'", specifier = ">=8" },
     { name = "sphinx-autoapi", specifier = ">=3.3.3" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
@@ -1431,16 +1413,10 @@ dev = [
 ]
 docs = [
     { name = "furo", specifier = ">=2024.8.6" },
-    { name = "ipython", marker = "python_full_version >= '3.10'", specifier = ">=8.29" },
     { name = "myst-nb", specifier = ">=1.1.2" },
-    { name = "myst-parser", marker = "python_full_version >= '3.10'", specifier = ">=4" },
-    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "pandas", extras = ["output-formatting"], specifier = ">=2.1.2" },
-    { name = "pandas", extras = ["output-formatting"], marker = "python_full_version >= '3.13'", specifier = ">=2.2.3" },
     { name = "qiskit", extras = ["qasm3-import", "visualization"], specifier = ">=1.0.0" },
-    { name = "scipy", marker = "python_full_version >= '3.13'", specifier = ">=1.14.1" },
     { name = "setuptools-scm", specifier = ">=8.1" },
-    { name = "sphinx", marker = "python_full_version >= '3.10'", specifier = ">=8" },
     { name = "sphinx-autoapi", specifier = ">=3.3.3" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
@@ -1449,14 +1425,12 @@ docs = [
     { name = "sphinxext-opengraph", specifier = ">=0.9.1" },
 ]
 test = [
-    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1" },
     { name = "pandas", extras = ["output-formatting"], specifier = ">=2.1.2" },
     { name = "pandas", extras = ["output-formatting"], marker = "python_full_version >= '3.13'", specifier = ">=2.2.3" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-console-scripts", specifier = ">=1.4.1" },
     { name = "pytest-cov", specifier = ">=6" },
     { name = "qiskit", extras = ["qasm3-import"], specifier = ">=1.0.0" },
-    { name = "scipy", marker = "python_full_version >= '3.13'", specifier = ">=1.14.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR slighlty simplifies the dependencies setup after the recent `uv` update which automatically picks newer versions for newer Python versions. This allows simplifying the configuration for some of our dependencies.
The pandas lower bound in the test dependencies cannot be dropped yet as `uv` still picks an old pandas version without wheels for Python 3.13 when resolving for minimum versions.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
