### PR TITLE
🚸 slightly tweak how optional qiskit dependency is handled

### DIFF
--- a/src/mqt/core/__init__.py
+++ b/src/mqt/core/__init__.py
@@ -35,8 +35,6 @@ def load(input_circuit: QuantumComputation | str | os.PathLike[str] | QuantumCir
         The :class:`~mqt.core.ir.QuantumComputation`.
 
     Raises:
-        ValueError: If the input circuit is a Qiskit :class:`~qiskit.circuit.QuantumCircuit`,
-                    but the `qiskit` extra is not installed.
         FileNotFoundError: If the input circuit is a file name and the file does not exist.
     """
     if isinstance(input_circuit, QuantumComputation):
@@ -54,11 +52,8 @@ def load(input_circuit: QuantumComputation | str | os.PathLike[str] | QuantumCir
 
         return QuantumComputation(input_str)
 
-    try:
-        from .plugins.qiskit import qiskit_to_mqt
-    except ImportError:
-        msg = "Qiskit is not installed. Please install `mqt.core[qiskit]` to use Qiskit circuits as input."
-        raise ValueError(msg) from None
+    # At this point, we know that the input is a Qiskit QuantumCircuit
+    from .plugins.qiskit import qiskit_to_mqt
 
     return qiskit_to_mqt(input_circuit)
 

--- a/src/mqt/core/plugins/qiskit.py
+++ b/src/mqt/core/plugins/qiskit.py
@@ -13,7 +13,7 @@ import re
 import warnings
 from typing import TYPE_CHECKING, cast
 
-from qiskit.circuit import AncillaQubit, AncillaRegister, Clbit, Instruction, ParameterExpression, Qubit
+from qiskit.circuit import AncillaQubit, AncillaRegister, Clbit, Qubit
 
 from ..ir import QuantumComputation
 from ..ir.operations import (
@@ -29,7 +29,7 @@ from ..ir.symbolic import Expression, Term, Variable
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
-    from qiskit.circuit import QuantumCircuit
+    from qiskit.circuit import Instruction, ParameterExpression, QuantumCircuit
 
 
 def qiskit_to_mqt(circ: QuantumCircuit) -> QuantumComputation:

--- a/test/python/test_load.py
+++ b/test/python/test_load.py
@@ -9,11 +9,7 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
-
-import pytest
-from qiskit import QuantumCircuit, qasm2
 
 from mqt.core import load
 from mqt.core.ir import QuantumComputation
@@ -92,11 +88,14 @@ def test_loading_nonexistent_file() -> None:
 
 def test_loading_qiskit_circuit() -> None:
     """Test whether importing a Qiskit circuit works."""
+    from qiskit import QuantumCircuit
+    from qiskit.qasm2 import dumps
+
     qiskit_circuit = QuantumCircuit(2, 2)
     qiskit_circuit.h(0)
     qiskit_circuit.cx(0, 1)
     qiskit_circuit.measure(range(2), range(2))
-    qasm = qasm2.dumps(qiskit_circuit)
+    qasm = dumps(qiskit_circuit)
 
     # load the circuit
     qc = load(qiskit_circuit)
@@ -108,14 +107,6 @@ def test_loading_qiskit_circuit() -> None:
 
     # remove any whitespace from both QASM strings and check for equality
     assert "".join(qasm.split()) in "".join(qc_qasm.split())
-
-
-def test_qiskit_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that trying to import a Qiskit circuit without the `qiskit` extra raises an error."""
-    monkeypatch.setitem(sys.modules, "mqt.core.plugins.qiskit", None)
-
-    with pytest.raises(ValueError, match="Qiskit is not installed"):
-        load(QuantumCircuit())
 
 
 def test_loading_qasm2_string() -> None:

--- a/test/python/test_qiskit.py
+++ b/test/python/test_qiskit.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 from typing import cast
 
 import pytest
-from qiskit import QuantumCircuit, transpile
-from qiskit.circuit import AncillaRegister, ClassicalRegister, Parameter, QuantumRegister
+from qiskit import transpile
+from qiskit.circuit import AncillaRegister, ClassicalRegister, Parameter, QuantumCircuit, QuantumRegister
 from qiskit.circuit.library import U2Gate, XXMinusYYGate, XXPlusYYGate
 from qiskit.providers.fake_provider import GenericBackendV2
 


### PR DESCRIPTION
## Description

This PR slightly adjusts how the optional qiskit dependency is handled in the `load` method.
At that point in the function, the user is passing in a Qiskit `QuantumCircuit` anyway, so Qiskit will naturally be available.

An observation I had while working on this:
We currently do not enforce a particular version constraint on qiskit at runtime.
Thus, someone might use a version of qiskit that is too old at runtime, and will probably run into errors.
We could probably do a better job of suggesting people to install the `mqt.core[qiskit]` extra to guarantee compatibility.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
