### PR TITLE
♻️ Refactor and improve register handling

### DIFF
--- a/docs/mqt_core_ir.md
+++ b/docs/mqt_core_ir.md
@@ -67,7 +67,7 @@ for i in range(precision):
 
   # Iterative inverse QFT
   for j in range(i):
-    qc.classic_controlled(op="p", target=0, creg=(j, 1), params=[-pi / 2**(i - j)])
+    qc.classic_controlled(op="p", target=0, cbit=j, params=[-pi / 2**(i - j)])
   qc.h(0)
 
   # Measure the result
@@ -292,7 +292,7 @@ qc = QuantumComputation(1, 1)
 qc.h(0)
 qc.measure(0, 0)
 
-classic_controlled = ClassicControlledOperation(operation=StandardOperation(target=0, op_type=OpType.x), control_register=(0, 1))
+classic_controlled = ClassicControlledOperation(operation=StandardOperation(target=0, op_type=OpType.x), control_bit=0)
 qc.append(classic_controlled)
 
 print(qc)

--- a/eval/eval_dd_package.cpp
+++ b/eval/eval_dd_package.cpp
@@ -100,7 +100,8 @@ benchmarkFunctionalityConstruction(const QuantumComputation& qc) {
 }
 
 std::unique_ptr<SimulationExperiment>
-benchmarkSimulateGrover(const qc::Qubit nq, const BitString& targetValue) {
+benchmarkSimulateGrover(const qc::Qubit nq,
+                        const GroverBitString& targetValue) {
   auto exp = std::make_unique<SimulationExperiment>();
   exp->dd = std::make_unique<Package<>>(nq + 1);
   auto& dd = *(exp->dd);
@@ -141,7 +142,7 @@ benchmarkSimulateGrover(const qc::Qubit nq, const BitString& targetValue) {
 
 std::unique_ptr<FunctionalityConstructionExperiment>
 benchmarkFunctionalityConstructionGrover(const qc::Qubit nq,
-                                         const BitString& targetValue) {
+                                         const GroverBitString& targetValue) {
   auto exp = std::make_unique<FunctionalityConstructionExperiment>();
   exp->dd = std::make_unique<Package<>>(nq + 1);
   auto& dd = *(exp->dd);
@@ -296,7 +297,7 @@ protected:
     constexpr std::array nqubits = {27U, 31U, 35U, 39U, 41U};
     std::cout << "Running Grover Simulation..." << '\n';
     for (const auto& nq : nqubits) {
-      BitString targetValue;
+      GroverBitString targetValue;
       targetValue.set();
       auto qc = createGrover(nq, targetValue);
       auto exp = benchmarkSimulateGrover(nq, targetValue);
@@ -305,7 +306,7 @@ protected:
 
     std::cout << "Running Grover Functionality..." << '\n';
     for (const auto& nq : nqubits) {
-      BitString targetValue;
+      GroverBitString targetValue;
       targetValue.set();
       auto qc = createGrover(nq, targetValue);
       auto exp = benchmarkFunctionalityConstructionGrover(nq, targetValue);

--- a/include/mqt-core/Definitions.hpp
+++ b/include/mqt-core/Definitions.hpp
@@ -54,8 +54,6 @@ using BitString = std::bitset<4096>;
 // floating-point type used throughout the library
 using fp = double;
 
-constexpr fp PARAMETER_TOLERANCE = 1e-13;
-
 static constexpr fp PI = static_cast<fp>(
     3.141592653589793238462643383279502884197169399375105820974L);
 static constexpr fp PI_2 = static_cast<fp>(

--- a/include/mqt-core/Definitions.hpp
+++ b/include/mqt-core/Definitions.hpp
@@ -12,8 +12,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <map>
-#include <memory>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -34,16 +32,6 @@ public:
 
 using Qubit = std::uint32_t;
 using Bit = std::uint64_t;
-
-template <class IdxType, class SizeType>
-using Register = std::pair<IdxType, SizeType>;
-using QuantumRegister = Register<Qubit, std::size_t>;
-using ClassicalRegister = Register<Bit, std::size_t>;
-template <class RegisterType>
-using RegisterMap = std::map<std::string, RegisterType, std::greater<>>;
-using QuantumRegisterMap = RegisterMap<QuantumRegister>;
-using ClassicalRegisterMap = RegisterMap<ClassicalRegister>;
-using RegisterNames = std::vector<std::pair<std::string, std::string>>;
 
 using Targets = std::vector<Qubit>;
 

--- a/include/mqt-core/Definitions.hpp
+++ b/include/mqt-core/Definitions.hpp
@@ -11,7 +11,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <deque>
 #include <functional>
 #include <map>
 #include <memory>
@@ -62,18 +61,8 @@ static constexpr fp TAU = static_cast<fp>(
 static constexpr fp E = static_cast<fp>(
     2.718281828459045235360287471352662497757247093699959574967L);
 
-// forward declaration
-class Operation;
-
 // supported file formats
 enum class Format : uint8_t { Real, OpenQASM2, OpenQASM3, TFC, QC, Tensor };
-
-using DAG = std::vector<std::deque<std::unique_ptr<Operation>*>>;
-using DAGIterator = std::deque<std::unique_ptr<Operation>*>::iterator;
-using DAGReverseIterator =
-    std::deque<std::unique_ptr<Operation>*>::reverse_iterator;
-using DAGIterators = std::vector<DAGIterator>;
-using DAGReverseIterators = std::vector<DAGReverseIterator>;
 
 /**
  * @brief 64bit mixing hash (from MurmurHash3)

--- a/include/mqt-core/Definitions.hpp
+++ b/include/mqt-core/Definitions.hpp
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <bitset>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
@@ -48,8 +47,6 @@ using ClassicalRegisterMap = RegisterMap<ClassicalRegister>;
 using RegisterNames = std::vector<std::pair<std::string, std::string>>;
 
 using Targets = std::vector<Qubit>;
-
-using BitString = std::bitset<4096>;
 
 // floating-point type used throughout the library
 using fp = double;

--- a/include/mqt-core/Definitions.hpp
+++ b/include/mqt-core/Definitions.hpp
@@ -62,8 +62,6 @@ static constexpr fp TAU = static_cast<fp>(
 static constexpr fp E = static_cast<fp>(
     2.718281828459045235360287471352662497757247093699959574967L);
 
-static constexpr size_t OUTPUT_INDENT_SIZE = 2;
-
 // forward declaration
 class Operation;
 

--- a/include/mqt-core/algorithms/BernsteinVazirani.hpp
+++ b/include/mqt-core/algorithms/BernsteinVazirani.hpp
@@ -12,24 +12,27 @@
 #include "Definitions.hpp"
 #include "ir/QuantumComputation.hpp"
 
+#include <bitset>
 #include <cstddef>
 
 namespace qc {
 
-[[nodiscard]] auto createBernsteinVazirani(const BitString& hiddenString)
+using BVBitString = std::bitset<4096>;
+
+[[nodiscard]] auto createBernsteinVazirani(const BVBitString& hiddenString)
     -> QuantumComputation;
 [[nodiscard]] auto createBernsteinVazirani(Qubit nq, std::size_t seed = 0)
     -> QuantumComputation;
-[[nodiscard]] auto createBernsteinVazirani(const BitString& hiddenString,
+[[nodiscard]] auto createBernsteinVazirani(const BVBitString& hiddenString,
                                            Qubit nq) -> QuantumComputation;
 
 [[nodiscard]] auto
-createIterativeBernsteinVazirani(const BitString& hiddenString)
+createIterativeBernsteinVazirani(const BVBitString& hiddenString)
     -> QuantumComputation;
 [[nodiscard]] auto createIterativeBernsteinVazirani(Qubit nq,
                                                     std::size_t seed = 0)
     -> QuantumComputation;
 [[nodiscard]] auto
-createIterativeBernsteinVazirani(const BitString& hiddenString, Qubit nq)
+createIterativeBernsteinVazirani(const BVBitString& hiddenString, Qubit nq)
     -> QuantumComputation;
 } // namespace qc

--- a/include/mqt-core/algorithms/Grover.hpp
+++ b/include/mqt-core/algorithms/Grover.hpp
@@ -12,17 +12,20 @@
 #include "Definitions.hpp"
 #include "ir/QuantumComputation.hpp"
 
+#include <bitset>
 #include <cstddef>
 
 namespace qc {
+
+using GroverBitString = std::bitset<128>;
 auto appendGroverInitialization(QuantumComputation& qc) -> void;
-auto appendGroverOracle(QuantumComputation& qc, const BitString& targetValue)
-    -> void;
+auto appendGroverOracle(QuantumComputation& qc,
+                        const GroverBitString& targetValue) -> void;
 auto appendGroverDiffusion(QuantumComputation& qc) -> void;
 
 [[nodiscard]] auto computeNumberOfIterations(Qubit nq) -> std::size_t;
 
-[[nodiscard]] auto createGrover(Qubit nq, const BitString& targetValue)
+[[nodiscard]] auto createGrover(Qubit nq, const GroverBitString& targetValue)
     -> QuantumComputation;
 [[nodiscard]] auto createGrover(Qubit nq, std::size_t seed = 0)
     -> QuantumComputation;

--- a/include/mqt-core/circuit_optimizer/CircuitOptimizer.hpp
+++ b/include/mqt-core/circuit_optimizer/CircuitOptimizer.hpp
@@ -12,15 +12,26 @@
 #include "Definitions.hpp"
 #include "ir/QuantumComputation.hpp"
 #include "ir/operations/OpType.hpp"
+#include "ir/operations/Operation.hpp"
 
 #include <cstddef>
+#include <deque>
+#include <memory>
 #include <unordered_set>
+#include <vector>
 
 namespace qc {
 
 class CircuitOptimizer {
 public:
   CircuitOptimizer() = default;
+
+  using DAG = std::vector<std::deque<std::unique_ptr<Operation>*>>;
+  using DAGIterator = std::deque<std::unique_ptr<Operation>*>::iterator;
+  using DAGReverseIterator =
+      std::deque<std::unique_ptr<Operation>*>::reverse_iterator;
+  using DAGIterators = std::vector<DAGIterator>;
+  using DAGReverseIterators = std::vector<DAGReverseIterator>;
 
   static DAG constructDAG(QuantumComputation& qc);
   static void printDAG(const DAG& dag);

--- a/include/mqt-core/circuit_optimizer/CircuitOptimizer.hpp
+++ b/include/mqt-core/circuit_optimizer/CircuitOptimizer.hpp
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include "Definitions.hpp"
 #include "ir/QuantumComputation.hpp"
 #include "ir/operations/OpType.hpp"
 #include "ir/operations/Operation.hpp"

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -17,6 +17,7 @@
 #include "operations/Control.hpp"
 #include "operations/Expression.hpp"
 #include "operations/OpType.hpp"
+#include "operations/Operation.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -52,9 +53,9 @@ protected:
   std::size_t nancillae = 0;
   std::string name;
 
-  QuantumRegisterMap quantumRegisters{};
-  ClassicalRegisterMap classicalRegisters{};
-  QuantumRegisterMap ancillaRegisters{};
+  QuantumRegisterMap quantumRegisters;
+  ClassicalRegisterMap classicalRegisters;
+  QuantumRegisterMap ancillaRegisters;
 
   std::vector<bool> ancillary;
   std::vector<bool> garbage;

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -11,6 +11,7 @@
 
 #include "Definitions.hpp"
 #include "Permutation.hpp"
+#include "Register.hpp"
 #include "operations/ClassicControlledOperation.hpp"
 #include "operations/CompoundOperation.hpp"
 #include "operations/Control.hpp"
@@ -25,11 +26,15 @@
 #include <optional>
 #include <random>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
 namespace qc {
+using QuantumRegisterMap = std::unordered_map<std::string, QuantumRegister>;
+using ClassicalRegisterMap = std::unordered_map<std::string, ClassicalRegister>;
+
 class QuantumComputation {
 public:
   using iterator = std::vector<std::unique_ptr<Operation>>::iterator;
@@ -47,11 +52,9 @@ protected:
   std::size_t nancillae = 0;
   std::string name;
 
-  // register names are used as keys, while the values are `{startIndex,
-  // length}` pairs
-  QuantumRegisterMap qregs;
-  ClassicalRegisterMap cregs;
-  QuantumRegisterMap ancregs;
+  QuantumRegisterMap quantumRegisters{};
+  ClassicalRegisterMap classicalRegisters{};
+  QuantumRegisterMap ancillaRegisters{};
 
   std::vector<bool> ancillary;
   std::vector<bool> garbage;
@@ -115,14 +118,14 @@ public:
   }
   [[nodiscard]] std::size_t getNcbits() const noexcept { return nclassics; }
   [[nodiscard]] std::string getName() const noexcept { return name; }
-  [[nodiscard]] const QuantumRegisterMap& getQregs() const noexcept {
-    return qregs;
+  [[nodiscard]] const auto& getQuantumRegisters() const noexcept {
+    return quantumRegisters;
   }
-  [[nodiscard]] const ClassicalRegisterMap& getCregs() const noexcept {
-    return cregs;
+  [[nodiscard]] const auto& getClassicalRegisters() const noexcept {
+    return classicalRegisters;
   }
-  [[nodiscard]] const QuantumRegisterMap& getANCregs() const noexcept {
-    return ancregs;
+  [[nodiscard]] const auto& getAncillaRegisters() const noexcept {
+    return ancillaRegisters;
   }
   [[nodiscard]] decltype(mt)& getGenerator() noexcept { return mt; }
 
@@ -142,16 +145,11 @@ public:
   [[nodiscard]] std::size_t getNsingleQubitOps() const;
   [[nodiscard]] std::size_t getDepth() const;
 
-  [[nodiscard]] std::string getQubitRegister(Qubit physicalQubitIndex) const;
-  [[nodiscard]] std::string getClassicalRegister(Bit classicalIndex) const;
+  [[nodiscard]] QuantumRegister& getQubitRegister(Qubit physicalQubitIndex);
   /// Returns the highest qubit index used as a value in the initial layout
   [[nodiscard]] Qubit getHighestLogicalQubitIndex() const;
   /// Returns the highest qubit index used as a key in the initial layout
   [[nodiscard]] Qubit getHighestPhysicalQubitIndex() const;
-  [[nodiscard]] std::pair<std::string, Qubit>
-  getQubitRegisterAndIndex(Qubit physicalQubitIndex) const;
-  [[nodiscard]] std::pair<std::string, Bit>
-  getClassicalRegisterAndIndex(Bit classicalIndex) const;
   /**
    * @brief Returns the physical qubit index of the given logical qubit index
    * @details Iterates over the initial layout dictionary and returns the key
@@ -160,11 +158,6 @@ public:
    * @return The physical qubit index of the given logical qubit index
    */
   [[nodiscard]] Qubit getPhysicalQubitIndex(Qubit logicalQubitIndex);
-
-  [[nodiscard]] Qubit
-  getIndexFromQubitRegister(const std::pair<std::string, Qubit>& qubit) const;
-  [[nodiscard]] Bit getIndexFromClassicalRegister(
-      const std::pair<std::string, std::size_t>& clbit) const;
   [[nodiscard]] bool isIdleQubit(Qubit physicalQubit) const;
   [[nodiscard]] bool isLastOperationOnQubit(const const_iterator& opIt,
                                             const const_iterator& end) const;
@@ -327,7 +320,6 @@ public:
 #undef DECLARE_TWO_TARGET_TWO_PARAMETER_OPERATION
 
   void measure(Qubit qubit, std::size_t bit);
-  void measure(Qubit qubit, const std::pair<std::string, Bit>& registerBit);
   void measure(const Targets& qubits, const std::vector<Bit>& bits);
 
   /**
@@ -361,6 +353,18 @@ public:
                          std::uint64_t expectedValue = 1U,
                          ComparisonKind cmp = Eq,
                          const std::vector<fp>& params = {});
+  void classicControlled(OpType op, Qubit target, Bit cBit,
+                         std::uint64_t expectedValue = 1U,
+                         ComparisonKind cmp = Eq,
+                         const std::vector<fp>& params = {});
+  void classicControlled(OpType op, Qubit target, Control control, Bit cBit,
+                         std::uint64_t expectedValue = 1U,
+                         ComparisonKind cmp = Eq,
+                         const std::vector<fp>& params = {});
+  void classicControlled(OpType op, Qubit target, const Controls& controls,
+                         Bit cBit, std::uint64_t expectedValue = 1U,
+                         ComparisonKind cmp = Eq,
+                         const std::vector<fp>& params = {});
 
   /// strip away qubits with no operations applied to them and which do not pop
   /// up in the output permutation \param force if true, also strip away idle
@@ -378,16 +382,20 @@ public:
 
   // this function augments a given circuit by additional registers
   void addQubitRegister(std::size_t nq, const std::string& regName = "q");
-  void addClassicalRegister(std::size_t nc, const std::string& regName = "c");
+  const ClassicalRegister&
+  addClassicalRegister(std::size_t nc, const std::string& regName = "c");
   void addAncillaryRegister(std::size_t nq, const std::string& regName = "anc");
   // a function to combine all quantum registers (qregs and ancregs) into a
   // single register (useful for circuits mapped to a device)
   void unifyQuantumRegisters(const std::string& regName = "q");
 
-  // removes a specific logical qubit and returns the index of the physical
-  // qubit in the initial layout as well as the index of the removed physical
-  // qubit's output permutation i.e., initialLayout[physical_qubit] =
-  // logical_qubit and outputPermutation[physicalQubit] = output_qubit
+  /**
+   * @brief Removes a logical qubit
+   * @param logicalQubitIndex The qubit to remove
+   * @return The physical qubit index that the logical qubit was mapped to in
+   * the initial layout and the output qubit index that the logical qubit was
+   * mapped to in the output permutation.
+   */
   std::pair<Qubit, std::optional<Qubit>> removeQubit(Qubit logicalQubitIndex);
 
   // adds physical qubit as ancillary qubit and gives it the appropriate output
@@ -436,8 +444,6 @@ public:
   }
 
   std::ostream& printStatistics(std::ostream& os) const;
-
-  std::ostream& printRegisters(std::ostream& os = std::cout) const;
 
   static std::ostream& printPermutation(const Permutation& permutation,
                                         std::ostream& os = std::cout);

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -369,7 +369,7 @@ public:
   /// strip away qubits with no operations applied to them and which do not pop
   /// up in the output permutation \param force if true, also strip away idle
   /// qubits occurring in the output permutation
-  void stripIdleQubits(bool force = false, bool reduceIOpermutations = true);
+  void stripIdleQubits(bool force = false);
 
   void import(const std::string& filename);
   void import(const std::string& filename, Format format);

--- a/include/mqt-core/ir/Register.hpp
+++ b/include/mqt-core/ir/Register.hpp
@@ -12,7 +12,8 @@
 #include "Definitions.hpp"
 
 #include <cstddef>
-#include <memory>
+#include <functional>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/include/mqt-core/ir/Register.hpp
+++ b/include/mqt-core/ir/Register.hpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025 Chair for Design Automation, TUM
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#pragma once
+
+#include "Definitions.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace qc {
+
+template <typename BitType> class Register {
+public:
+  Register(const BitType regStartIndex, const std::size_t regSize,
+           std::string regName)
+      : startIndex(regStartIndex), size(regSize), name(std::move(regName)) {}
+  virtual ~Register() = default;
+
+  [[nodiscard]] const std::string& getName() const noexcept { return name; }
+  [[nodiscard]] std::size_t getSize() const noexcept { return size; }
+  [[nodiscard]] std::size_t& getSize() noexcept { return size; }
+  [[nodiscard]] BitType getStartIndex() const noexcept { return startIndex; }
+  [[nodiscard]] BitType& getStartIndex() noexcept { return startIndex; }
+  [[nodiscard]] BitType getEndIndex() const noexcept {
+    return static_cast<BitType>(startIndex + size - 1);
+  }
+
+  [[nodiscard]] bool operator==(const Register& other) const {
+    return name == other.name && size == other.size;
+  }
+  [[nodiscard]] bool operator!=(const Register& other) const {
+    return !(*this == other);
+  }
+
+  [[nodiscard]] bool contains(const BitType index) const {
+    return startIndex <= index && index < startIndex + size;
+  }
+
+  [[nodiscard]] BitType getLocalIndex(const BitType globalIndex) const {
+    if (!contains(globalIndex)) {
+      throw std::out_of_range("Index out of range");
+    }
+    return globalIndex - startIndex;
+  }
+
+  [[nodiscard]] std::string toString(const BitType globalIndex) const {
+    return name + "[" + std::to_string(getLocalIndex(globalIndex)) + "]";
+  }
+
+private:
+  BitType startIndex;
+  std::size_t size;
+  std::string name;
+};
+
+class QuantumRegister final : public Register<Qubit> {
+public:
+  QuantumRegister(const Qubit regStartIndex, const std::size_t regSize,
+                  const std::string& regName = "")
+      : Register(regStartIndex, regSize,
+                 regName.empty() ? generateName() : regName) {}
+
+protected:
+  static std::string generateName() {
+    static std::size_t counter = 0;
+    return "q" + std::to_string(counter++);
+  }
+};
+
+using QubitIndexToRegisterMap =
+    std::unordered_map<Qubit, std::pair<const QuantumRegister&, std::string>>;
+
+class ClassicalRegister final : public Register<Bit> {
+public:
+  ClassicalRegister(const Bit regStartIndex, const std::size_t regSize,
+                    const std::string& regName = "")
+      : Register(regStartIndex, regSize,
+                 regName.empty() ? generateName() : regName) {}
+
+protected:
+  static std::string generateName() {
+    static std::size_t counter = 0;
+    return "c" + std::to_string(counter++);
+  }
+};
+
+using BitIndexToRegisterMap =
+    std::unordered_map<Bit, std::pair<const ClassicalRegister&, std::string>>;
+
+} // namespace qc
+
+template <> struct std::hash<qc::QuantumRegister> {
+  std::size_t operator()(const qc::QuantumRegister& reg) const noexcept {
+    return qc::combineHash(reg.getStartIndex(), reg.getSize());
+  }
+};
+
+template <> struct std::hash<qc::ClassicalRegister> {
+  std::size_t operator()(const qc::ClassicalRegister& reg) const noexcept {
+    return qc::combineHash(reg.getStartIndex(), reg.getSize());
+  }
+};

--- a/include/mqt-core/ir/operations/AodOperation.hpp
+++ b/include/mqt-core/ir/operations/AodOperation.hpp
@@ -13,6 +13,7 @@
 #include "Definitions.hpp"
 #include "OpType.hpp"
 #include "Operation.hpp"
+#include "ir/Register.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -80,8 +81,9 @@ public:
 
   [[nodiscard]] std::vector<qc::fp> getDistances(Dimension dir) const;
 
-  void dumpOpenQASM(std::ostream& of, const qc::RegisterNames& qreg,
-                    const qc::RegisterNames& creg, size_t indent,
+  void dumpOpenQASM(std::ostream& of,
+                    const qc::QubitIndexToRegisterMap& qubitMap,
+                    const qc::BitIndexToRegisterMap& bitMap, std::size_t indent,
                     bool openQASM3) const override;
 
   void invert() override;

--- a/include/mqt-core/ir/operations/ClassicControlledOperation.hpp
+++ b/include/mqt-core/ir/operations/ClassicControlledOperation.hpp
@@ -22,7 +22,6 @@
 #include <optional>
 #include <ostream>
 #include <string>
-#include <utility>
 
 namespace qc {
 
@@ -143,12 +142,13 @@ template <> struct std::hash<qc::ClassicControlledOperation> {
     auto seed =
         qc::combineHash(std::hash<qc::Operation>{}(*ccop.getOperation()),
                         ccop.getExpectedValue());
-    if (ccop.getControlRegister().has_value()) {
-      qc::hashCombine(seed, std::hash<qc::ClassicalRegister>{}(
-                                ccop.getControlRegister().value()));
+    if (const auto& controlRegister = ccop.getControlRegister();
+        controlRegister.has_value()) {
+      qc::hashCombine(
+          seed, std::hash<qc::ClassicalRegister>{}(controlRegister.value()));
     }
-    if (ccop.getControlBit().has_value()) {
-      qc::hashCombine(seed, ccop.getControlBit().value());
+    if (const auto& controlBit = ccop.getControlBit(); controlBit.has_value()) {
+      qc::hashCombine(seed, controlBit.value());
     }
     return seed;
   }

--- a/include/mqt-core/ir/operations/ClassicControlledOperation.hpp
+++ b/include/mqt-core/ir/operations/ClassicControlledOperation.hpp
@@ -13,6 +13,7 @@
 #include "Definitions.hpp"
 #include "Operation.hpp"
 #include "ir/Permutation.hpp"
+#include "ir/Register.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -115,8 +116,8 @@ public:
     return equals(operation, {}, {});
   }
 
-  void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
-                    const RegisterNames& creg, std::size_t indent,
+  void dumpOpenQASM(std::ostream& of, const QubitIndexToRegisterMap& qubitMap,
+                    const BitIndexToRegisterMap& bitMap, std::size_t indent,
                     bool openQASM3) const override;
 
   void invert() override { op->invert(); }

--- a/include/mqt-core/ir/operations/CompoundOperation.hpp
+++ b/include/mqt-core/ir/operations/CompoundOperation.hpp
@@ -13,6 +13,7 @@
 #include "Definitions.hpp"
 #include "Operation.hpp"
 #include "ir/Permutation.hpp"
+#include "ir/Register.hpp"
 
 #include <cstddef>
 #include <functional>
@@ -74,8 +75,8 @@ public:
 
   void addDepthContribution(std::vector<std::size_t>& depths) const override;
 
-  void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
-                    const RegisterNames& creg, size_t indent,
+  void dumpOpenQASM(std::ostream& of, const QubitIndexToRegisterMap& qubitMap,
+                    const BitIndexToRegisterMap& bitMap, std::size_t indent,
                     bool openQASM3) const override;
 
   std::vector<std::unique_ptr<Operation>>& getOps() noexcept { return ops; }

--- a/include/mqt-core/ir/operations/NonUnitaryOperation.hpp
+++ b/include/mqt-core/ir/operations/NonUnitaryOperation.hpp
@@ -14,6 +14,7 @@
 #include "OpType.hpp"
 #include "Operation.hpp"
 #include "ir/Permutation.hpp"
+#include "ir/Register.hpp"
 
 #include <cstddef>
 #include <functional>
@@ -74,8 +75,8 @@ public:
                       std::size_t prefixWidth,
                       std::size_t nqubits) const override;
 
-  void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
-                    const RegisterNames& creg, size_t indent,
+  void dumpOpenQASM(std::ostream& of, const QubitIndexToRegisterMap& qubitMap,
+                    const BitIndexToRegisterMap& bitMap, std::size_t indent,
                     bool openQASM3) const override;
 
   void invert() override {

--- a/include/mqt-core/ir/operations/Operation.hpp
+++ b/include/mqt-core/ir/operations/Operation.hpp
@@ -34,6 +34,8 @@ protected:
   OpType type = None;
   std::string name;
 
+  static constexpr size_t OUTPUT_INDENT_SIZE = 2;
+
   static bool isWholeQubitRegister(const RegisterNames& reg, std::size_t start,
                                    std::size_t end) {
     return !reg.empty() && reg[start].first == reg[end].first &&

--- a/include/mqt-core/ir/operations/Operation.hpp
+++ b/include/mqt-core/ir/operations/Operation.hpp
@@ -13,6 +13,7 @@
 #include "Definitions.hpp"
 #include "OpType.hpp"
 #include "ir/Permutation.hpp"
+#include "ir/Register.hpp"
 
 #include <algorithm>
 #include <array>
@@ -36,11 +37,12 @@ protected:
 
   static constexpr size_t OUTPUT_INDENT_SIZE = 2;
 
-  static bool isWholeQubitRegister(const RegisterNames& reg, std::size_t start,
-                                   std::size_t end) {
-    return !reg.empty() && reg[start].first == reg[end].first &&
-           (start == 0 || reg[start].first != reg[start - 1].first) &&
-           (end == reg.size() - 1 || reg[end].first != reg[end + 1].first);
+  static bool isWholeQubitRegister(const QubitIndexToRegisterMap& regMap,
+                                   const Qubit start, const Qubit end) {
+    const auto& startReg = regMap.at(start).first;
+    const auto& endReg = regMap.at(end).first;
+    return startReg == endReg && startReg.getStartIndex() == start &&
+           endReg.getEndIndex() == end;
   }
 
 public:
@@ -180,16 +182,17 @@ public:
                               std::size_t prefixWidth,
                               std::size_t nqubits) const;
 
-  void dumpOpenQASM2(std::ostream& of, const RegisterNames& qreg,
-                     const RegisterNames& creg) const {
-    dumpOpenQASM(of, qreg, creg, 0, false);
+  void dumpOpenQASM2(std::ostream& of, const QubitIndexToRegisterMap& qubitMap,
+                     const BitIndexToRegisterMap& bitMap) const {
+    dumpOpenQASM(of, qubitMap, bitMap, 0, false);
   }
-  void dumpOpenQASM3(std::ostream& of, const RegisterNames& qreg,
-                     const RegisterNames& creg) const {
-    dumpOpenQASM(of, qreg, creg, 0, true);
+  void dumpOpenQASM3(std::ostream& of, const QubitIndexToRegisterMap& qubitMap,
+                     const BitIndexToRegisterMap& bitMap) const {
+    dumpOpenQASM(of, qubitMap, bitMap, 0, true);
   }
-  virtual void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
-                            const RegisterNames& creg, size_t indent,
+  virtual void dumpOpenQASM(std::ostream& of,
+                            const QubitIndexToRegisterMap& qubitMap,
+                            const BitIndexToRegisterMap& bitMap, size_t indent,
                             bool openQASM3) const = 0;
 
   /// Checks whether operation commutes with other operation on a given qubit.

--- a/include/mqt-core/ir/operations/StandardOperation.hpp
+++ b/include/mqt-core/ir/operations/StandardOperation.hpp
@@ -26,6 +26,8 @@
 namespace qc {
 class StandardOperation : public Operation {
 protected:
+  constexpr static fp PARAMETER_TOLERANCE = 1e-13;
+
   static void checkInteger(fp& ld) {
     const fp nearest = std::nearbyint(ld);
     if (std::abs(ld - nearest) < PARAMETER_TOLERANCE) {

--- a/include/mqt-core/ir/operations/StandardOperation.hpp
+++ b/include/mqt-core/ir/operations/StandardOperation.hpp
@@ -14,6 +14,7 @@
 #include "OpType.hpp"
 #include "Operation.hpp"
 #include "ir/Permutation.hpp"
+#include "ir/Register.hpp"
 
 #include <cmath>
 #include <cstddef>
@@ -51,7 +52,7 @@ protected:
   void setup();
 
   void dumpOpenQASMTeleportation(std::ostream& of,
-                                 const RegisterNames& qreg) const;
+                                 const QubitIndexToRegisterMap& qreg) const;
 
 public:
   StandardOperation() = default;
@@ -112,8 +113,8 @@ public:
     return equals(operation, {}, {});
   }
 
-  void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
-                    const RegisterNames& creg, std::size_t indent,
+  void dumpOpenQASM(std::ostream& of, const QubitIndexToRegisterMap& qubitMap,
+                    const BitIndexToRegisterMap& bitMap, size_t indent,
                     bool openQASM3) const override;
 
   [[nodiscard]] auto commutesAtQubit(const Operation& other,
@@ -123,12 +124,12 @@ public:
 
 protected:
   void dumpOpenQASM2(std::ostream& of, std::ostringstream& op,
-                     const RegisterNames& qreg) const;
+                     const QubitIndexToRegisterMap& qubitMap) const;
   void dumpOpenQASM3(std::ostream& of, std::ostringstream& op,
-                     const RegisterNames& qreg) const;
+                     const QubitIndexToRegisterMap& qubitMap) const;
 
   void dumpGateType(std::ostream& of, std::ostringstream& op,
-                    const RegisterNames& qreg) const;
+                    const QubitIndexToRegisterMap& qubitMap) const;
 
   void dumpControls(std::ostringstream& op) const;
 };

--- a/include/mqt-core/ir/operations/SymbolicOperation.hpp
+++ b/include/mqt-core/ir/operations/SymbolicOperation.hpp
@@ -13,6 +13,7 @@
 #include "Definitions.hpp"
 #include "Expression.hpp"
 #include "OpType.hpp"
+#include "Operation.hpp"
 #include "StandardOperation.hpp"
 #include "ir/Permutation.hpp"
 #include "ir/Register.hpp"

--- a/include/mqt-core/ir/operations/SymbolicOperation.hpp
+++ b/include/mqt-core/ir/operations/SymbolicOperation.hpp
@@ -15,6 +15,7 @@
 #include "OpType.hpp"
 #include "StandardOperation.hpp"
 #include "ir/Permutation.hpp"
+#include "ir/Register.hpp"
 
 #include <cstddef>
 #include <functional>
@@ -70,8 +71,10 @@ public:
     return equals(op, {}, {});
   }
 
-  [[noreturn]] void dumpOpenQASM(std::ostream& of, const RegisterNames& qreg,
-                                 const RegisterNames& creg, size_t indent,
+  [[noreturn]] void dumpOpenQASM(std::ostream& of,
+                                 const QubitIndexToRegisterMap& qubitMap,
+                                 const BitIndexToRegisterMap& bitMap,
+                                 std::size_t indent,
                                  bool openQASM3) const override;
 
   [[nodiscard]] StandardOperation

--- a/src/algorithms/BernsteinVazirani.cpp
+++ b/src/algorithms/BernsteinVazirani.cpp
@@ -19,7 +19,7 @@
 
 namespace qc {
 
-[[nodiscard]] auto getMostSignificantBit(const BitString& s) -> std::size_t {
+[[nodiscard]] auto getMostSignificantBit(const BVBitString& s) -> std::size_t {
   std::size_t msb = 0;
   for (std::size_t i = 0; i < s.size(); ++i) {
     if (s.test(i)) {
@@ -30,8 +30,8 @@ namespace qc {
 }
 
 [[nodiscard]] auto generateBitstring(const std::size_t nq, std::mt19937_64& mt)
-    -> BitString {
-  BitString s;
+    -> BVBitString {
+  BVBitString s;
   auto distribution = std::bernoulli_distribution();
   for (std::size_t i = 0; i < nq; ++i) {
     if (distribution(mt)) {
@@ -41,7 +41,7 @@ namespace qc {
   return s;
 }
 
-[[nodiscard]] auto getExpected(const BitString& s, const Qubit nq)
+[[nodiscard]] auto getExpected(const BVBitString& s, const Qubit nq)
     -> std::string {
   auto expected = s.to_string();
   std::reverse(expected.begin(), expected.end());
@@ -53,7 +53,7 @@ namespace qc {
 }
 
 auto constructBernsteinVaziraniCircuit(QuantumComputation& qc,
-                                       const BitString& s, const Qubit nq) {
+                                       const BVBitString& s, const Qubit nq) {
   qc.setName("bv_" + getExpected(s, nq));
   qc.addQubitRegister(1, "flag");
   qc.addQubitRegister(nq, "q");
@@ -94,7 +94,7 @@ auto constructBernsteinVaziraniCircuit(QuantumComputation& qc,
   }
 }
 
-auto createBernsteinVazirani(const BitString& hiddenString)
+auto createBernsteinVazirani(const BVBitString& hiddenString)
     -> QuantumComputation {
   const auto msb = static_cast<Qubit>(getMostSignificantBit(hiddenString));
   return createBernsteinVazirani(hiddenString, msb + 1);
@@ -108,7 +108,7 @@ auto createBernsteinVazirani(const Qubit nq, const std::size_t seed)
   return qc;
 }
 
-auto createBernsteinVazirani(const BitString& hiddenString, const Qubit nq)
+auto createBernsteinVazirani(const BVBitString& hiddenString, const Qubit nq)
     -> QuantumComputation {
   auto qc = QuantumComputation(0, 0);
   constructBernsteinVaziraniCircuit(qc, hiddenString, nq);
@@ -116,7 +116,7 @@ auto createBernsteinVazirani(const BitString& hiddenString, const Qubit nq)
 }
 
 auto constructIterativeBernsteinVaziraniCircuit(QuantumComputation& qc,
-                                                const BitString& s,
+                                                const BVBitString& s,
                                                 const Qubit nq) {
   qc.setName("iterative_bv_" + getExpected(s, nq));
   qc.addQubitRegister(1, "flag");
@@ -156,7 +156,7 @@ auto constructIterativeBernsteinVaziraniCircuit(QuantumComputation& qc,
   return qc;
 }
 
-auto createIterativeBernsteinVazirani(const BitString& hiddenString)
+auto createIterativeBernsteinVazirani(const BVBitString& hiddenString)
     -> QuantumComputation {
   const auto msb = static_cast<Qubit>(getMostSignificantBit(hiddenString));
   return createIterativeBernsteinVazirani(hiddenString, msb + 1);
@@ -170,7 +170,7 @@ auto createIterativeBernsteinVazirani(const Qubit nq, const std::size_t seed)
   return qc;
 }
 
-auto createIterativeBernsteinVazirani(const BitString& hiddenString,
+auto createIterativeBernsteinVazirani(const BVBitString& hiddenString,
                                       const Qubit nq) -> QuantumComputation {
   auto qc = QuantumComputation(0, 0);
   constructIterativeBernsteinVaziraniCircuit(qc, hiddenString, nq);

--- a/src/algorithms/Grover.cpp
+++ b/src/algorithms/Grover.cpp
@@ -29,8 +29,8 @@ auto appendGroverInitialization(QuantumComputation& qc) -> void {
   }
 }
 
-auto appendGroverOracle(QuantumComputation& qc, const BitString& targetValue)
-    -> void {
+auto appendGroverOracle(QuantumComputation& qc,
+                        const GroverBitString& targetValue) -> void {
   const auto nDataQubits = static_cast<Qubit>(qc.getNqubits() - 1);
   Controls controls{};
   for (std::size_t i = 0; i < nDataQubits; ++i) {
@@ -77,8 +77,8 @@ auto computeNumberOfIterations(const Qubit nq) -> std::size_t {
 }
 
 [[nodiscard]] auto generateTargetValue(const std::size_t nDataQubits,
-                                       std::mt19937_64& mt) -> BitString {
-  BitString targetValue;
+                                       std::mt19937_64& mt) -> GroverBitString {
+  GroverBitString targetValue;
   std::bernoulli_distribution distribution{};
   for (std::size_t i = 0; i < nDataQubits; i++) {
     if (distribution(mt)) {
@@ -88,7 +88,7 @@ auto computeNumberOfIterations(const Qubit nq) -> std::size_t {
   return targetValue;
 }
 
-[[nodiscard]] auto getGroverName(const BitString& s, const Qubit nq)
+[[nodiscard]] auto getGroverName(const GroverBitString& s, const Qubit nq)
     -> std::string {
   auto expected = s.to_string();
   std::reverse(expected.begin(), expected.end());
@@ -100,7 +100,7 @@ auto computeNumberOfIterations(const Qubit nq) -> std::size_t {
 }
 
 auto constructGroverCircuit(QuantumComputation& qc, const Qubit nq,
-                            const BitString& targetValue) {
+                            const GroverBitString& targetValue) {
   qc.setName(getGroverName(targetValue, nq));
   qc.addQubitRegister(nq, "q");
   qc.addQubitRegister(1, "flag");
@@ -130,7 +130,7 @@ auto createGrover(const Qubit nq, const std::size_t seed)
   return qc;
 }
 
-auto createGrover(const Qubit nq, const BitString& targetValue)
+auto createGrover(const Qubit nq, const GroverBitString& targetValue)
     -> QuantumComputation {
   auto qc = QuantumComputation();
   constructGroverCircuit(qc, nq, targetValue);

--- a/src/algorithms/QFT.cpp
+++ b/src/algorithms/QFT.cpp
@@ -78,13 +78,13 @@ auto createIterativeQFT(const Qubit nq) -> QuantumComputation {
     for (Qubit j = 1; j <= i; ++j) {
       const auto d = nq - j;
       if (j == i) {
-        qc.classicControlled(S, 0, {d, 1U}, 1U);
+        qc.classicControlled(S, 0, d, 1U);
       } else if (j == i - 1) {
-        qc.classicControlled(T, 0, {d, 1U}, 1U);
+        qc.classicControlled(T, 0, d, 1U);
       } else {
         const auto powerOfTwo = std::pow(2., i - j + 1);
         const auto lambda = PI / powerOfTwo;
-        qc.classicControlled(P, 0, {d, 1U}, 1U, Eq, {lambda});
+        qc.classicControlled(P, 0, d, 1U, Eq, {lambda});
       }
     }
 

--- a/src/algorithms/QPE.cpp
+++ b/src/algorithms/QPE.cpp
@@ -173,7 +173,7 @@ auto constructIterativeQPECircuit(QuantumComputation& qc, const fp lambda,
     // hybrid quantum-classical inverse QFT
     for (std::size_t j = 0; j < i; j++) {
       auto iQFTLambda = -PI / static_cast<double>(1ULL << (i - j));
-      qc.classicControlled(P, 1, {j, 1U}, 1U, Eq, {iQFTLambda});
+      qc.classicControlled(P, 1, j, 1U, Eq, {iQFTLambda});
     }
     qc.h(1);
 

--- a/src/circuit_optimizer/CircuitOptimizer.cpp
+++ b/src/circuit_optimizer/CircuitOptimizer.cpp
@@ -14,6 +14,7 @@
 #include "ir/operations/CompoundOperation.hpp"
 #include "ir/operations/NonUnitaryOperation.hpp"
 #include "ir/operations/OpType.hpp"
+#include "ir/operations/Operation.hpp"
 #include "ir/operations/StandardOperation.hpp"
 
 #include <algorithm>

--- a/src/circuit_optimizer/CircuitOptimizer.cpp
+++ b/src/circuit_optimizer/CircuitOptimizer.cpp
@@ -35,7 +35,7 @@
 #include <vector>
 
 namespace qc {
-void addToDag(DAG& dag, std::unique_ptr<Operation>* op) {
+void addToDag(CircuitOptimizer::DAG& dag, std::unique_ptr<Operation>* op) {
   const auto usedQubits = (*op)->getUsedQubits();
   for (const auto q : usedQubits) {
     dag.at(q).push_back(op);
@@ -164,7 +164,7 @@ void CircuitOptimizer::swapReconstruction(QuantumComputation& qc) {
   removeIdentities(qc);
 }
 
-DAG CircuitOptimizer::constructDAG(QuantumComputation& qc) {
+CircuitOptimizer::DAG CircuitOptimizer::constructDAG(QuantumComputation& qc) {
   auto dag = DAG(qc.getHighestPhysicalQubitIndex() + 1);
 
   for (auto& op : qc) {
@@ -270,12 +270,15 @@ void CircuitOptimizer::singleQubitGateFusion(QuantumComputation& qc) {
   removeIdentities(qc);
 }
 
-bool removeDiagonalGate(DAG& dag, DAGReverseIterators& dagIterators, Qubit idx,
-                        DAGReverseIterator& it, qc::Operation* op);
+bool removeDiagonalGate(CircuitOptimizer::DAG& dag,
+                        CircuitOptimizer::DAGReverseIterators& dagIterators,
+                        Qubit idx, CircuitOptimizer::DAGReverseIterator& it,
+                        Operation* op);
 
 void removeDiagonalGatesBeforeMeasureRecursive(
-    DAG& dag, DAGReverseIterators& dagIterators, Qubit idx,
-    const qc::Operation* until) {
+    CircuitOptimizer::DAG& dag,
+    CircuitOptimizer::DAGReverseIterators& dagIterators, Qubit idx,
+    const Operation* until) {
   // qubit is finished -> consider next qubit
   if (dagIterators.at(idx) == dag.at(idx).rend()) {
     if (idx < static_cast<Qubit>(dag.size() - 1)) {
@@ -364,8 +367,10 @@ void removeDiagonalGatesBeforeMeasureRecursive(
   }
 }
 
-bool removeDiagonalGate(DAG& dag, DAGReverseIterators& dagIterators, Qubit idx,
-                        DAGReverseIterator& it, qc::Operation* op) {
+bool removeDiagonalGate(CircuitOptimizer::DAG& dag,
+                        CircuitOptimizer::DAGReverseIterators& dagIterators,
+                        Qubit idx, CircuitOptimizer::DAGReverseIterator& it,
+                        Operation* op) {
   // not a diagonal gate
   if (std::find(DIAGONAL_GATES.begin(), DIAGONAL_GATES.end(), op->getType()) ==
       DIAGONAL_GATES.end()) {
@@ -455,13 +460,15 @@ void CircuitOptimizer::removeDiagonalGatesBeforeMeasure(
   removeIdentities(qc);
 }
 
-bool removeFinalMeasurement(DAG& dag, DAGReverseIterators& dagIterators,
-                            Qubit idx, DAGReverseIterator& it,
-                            qc::Operation* op);
+bool removeFinalMeasurement(CircuitOptimizer::DAG& dag,
+                            CircuitOptimizer::DAGReverseIterators& dagIterators,
+                            Qubit idx, CircuitOptimizer::DAGReverseIterator& it,
+                            Operation* op);
 
-void removeFinalMeasurementsRecursive(DAG& dag,
-                                      DAGReverseIterators& dagIterators,
-                                      Qubit idx, const qc::Operation* until) {
+void removeFinalMeasurementsRecursive(
+    CircuitOptimizer::DAG& dag,
+    CircuitOptimizer::DAGReverseIterators& dagIterators, Qubit idx,
+    const Operation* until) {
   if (dagIterators.at(idx) == dag.at(idx).rend()) { // we reached the end
     if (idx < static_cast<Qubit>(dag.size() - 1)) {
       removeFinalMeasurementsRecursive(dag, dagIterators, idx + 1, nullptr);
@@ -527,9 +534,10 @@ void removeFinalMeasurementsRecursive(DAG& dag,
   }
 }
 
-bool removeFinalMeasurement(DAG& dag, DAGReverseIterators& dagIterators,
-                            Qubit idx, DAGReverseIterator& it,
-                            qc::Operation* op) {
+bool removeFinalMeasurement(CircuitOptimizer::DAG& dag,
+                            CircuitOptimizer::DAGReverseIterators& dagIterators,
+                            Qubit idx, CircuitOptimizer::DAGReverseIterator& it,
+                            Operation* op) {
   if (op->getNtargets() != 0) {
     // need to check all targets
     bool onlyMeasurements = true;

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -459,6 +459,11 @@ void QuantumComputation::addAncillaryRegister(std::size_t nq,
                        " already exists");
   }
 
+  if (nq == 0) {
+    throw QFRException(
+        "[addAncillaryRegister] New register size must be larger than 0");
+  }
+
   const auto totalqubits = nqubits + nancillae;
   ancillaRegisters.try_emplace(regName, totalqubits, nq, regName);
   ancillary.resize(totalqubits + nq);

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -847,8 +847,7 @@ bool QuantumComputation::isIdleQubit(const Qubit physicalQubit) const {
       [&physicalQubit](const auto& op) { return op->actsOn(physicalQubit); });
 }
 
-void QuantumComputation::stripIdleQubits(bool force,
-                                         bool reduceIOpermutations) {
+void QuantumComputation::stripIdleQubits(bool force) {
   auto layoutCopy = initialLayout;
   for (auto physicalQubitIt = layoutCopy.rbegin();
        physicalQubitIt != layoutCopy.rend(); ++physicalQubitIt) {
@@ -875,7 +874,7 @@ void QuantumComputation::stripIdleQubits(bool force,
 
       removeQubit(logicalQubitIndex);
 
-      if (reduceIOpermutations && (logicalQubitIndex < nqubits + nancillae)) {
+      if (logicalQubitIndex < nqubits + nancillae) {
         for (auto& [physical, logical] : initialLayout) {
           if (logical > logicalQubitIndex) {
             --logical;

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -10,6 +10,7 @@
 #include "ir/QuantumComputation.hpp"
 
 #include "Definitions.hpp"
+#include "ir/Register.hpp"
 #include "ir/operations/ClassicControlledOperation.hpp"
 #include "ir/operations/CompoundOperation.hpp"
 #include "ir/operations/Control.hpp"
@@ -42,6 +43,7 @@
 #include <sstream>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -50,80 +52,55 @@ namespace qc {
 
 namespace {
 template <class RegisterType>
-void printSortedRegisters(const RegisterMap<RegisterType>& regmap,
-                          const std::string& identifier, std::ostream& of,
-                          const bool openQASM3) {
+void printSortedRegisters(
+    const std::unordered_map<std::string, RegisterType>& registers,
+    const std::string& identifier, std::ostream& of, const bool openQASM3) {
   // sort regs by start index
-  std::map<decltype(RegisterType::first), std::pair<std::string, RegisterType>>
-      sortedRegs{};
-  for (const auto& reg : regmap) {
-    sortedRegs.insert({reg.second.first, reg});
+  std::map<size_t, RegisterType> sortedRegs{};
+  for (const auto& [name, reg] : registers) {
+    sortedRegs.emplace(reg.getStartIndex(), reg);
   }
 
-  for (const auto& reg : sortedRegs) {
+  for (const auto& r : sortedRegs) {
+    const auto& reg = r.second;
     if (openQASM3) {
-      of << identifier << "[" << reg.second.second.second << "] "
-         << reg.second.first << ";" << std::endl;
+      of << identifier << "[" << reg.getSize() << "] " << reg.getName()
+         << ";\n";
     } else {
-      of << identifier << " " << reg.second.first << "["
-         << reg.second.second.second << "];" << std::endl;
+      of << identifier << " " << reg.getName() << "[" << reg.getSize()
+         << "];\n";
     }
   }
 }
 
-template <class RegisterType>
-void consolidateRegister(RegisterMap<RegisterType>& regs) {
+void consolidateRegister(QuantumRegisterMap& regs) {
   bool finished = regs.empty();
   while (!finished) {
-    for (const auto& qreg : regs) {
+    for (const auto& [name, qreg] : regs) {
       finished = true;
-      auto regname = qreg.first;
       // check if lower part of register
-      if (regname.length() > 2 &&
-          regname.compare(regname.size() - 2, 2, "_l") == 0) {
-        auto lowidx = qreg.second.first;
-        auto lownum = qreg.second.second;
+      if (name.length() > 2 && name.compare(name.size() - 2, 2, "_l") == 0) {
+        auto lowidx = qreg.getStartIndex();
+        auto lownum = qreg.getSize();
         // search for higher part of register
-        auto highname = regname.substr(0, regname.size() - 1) + 'h';
-        auto it = regs.find(highname);
-        if (it != regs.end()) {
-          auto highidx = it->second.first;
-          auto highnum = it->second.second;
+        auto highname = name.substr(0, name.size() - 1) + 'h';
+        if (const auto it = regs.find(highname); it != regs.end()) {
+          auto& highReg = it->second;
+          auto highidx = highReg.getStartIndex();
+          auto highnum = highReg.getSize();
           // fusion of registers possible
           if (lowidx + lownum == highidx) {
             finished = false;
-            auto targetname = regname.substr(0, regname.size() - 2);
+            auto targetname = name.substr(0, name.size() - 2);
             auto targetidx = lowidx;
             auto targetnum = lownum + highnum;
-            regs.insert({targetname, {targetidx, targetnum}});
-            regs.erase(regname);
+            regs.erase(name);
             regs.erase(highname);
+            regs.try_emplace(targetname, targetidx, targetnum, targetname);
           }
         }
         break;
       }
-    }
-  }
-}
-
-template <class RegisterType>
-void createRegisterArray(const RegisterMap<RegisterType>& regs,
-                         RegisterNames& regnames) {
-  regnames.clear();
-  std::stringstream ss;
-  // sort regs by start index
-  std::map<decltype(RegisterType::first), std::pair<std::string, RegisterType>>
-      sortedRegs{};
-  for (const auto& reg : regs) {
-    sortedRegs.insert({reg.second.first, reg});
-  }
-
-  for (const auto& reg : sortedRegs) {
-    for (decltype(RegisterType::second) i = 0; i < reg.second.second.second;
-         ++i) {
-      ss << reg.second.first << "[" << i << "]";
-      regnames.push_back(std::make_pair(reg.second.first, ss.str()));
-      ss.str(std::string());
     }
   }
 }
@@ -140,34 +117,35 @@ void createRegisterArray(const RegisterMap<RegisterType>& regs,
  * @param idx The index of the qubit in the register to be removed
  */
 void removeQubitfromQubitRegister(QuantumRegisterMap& regs,
-                                  const std::string& reg, Qubit idx) {
+                                  QuantumRegister& reg, const Qubit idx) {
   if (idx == 0) {
     // last remaining qubit of register
-    if (regs[reg].second == 1) {
+    if (reg.getSize() == 1) {
       // delete register
-      regs.erase(reg);
+      regs.erase(reg.getName());
     }
     // first qubit of register
     else {
-      regs[reg].first++;
-      regs[reg].second--;
+      reg.getStartIndex()++;
+      reg.getSize()--;
     }
     // last index
-  } else if (idx == regs[reg].second - 1) {
+  } else if (idx == reg.getSize() - 1) {
     // reduce count of register
-    regs[reg].second--;
+    reg.getSize()--;
   } else {
-    auto qreg = regs.at(reg);
-    auto lowPart = reg + "_l";
-    auto lowIndex = qreg.first;
-    auto lowCount = idx;
-    auto highPart = reg + "_h";
-    auto highIndex = qreg.first + idx + 1;
-    auto highCount = qreg.second - idx - 1;
+    const auto startIndex = reg.getStartIndex();
+    const auto count = reg.getSize();
+    const auto lowPart = reg.getName() + "_l";
+    const auto lowIndex = startIndex;
+    const auto lowCount = idx;
+    const auto highPart = reg.getName() + "_h";
+    const auto highIndex = startIndex + idx + 1;
+    const auto highCount = count - idx - 1;
 
-    regs.erase(reg);
-    regs.try_emplace(lowPart, lowIndex, lowCount);
-    regs.try_emplace(highPart, highIndex, highCount);
+    regs.erase(reg.getName());
+    regs.try_emplace(lowPart, lowIndex, lowCount, lowPart);
+    regs.try_emplace(highPart, highIndex, highCount, highPart);
   }
 }
 
@@ -184,9 +162,9 @@ void removeQubitfromQubitRegister(QuantumRegisterMap& regs,
 void addQubitToQubitRegister(QuantumRegisterMap& regs, Qubit physicalQubitIndex,
                              const std::string& defaultRegName) {
   auto fusionPossible = false;
-  for (auto& reg : regs) {
-    auto& startIndex = reg.second.first;
-    auto& count = reg.second.second;
+  for (auto& [name, reg] : regs) {
+    auto& startIndex = reg.getStartIndex();
+    auto& count = reg.getSize();
     // 1st case: can append to start of existing register
     if (startIndex == physicalQubitIndex + 1) {
       startIndex--;
@@ -205,10 +183,11 @@ void addQubitToQubitRegister(QuantumRegisterMap& regs, Qubit physicalQubitIndex,
   consolidateRegister(regs);
 
   if (regs.empty()) {
-    regs.try_emplace(defaultRegName, physicalQubitIndex, 1);
+    regs.try_emplace(defaultRegName, physicalQubitIndex, 1, defaultRegName);
   } else if (!fusionPossible) {
-    auto newRegName = defaultRegName + "_" + std::to_string(physicalQubitIndex);
-    regs.try_emplace(newRegName, physicalQubitIndex, 1);
+    const auto newRegName =
+        defaultRegName + "_" + std::to_string(physicalQubitIndex);
+    regs.try_emplace(newRegName, physicalQubitIndex, 1, newRegName);
   }
 }
 } // namespace
@@ -427,21 +406,23 @@ void QuantumComputation::initializeIOMapping() {
 
 void QuantumComputation::addQubitRegister(std::size_t nq,
                                           const std::string& regName) {
-  if (qregs.count(regName) != 0) {
-    auto& reg = qregs.at(regName);
-    if (reg.first + reg.second == nqubits + nancillae) {
-      reg.second += nq;
-    } else {
-      throw QFRException(
-          "[addQubitRegister] Augmenting existing qubit registers is only "
-          "supported for the last register in a circuit");
-    }
-  } else {
-    qregs.try_emplace(regName, static_cast<Qubit>(nqubits), nq);
+  if (quantumRegisters.count(regName) != 0) {
+    throw QFRException("[addQubitRegister] Register " + regName +
+                       " already exists");
   }
-  assert(nancillae ==
-         0); // should only reach this point if no ancillae are present
 
+  if (nq == 0) {
+    throw QFRException(
+        "[addQubitRegister] New register size must be larger than 0");
+  }
+
+  if (nancillae != 0) {
+    throw QFRException(
+        "[addQubitRegister] Cannot add qubit register after ancillary "
+        "qubits have been added");
+  }
+
+  quantumRegisters.try_emplace(regName, nqubits, nq, regName);
   for (std::size_t i = 0; i < nq; ++i) {
     auto j = static_cast<Qubit>(nqubits + i);
     initialLayout.insert({j, j});
@@ -452,37 +433,34 @@ void QuantumComputation::addQubitRegister(std::size_t nq,
   garbage.resize(nqubits + nancillae);
 }
 
-void QuantumComputation::addClassicalRegister(std::size_t nc,
-                                              const std::string& regName) {
-  if (cregs.count(regName) != 0) {
-    throw QFRException("[addClassicalRegister] Augmenting existing classical "
-                       "registers is currently not supported");
+const ClassicalRegister&
+QuantumComputation::addClassicalRegister(std::size_t nc,
+                                         const std::string& regName) {
+  if (classicalRegisters.count(regName) != 0) {
+    throw QFRException("[addClassicalRegister] Register " + regName +
+                       " already exists");
   }
   if (nc == 0) {
     throw QFRException(
         "[addClassicalRegister] New register size must be larger than 0");
   }
 
-  cregs.try_emplace(regName, nclassics, nc);
+  const auto [it, success] =
+      classicalRegisters.try_emplace(regName, nclassics, nc, regName);
+  assert(success);
   nclassics += nc;
+  return it->second;
 }
 
 void QuantumComputation::addAncillaryRegister(std::size_t nq,
                                               const std::string& regName) {
-  const auto totalqubits = nqubits + nancillae;
-  if (ancregs.count(regName) != 0) {
-    auto& reg = ancregs.at(regName);
-    if (reg.first + reg.second == totalqubits) {
-      reg.second += nq;
-    } else {
-      throw QFRException(
-          "[addAncillaryRegister] Augmenting existing ancillary registers is "
-          "only supported for the last register in a circuit");
-    }
-  } else {
-    ancregs.try_emplace(regName, static_cast<Qubit>(totalqubits), nq);
+  if (ancillaRegisters.count(regName) != 0) {
+    throw QFRException("[addAncillaryRegister] Register " + regName +
+                       " already exists");
   }
 
+  const auto totalqubits = nqubits + nancillae;
+  ancillaRegisters.try_emplace(regName, totalqubits, nq, regName);
   ancillary.resize(totalqubits + nq);
   garbage.resize(totalqubits + nq);
   for (std::size_t i = 0; i < nq; ++i) {
@@ -494,22 +472,21 @@ void QuantumComputation::addAncillaryRegister(std::size_t nq,
   nancillae += nq;
 }
 
-// removes the i-th logical qubit and returns the index j it was assigned to in
-// the initial layout i.e., initialLayout[j] = i
 std::pair<Qubit, std::optional<Qubit>>
 QuantumComputation::removeQubit(const Qubit logicalQubitIndex) {
   // Find index of the physical qubit i is assigned to
   const auto physicalQubitIndex = getPhysicalQubitIndex(logicalQubitIndex);
 
   // get register and register-index of the corresponding qubit
-  const auto [reg, idx] = getQubitRegisterAndIndex(physicalQubitIndex);
+  auto& reg = getQubitRegister(physicalQubitIndex);
+  const auto& idx = reg.getLocalIndex(physicalQubitIndex);
 
   if (physicalQubitIsAncillary(physicalQubitIndex)) {
-    removeQubitfromQubitRegister(ancregs, reg, idx);
+    removeQubitfromQubitRegister(ancillaRegisters, reg, idx);
     // reduce ancilla count
     nancillae--;
   } else {
-    removeQubitfromQubitRegister(qregs, reg, idx);
+    removeQubitfromQubitRegister(quantumRegisters, reg, idx);
     // reduce qubit count
     if (ancillary.at(logicalQubitIndex)) {
       // if the qubit is ancillary, it is not counted as a qubit
@@ -554,7 +531,7 @@ void QuantumComputation::addAncillaryQubit(
                        "qubit that is already assigned");
   }
 
-  addQubitToQubitRegister(ancregs, physicalQubitIndex, "anc");
+  addQubitToQubitRegister(ancillaRegisters, physicalQubitIndex, "anc");
 
   // index of logical qubit
   const auto logicalQubitIndex = nqubits + nancillae;
@@ -598,7 +575,7 @@ void QuantumComputation::addQubit(const Qubit logicalQubitIndex,
     // register could be created and all ancillaries shifted
   }
 
-  addQubitToQubitRegister(qregs, physicalQubitIndex, "q");
+  addQubitToQubitRegister(quantumRegisters, physicalQubitIndex, "q");
 
   // increase qubit count
   nqubits++;
@@ -646,8 +623,10 @@ void QuantumComputation::invert() {
 
 bool QuantumComputation::operator==(const QuantumComputation& rhs) const {
   if (nqubits != rhs.nqubits || nancillae != rhs.nancillae ||
-      nclassics != rhs.nclassics || qregs != rhs.qregs || cregs != rhs.cregs ||
-      ancregs != rhs.ancregs || initialLayout != rhs.initialLayout ||
+      nclassics != rhs.nclassics || quantumRegisters != rhs.quantumRegisters ||
+      classicalRegisters != rhs.classicalRegisters ||
+      ancillaRegisters != rhs.ancillaRegisters ||
+      initialLayout != rhs.initialLayout ||
       outputPermutation != rhs.outputPermutation ||
       ancillary != rhs.ancillary || garbage != rhs.garbage ||
       seed != rhs.seed || globalPhase != rhs.globalPhase ||
@@ -771,23 +750,35 @@ void QuantumComputation::dumpOpenQASM(std::ostream& of, bool openQASM3) const {
   }
 
   // combine qregs and ancregs
-  QuantumRegisterMap combinedRegs = qregs;
-  for (const auto& [regName, reg] : ancregs) {
-    combinedRegs.try_emplace(regName, reg.first, reg.second);
+  auto combinedRegs = quantumRegisters;
+  for (const auto& reg : ancillaRegisters) {
+    combinedRegs.emplace(reg);
   }
   printSortedRegisters(combinedRegs, openQASM3 ? "qubit" : "qreg", of,
                        openQASM3);
-  RegisterNames combinedRegNames{};
-  createRegisterArray(combinedRegs, combinedRegNames);
-  assert(combinedRegNames.size() == nqubits + nancillae);
 
-  printSortedRegisters(cregs, openQASM3 ? "bit" : "creg", of, openQASM3);
-  RegisterNames cregnames{};
-  createRegisterArray(cregs, cregnames);
-  assert(cregnames.size() == nclassics);
+  printSortedRegisters(classicalRegisters, openQASM3 ? "bit" : "creg", of,
+                       openQASM3);
+
+  // build qubit index -> register map
+  QubitIndexToRegisterMap qubitMap{};
+  for (const auto& [_, reg] : combinedRegs) {
+    const auto bound = reg.getStartIndex() + reg.getSize();
+    for (Qubit i = reg.getStartIndex(); i < bound; ++i) {
+      qubitMap.try_emplace(i, reg, reg.toString(i));
+    }
+  }
+  // build classical index -> register map
+  BitIndexToRegisterMap bitMap{};
+  for (const auto& [_, reg] : classicalRegisters) {
+    const auto bound = reg.getStartIndex() + reg.getSize();
+    for (Bit i = reg.getStartIndex(); i < bound; ++i) {
+      bitMap.try_emplace(i, reg, reg.toString(i));
+    }
+  }
 
   for (const auto& op : ops) {
-    op->dumpOpenQASM(of, combinedRegNames, cregnames, 0, openQASM3);
+    op->dumpOpenQASM(of, qubitMap, bitMap, 0, openQASM3);
   }
 }
 
@@ -812,9 +803,9 @@ void QuantumComputation::reset() {
   nqubits = 0;
   nclassics = 0;
   nancillae = 0;
-  qregs.clear();
-  cregs.clear();
-  ancregs.clear();
+  quantumRegisters.clear();
+  classicalRegisters.clear();
+  ancillaRegisters.clear();
   initialLayout.clear();
   outputPermutation.clear();
 }
@@ -861,16 +852,16 @@ void QuantumComputation::stripIdleQubits(bool force,
   auto layoutCopy = initialLayout;
   for (auto physicalQubitIt = layoutCopy.rbegin();
        physicalQubitIt != layoutCopy.rend(); ++physicalQubitIt) {
-    auto physicalQubitIndex = physicalQubitIt->first;
-    if (isIdleQubit(physicalQubitIndex)) {
+    if (const auto physicalQubitIndex = physicalQubitIt->first;
+        isIdleQubit(physicalQubitIndex)) {
       if (auto it = outputPermutation.find(physicalQubitIndex);
           it != outputPermutation.end() && !force) {
         continue;
       }
 
-      auto logicalQubitIndex = initialLayout.at(physicalQubitIndex);
+      const auto logicalQubitIndex = initialLayout.at(physicalQubitIndex);
       // check whether the logical qubit is used in the output permutation
-      bool usedInOutputPermutation = false;
+      auto usedInOutputPermutation = false;
       for (const auto& [physical, logical] : outputPermutation) {
         if (logical == logicalQubitIndex) {
           usedInOutputPermutation = true;
@@ -901,82 +892,23 @@ void QuantumComputation::stripIdleQubits(bool force,
   }
 }
 
-std::string
-QuantumComputation::getQubitRegister(const Qubit physicalQubitIndex) const {
-  for (const auto& reg : qregs) {
-    auto startIdx = reg.second.first;
-    auto count = reg.second.second;
-    if (physicalQubitIndex < startIdx) {
-      continue;
+QuantumRegister&
+QuantumComputation::getQubitRegister(const Qubit physicalQubitIndex) {
+  for (auto& [_, reg] : quantumRegisters) {
+    if (reg.contains(physicalQubitIndex)) {
+      return reg;
     }
-    if (physicalQubitIndex >= startIdx + count) {
-      continue;
-    }
-    return reg.first;
   }
-  for (const auto& reg : ancregs) {
-    auto startIdx = reg.second.first;
-    auto count = reg.second.second;
-    if (physicalQubitIndex < startIdx) {
-      continue;
+
+  for (auto& [_, reg] : ancillaRegisters) {
+    if (reg.contains(physicalQubitIndex)) {
+      return reg;
     }
-    if (physicalQubitIndex >= startIdx + count) {
-      continue;
-    }
-    return reg.first;
   }
 
   throw QFRException("[getQubitRegister] Qubit index " +
                      std::to_string(physicalQubitIndex) +
                      " not found in any register");
-}
-
-std::pair<std::string, Qubit> QuantumComputation::getQubitRegisterAndIndex(
-    const Qubit physicalQubitIndex) const {
-  const std::string regName = getQubitRegister(physicalQubitIndex);
-  Qubit index = 0;
-  auto it = qregs.find(regName);
-  if (it != qregs.end()) {
-    index = physicalQubitIndex - it->second.first;
-  } else {
-    auto itAnc = ancregs.find(regName);
-    if (itAnc != ancregs.end()) {
-      index = physicalQubitIndex - itAnc->second.first;
-    }
-    // no else branch needed here, since error would have already shown in
-    // getQubitRegister(physicalQubitIndex)
-  }
-  return {regName, index};
-}
-
-std::string
-QuantumComputation::getClassicalRegister(const Bit classicalIndex) const {
-  for (const auto& reg : cregs) {
-    auto startIdx = reg.second.first;
-    auto count = reg.second.second;
-    if (classicalIndex < startIdx) {
-      continue;
-    }
-    if (classicalIndex >= startIdx + count) {
-      continue;
-    }
-    return reg.first;
-  }
-
-  throw QFRException("[getClassicalRegister] Classical index " +
-                     std::to_string(classicalIndex) +
-                     " not found in any register");
-}
-
-std::pair<std::string, Bit> QuantumComputation::getClassicalRegisterAndIndex(
-    const Bit classicalIndex) const {
-  const std::string regName = getClassicalRegister(classicalIndex);
-  std::size_t index = 0;
-  auto it = cregs.find(regName);
-  if (it != cregs.end()) {
-    index = classicalIndex - it->second.first;
-  } // else branch not needed since getClassicalRegister covers this case
-  return {regName, index};
 }
 
 Qubit QuantumComputation::getPhysicalQubitIndex(const Qubit logicalQubitIndex) {
@@ -990,47 +922,12 @@ Qubit QuantumComputation::getPhysicalQubitIndex(const Qubit logicalQubitIndex) {
                      " not found in initial layout");
 }
 
-Qubit QuantumComputation::getIndexFromQubitRegister(
-    const std::pair<std::string, Qubit>& qubit) const {
-  // no range check is performed here!
-  return qregs.at(qubit.first).first + qubit.second;
-}
-Bit QuantumComputation::getIndexFromClassicalRegister(
-    const std::pair<std::string, std::size_t>& clbit) const {
-  // no range check is performed here!
-  return cregs.at(clbit.first).first + clbit.second;
-}
-
 std::ostream&
 QuantumComputation::printPermutation(const Permutation& permutation,
                                      std::ostream& os) {
   for (const auto& [physical, logical] : permutation) {
     os << "\t" << physical << ": " << logical << "\n";
   }
-  return os;
-}
-
-std::ostream& QuantumComputation::printRegisters(std::ostream& os) const {
-  os << "qregs:";
-  for (const auto& qreg : qregs) {
-    os << " {" << qreg.first << ", {" << qreg.second.first << ", "
-       << qreg.second.second << "}}";
-  }
-  os << "\n";
-  if (!ancregs.empty()) {
-    os << "ancregs:";
-    for (const auto& ancreg : ancregs) {
-      os << " {" << ancreg.first << ", {" << ancreg.second.first << ", "
-         << ancreg.second.second << "}}";
-    }
-    os << "\n";
-  }
-  os << "cregs:";
-  for (const auto& creg : cregs) {
-    os << " {" << creg.first << ", {" << creg.second.first << ", "
-       << creg.second.second << "}}";
-  }
-  os << "\n";
   return os;
 }
 
@@ -1044,11 +941,9 @@ Qubit QuantumComputation::getHighestPhysicalQubitIndex() const {
 
 bool QuantumComputation::physicalQubitIsAncillary(
     const Qubit physicalQubitIndex) const {
-  return std::any_of(ancregs.cbegin(), ancregs.cend(),
-                     [&physicalQubitIndex](const auto& ancreg) {
-                       return ancreg.second.first <= physicalQubitIndex &&
-                              physicalQubitIndex <
-                                  ancreg.second.first + ancreg.second.second;
+  return std::any_of(ancillaRegisters.cbegin(), ancillaRegisters.cend(),
+                     [&physicalQubitIndex](const auto& reg) {
+                       return reg.second.contains(physicalQubitIndex);
                      });
 }
 
@@ -1132,28 +1027,26 @@ bool QuantumComputation::isLastOperationOnQubit(
 }
 
 void QuantumComputation::unifyQuantumRegisters(const std::string& regName) {
-  ancregs.clear();
-  qregs.clear();
+  ancillaRegisters.clear();
+  quantumRegisters.clear();
   nqubits += nancillae;
   nancillae = 0;
-  qregs[regName] = {0, nqubits};
+  quantumRegisters.try_emplace(regName, 0, nqubits, regName);
 }
 
 void QuantumComputation::appendMeasurementsAccordingToOutputPermutation(
     const std::string& registerName) {
   // ensure that the circuit contains enough classical registers
-  if (cregs.empty()) {
+  if (classicalRegisters.empty()) {
     // in case there are no registers, create a new one
     addClassicalRegister(outputPermutation.size(), registerName);
   } else if (nclassics < outputPermutation.size()) {
-    if (cregs.find(registerName) == cregs.end()) {
-      // in case there are registers but not enough, add a new one
-      addClassicalRegister(outputPermutation.size() - nclassics, registerName);
-    } else {
-      // in case the register already exists, augment it
-      nclassics += outputPermutation.size() - nclassics;
-      cregs[registerName].second = outputPermutation.size();
+    if (classicalRegisters.find(registerName) != classicalRegisters.end()) {
+      throw QFRException(
+          "[appendMeasurementsAccordingToOutputPermutation] Register " +
+          registerName + " already exists but is too small");
     }
+    addClassicalRegister(outputPermutation.size() - nclassics, registerName);
   }
   auto targets = std::vector<Qubit>{};
   for (std::size_t q = 0; q < getNqubits(); ++q) {
@@ -1209,11 +1102,11 @@ void QuantumComputation::checkBitRange(const std::vector<Bit>& bits) const {
 
 void QuantumComputation::checkClassicalRegister(
     const ClassicalRegister& creg) const {
-  if (creg.first + creg.second > nclassics) {
+  if (creg.getStartIndex() + creg.getSize() > nclassics) {
     std::stringstream ss{};
-    ss << "Classical register starting at index " << creg.first << " with "
-       << creg.second << " bits is too large! The circuit has " << nclassics
-       << " classical bits.";
+    ss << "Classical register starting at index " << creg.getStartIndex()
+       << " with " << creg.getSize() << " bits is too large! The circuit has "
+       << nclassics << " classical bits.";
     throw QFRException(ss.str());
   }
 }
@@ -1262,8 +1155,10 @@ QuantumComputation::QuantumComputation(const std::string& filename,
 }
 QuantumComputation::QuantumComputation(const QuantumComputation& qc)
     : nqubits(qc.nqubits), nclassics(qc.nclassics), nancillae(qc.nancillae),
-      name(qc.name), qregs(qc.qregs), cregs(qc.cregs), ancregs(qc.ancregs),
-      ancillary(qc.ancillary), garbage(qc.garbage), mt(qc.mt), seed(qc.seed),
+      name(qc.name), quantumRegisters(qc.quantumRegisters),
+      classicalRegisters(qc.classicalRegisters),
+      ancillaRegisters(qc.ancillaRegisters), ancillary(qc.ancillary),
+      garbage(qc.garbage), mt(qc.mt), seed(qc.seed),
       globalPhase(qc.globalPhase), occurringVariables(qc.occurringVariables),
       initialLayout(qc.initialLayout), outputPermutation(qc.outputPermutation) {
   ops.reserve(qc.ops.size());
@@ -1278,9 +1173,9 @@ QuantumComputation::operator=(const QuantumComputation& qc) {
     nclassics = qc.nclassics;
     nancillae = qc.nancillae;
     name = qc.name;
-    qregs = qc.qregs;
-    cregs = qc.cregs;
-    ancregs = qc.ancregs;
+    quantumRegisters = qc.quantumRegisters;
+    classicalRegisters = qc.classicalRegisters;
+    ancillaRegisters = qc.ancillaRegisters;
     mt = qc.mt;
     seed = qc.seed;
     globalPhase = qc.globalPhase;
@@ -1765,29 +1660,6 @@ void QuantumComputation::measure(const Qubit qubit, const std::size_t bit) {
   emplace_back<NonUnitaryOperation>(qubit, bit);
 }
 
-void QuantumComputation::measure(
-    const Qubit qubit, const std::pair<std::string, Bit>& registerBit) {
-  checkQubitRange(qubit);
-  if (const auto cRegister = cregs.find(registerBit.first);
-      cRegister != cregs.end()) {
-    if (registerBit.second >= cRegister->second.second) {
-      std::stringstream ss{};
-      ss << "The classical register \"" << registerBit.first
-         << "\" is too small! (" << registerBit.second
-         << " >= " << cRegister->second.second << ")";
-      throw QFRException(ss.str());
-    }
-    emplace_back<NonUnitaryOperation>(qubit, cRegister->second.first +
-                                                 registerBit.second);
-
-  } else {
-    std::stringstream ss{};
-    ss << "The classical register \"" << registerBit.first
-       << "\" does not exist!";
-    throw QFRException(ss.str());
-  }
-}
-
 void QuantumComputation::measure(const Targets& qubits,
                                  const std::vector<Bit>& bits) {
   checkQubitRange(qubits);
@@ -1810,7 +1682,7 @@ void QuantumComputation::measureAll(const bool addBits) {
   barrier();
   Qubit start = 0U;
   if (addBits) {
-    start = static_cast<Qubit>(cregs.at("meas").first);
+    start = static_cast<Qubit>(classicalRegisters.at("meas").getStartIndex());
   }
   // measure i -> (start+i) in descending order
   // (this is an optimization for the simulator)

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -842,7 +842,7 @@ void QuantumComputation::dump(std::ostream& of, Format format) const {
 }
 
 bool QuantumComputation::isIdleQubit(const Qubit physicalQubit) const {
-  return !std::any_of(
+  return std::none_of(
       ops.cbegin(), ops.cend(),
       [&physicalQubit](const auto& op) { return op->actsOn(physicalQubit); });
 }
@@ -1047,11 +1047,7 @@ void QuantumComputation::appendMeasurementsAccordingToOutputPermutation(
     }
     addClassicalRegister(outputPermutation.size() - nclassics, registerName);
   }
-  auto targets = std::vector<Qubit>{};
-  for (std::size_t q = 0; q < getNqubits(); ++q) {
-    targets.emplace_back(static_cast<Qubit>(q));
-  }
-  barrier(targets);
+  barrier();
   // append measurements according to output permutation
   for (const auto& [qubit, clbit] : outputPermutation) {
     measure(qubit, clbit);

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -1738,4 +1738,33 @@ void QuantumComputation::classicControlled(
   emplace_back<ClassicControlledOperation>(std::move(gate), controlRegister,
                                            expectedValue, cmp);
 }
+void QuantumComputation::classicControlled(const OpType op, const Qubit target,
+                                           const Bit cBit,
+                                           const std::uint64_t expectedValue,
+                                           const ComparisonKind cmp,
+                                           const std::vector<fp>& params) {
+  classicControlled(op, target, Controls{}, cBit, expectedValue, cmp, params);
+}
+void QuantumComputation::classicControlled(const OpType op, const Qubit target,
+                                           const Control control,
+                                           const Bit cBit,
+                                           const std::uint64_t expectedValue,
+                                           const ComparisonKind cmp,
+                                           const std::vector<fp>& params) {
+  classicControlled(op, target, Controls{control}, cBit, expectedValue, cmp,
+                    params);
+}
+void QuantumComputation::classicControlled(const OpType op, const Qubit target,
+                                           const Controls& controls,
+                                           const Bit cBit,
+                                           const std::uint64_t expectedValue,
+                                           const ComparisonKind cmp,
+                                           const std::vector<fp>& params) {
+  checkQubitRange(target, controls);
+  checkClassicalRegister({1, cBit});
+  std::unique_ptr<Operation> gate =
+      std::make_unique<StandardOperation>(controls, target, op, params);
+  emplace_back<ClassicControlledOperation>(std::move(gate), cBit, expectedValue,
+                                           cmp);
+}
 } // namespace qc

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -1335,6 +1336,10 @@ void QuantumComputation::instantiateInplace(
 }
 
 void QuantumComputation::reorderOperations() {
+  using DAG = std::vector<std::deque<std::unique_ptr<Operation>*>>;
+  using DAGIterator = std::deque<std::unique_ptr<Operation>*>::iterator;
+  using DAGIterators = std::vector<DAGIterator>;
+
   Qubit highestPhysicalQubit = 0;
   for (const auto& q : initialLayout) {
     highestPhysicalQubit = std::max(q.first, highestPhysicalQubit);

--- a/src/ir/operations/AodOperation.cpp
+++ b/src/ir/operations/AodOperation.cpp
@@ -10,6 +10,7 @@
 #include "ir/operations/AodOperation.hpp"
 
 #include "Definitions.hpp"
+#include "ir/Register.hpp"
 #include "ir/operations/OpType.hpp"
 
 #include <algorithm>
@@ -125,11 +126,12 @@ std::vector<qc::fp> AodOperation::getDistances(const Dimension dir) const {
   }
   return params;
 }
-void AodOperation::dumpOpenQASM(std::ostream& of, const qc::RegisterNames& qreg,
-                                [[maybe_unused]] const qc::RegisterNames& creg,
-                                const size_t indent, bool /*openQASM3*/) const {
+void AodOperation::dumpOpenQASM(
+    std::ostream& of, const qc::QubitIndexToRegisterMap& qubitMap,
+    [[maybe_unused]] const qc::BitIndexToRegisterMap& bitMap,
+    const size_t indent, bool /*openQASM3*/) const {
   of << std::setprecision(std::numeric_limits<qc::fp>::digits10);
-  of << std::string(indent * qc::OUTPUT_INDENT_SIZE, ' ');
+  of << std::string(indent * OUTPUT_INDENT_SIZE, ' ');
   of << name;
   // write AOD operations
   of << " (";
@@ -141,7 +143,7 @@ void AodOperation::dumpOpenQASM(std::ostream& of, const qc::RegisterNames& qreg,
   of << ")";
   // write qubit start
   for (const auto& qubit : targets) {
-    of << " " << qreg[qubit].second << ",";
+    of << " " << qubitMap.at(qubit).second << ",";
   }
   of.seekp(-1, std::ios_base::end);
   of << ";\n";

--- a/src/ir/operations/ClassicControlledOperation.cpp
+++ b/src/ir/operations/ClassicControlledOperation.cpp
@@ -13,6 +13,7 @@
 #include "ir/Permutation.hpp"
 #include "ir/Register.hpp"
 #include "ir/operations/OpType.hpp"
+#include "ir/operations/Operation.hpp"
 
 #include <cassert>
 #include <cstddef>

--- a/src/ir/operations/ClassicControlledOperation.cpp
+++ b/src/ir/operations/ClassicControlledOperation.cpp
@@ -11,8 +11,10 @@
 
 #include "Definitions.hpp"
 #include "ir/Permutation.hpp"
+#include "ir/Register.hpp"
 #include "ir/operations/OpType.hpp"
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -93,11 +95,10 @@ bool ClassicControlledOperation::equals(const Operation& operation,
   }
   return false;
 }
-void ClassicControlledOperation::dumpOpenQASM(std::ostream& of,
-                                              const RegisterNames& qreg,
-                                              const RegisterNames& creg,
-                                              const std::size_t indent,
-                                              const bool openQASM3) const {
+void ClassicControlledOperation::dumpOpenQASM(
+    std::ostream& of, const QubitIndexToRegisterMap& qubitMap,
+    const BitIndexToRegisterMap& bitMap, const std::size_t indent,
+    const bool openQASM3) const {
   of << std::string(indent * OUTPUT_INDENT_SIZE, ' ');
   of << "if (";
   if (isWholeQubitRegister(creg, controlRegister.first,
@@ -117,7 +118,7 @@ void ClassicControlledOperation::dumpOpenQASM(std::ostream& of,
   if (openQASM3) {
     of << "{\n";
   }
-  op->dumpOpenQASM(of, qreg, creg, indent + 1, openQASM3);
+  op->dumpOpenQASM(of, qubitMap, bitMap, indent + 1, openQASM3);
   if (openQASM3) {
     of << "}\n";
   }

--- a/src/ir/operations/CompoundOperation.cpp
+++ b/src/ir/operations/CompoundOperation.cpp
@@ -12,6 +12,7 @@
 #include "Definitions.hpp"
 #include "ir/Permutation.hpp"
 #include "ir/QuantumComputation.hpp"
+#include "ir/Register.hpp"
 #include "ir/operations/Control.hpp"
 #include "ir/operations/OpType.hpp"
 
@@ -163,11 +164,12 @@ void CompoundOperation::addDepthContribution(
 }
 
 void CompoundOperation::dumpOpenQASM(std::ostream& of,
-                                     const RegisterNames& qreg,
-                                     const RegisterNames& creg, size_t indent,
+                                     const QubitIndexToRegisterMap& qubitMap,
+                                     const BitIndexToRegisterMap& bitMap,
+                                     const std::size_t indent,
                                      bool openQASM3) const {
   for (const auto& op : ops) {
-    op->dumpOpenQASM(of, qreg, creg, indent, openQASM3);
+    op->dumpOpenQASM(of, qubitMap, bitMap, indent, openQASM3);
   }
 }
 

--- a/src/ir/operations/CompoundOperation.cpp
+++ b/src/ir/operations/CompoundOperation.cpp
@@ -15,6 +15,7 @@
 #include "ir/Register.hpp"
 #include "ir/operations/Control.hpp"
 #include "ir/operations/OpType.hpp"
+#include "ir/operations/Operation.hpp"
 
 #include <algorithm>
 #include <cassert>

--- a/src/ir/operations/Operation.cpp
+++ b/src/ir/operations/Operation.cpp
@@ -27,11 +27,14 @@ namespace qc {
 
 std::ostream& Operation::printParameters(std::ostream& os) const {
   if (isClassicControlledOperation()) {
+
     os << "  c[" << parameter[0];
-    if (parameter[1] != 1) {
-      os << " ... " << (parameter[0] + parameter[1] - 1);
+    if (parameter.size() == 2) {
+      os << "] == " << parameter[1];
+    } else {
+      os << "..." << (parameter[0] + parameter[1] - 1)
+         << "] == " << parameter[2];
     }
-    os << "] == " << parameter[2];
     return os;
   }
 

--- a/src/ir/operations/StandardOperation.cpp
+++ b/src/ir/operations/StandardOperation.cpp
@@ -10,6 +10,7 @@
 #include "ir/operations/StandardOperation.hpp"
 
 #include "Definitions.hpp"
+#include "ir/Register.hpp"
 #include "ir/operations/Control.hpp"
 #include "ir/operations/OpType.hpp"
 #include "ir/operations/Operation.hpp"
@@ -243,24 +244,25 @@ StandardOperation::StandardOperation(const Controls& c, const Qubit target0,
 /***
  * Public Methods
  ***/
-void StandardOperation::dumpOpenQASM(std::ostream& of,
-                                     const RegisterNames& qreg,
-                                     [[maybe_unused]] const RegisterNames& creg,
-                                     size_t indent, bool openQASM3) const {
+void StandardOperation::dumpOpenQASM(
+    std::ostream& of, const QubitIndexToRegisterMap& qubitMap,
+    [[maybe_unused]] const BitIndexToRegisterMap& bitMap, size_t indent,
+    bool openQASM3) const {
   std::ostringstream op;
   op << std::setprecision(std::numeric_limits<fp>::digits10);
 
   op << std::string(indent * OUTPUT_INDENT_SIZE, ' ');
 
   if (openQASM3) {
-    dumpOpenQASM3(of, op, qreg);
+    dumpOpenQASM3(of, op, qubitMap);
   } else {
-    dumpOpenQASM2(of, op, qreg);
+    dumpOpenQASM2(of, op, qubitMap);
   }
 }
 
-void StandardOperation::dumpOpenQASM2(std::ostream& of, std::ostringstream& op,
-                                      const RegisterNames& qreg) const {
+void StandardOperation::dumpOpenQASM2(
+    std::ostream& of, std::ostringstream& op,
+    const QubitIndexToRegisterMap& qubitMap) const {
   if ((controls.size() > 1 && type != X) || controls.size() > 2) {
     std::cout << "[WARNING] Multiple controlled gates are not natively "
                  "supported by OpenQASM. "
@@ -280,32 +282,34 @@ void StandardOperation::dumpOpenQASM2(std::ostream& of, std::ostringstream& op,
     // apply X operations to negate the respective controls
     for (const auto& c : controls) {
       if (c.type == Control::Type::Neg) {
-        of << "x " << qreg[c.qubit].second << ";\n";
+        of << "x " << qubitMap.at(c.qubit).second << ";\n";
       }
     }
   }
 
-  dumpGateType(of, op, qreg);
+  dumpGateType(of, op, qubitMap);
 
   if (!isSpecialGate) {
     // apply X operations to negate the respective controls again
     for (const auto& c : controls) {
       if (c.type == Control::Type::Neg) {
-        of << "x " << qreg[c.qubit].second << ";\n";
+        of << "x " << qubitMap.at(c.qubit).second << ";\n";
       }
     }
   }
 }
 
-void StandardOperation::dumpOpenQASM3(std::ostream& of, std::ostringstream& op,
-                                      const RegisterNames& qreg) const {
+void StandardOperation::dumpOpenQASM3(
+    std::ostream& of, std::ostringstream& op,
+    const QubitIndexToRegisterMap& qubitMap) const {
   dumpControls(op);
 
-  dumpGateType(of, op, qreg);
+  dumpGateType(of, op, qubitMap);
 }
 
-void StandardOperation::dumpGateType(std::ostream& of, std::ostringstream& op,
-                                     const RegisterNames& qreg) const {
+void StandardOperation::dumpGateType(
+    std::ostream& of, std::ostringstream& op,
+    const QubitIndexToRegisterMap& qubitMap) const {
   // Dump the operation name and parameters.
   switch (type) {
   case GPhase:
@@ -428,33 +432,33 @@ void StandardOperation::dumpGateType(std::ostream& of, std::ostringstream& op,
   case Peres:
     of << op.str() << "cx";
     for (const auto& c : controls) {
-      of << " " << qreg[c.qubit].second << ",";
+      of << " " << qubitMap.at(c.qubit).second << ",";
     }
-    of << " " << qreg[targets[1]].second << ", " << qreg[targets[0]].second
-       << ";\n";
+    of << " " << qubitMap.at(targets[1]).second << ", "
+       << qubitMap.at(targets[0]).second << ";\n";
 
     of << op.str() << "x";
     for (const auto& c : controls) {
-      of << " " << qreg[c.qubit].second << ",";
+      of << " " << qubitMap.at(c.qubit).second << ",";
     }
-    of << " " << qreg[targets[1]].second << ";\n";
+    of << " " << qubitMap.at(targets[1]).second << ";\n";
     return;
   case Peresdg:
     of << op.str() << "x";
     for (const auto& c : controls) {
-      of << " " << qreg[c.qubit].second << ",";
+      of << " " << qubitMap.at(c.qubit).second << ",";
     }
-    of << " " << qreg[targets[1]].second << ";\n";
+    of << " " << qubitMap.at(targets[1]).second << ";\n";
 
     of << op.str() << "cx";
     for (const auto& c : controls) {
-      of << " " << qreg[c.qubit].second << ",";
+      of << " " << qubitMap.at(c.qubit).second << ",";
     }
-    of << " " << qreg[targets[1]].second << ", " << qreg[targets[0]].second
-       << ";\n";
+    of << " " << qubitMap.at(targets[1]).second << ", "
+       << qubitMap.at(targets[0]).second << ";\n";
     return;
   case Teleportation:
-    dumpOpenQASMTeleportation(of, qreg);
+    dumpOpenQASMTeleportation(of, qubitMap);
     return;
   default:
     std::cerr << "gate type " << toString(type)
@@ -466,7 +470,7 @@ void StandardOperation::dumpGateType(std::ostream& of, std::ostringstream& op,
 
   // First print control qubits.
   for (auto it = controls.begin(); it != controls.end();) {
-    of << " " << qreg[it->qubit].second;
+    of << " " << qubitMap.at(it->qubit).second;
     // we only print a comma if there are more controls or targets.
     if (++it != controls.end() || !targets.empty()) {
       of << ",";
@@ -474,11 +478,11 @@ void StandardOperation::dumpGateType(std::ostream& of, std::ostringstream& op,
   }
   // Print target qubits.
   if (!targets.empty() && type == Barrier &&
-      isWholeQubitRegister(qreg, targets.front(), targets.back())) {
-    of << " " << qreg[targets.front()].first;
+      isWholeQubitRegister(qubitMap, targets.front(), targets.back())) {
+    of << " " << qubitMap.at(targets.front()).first.getName();
   } else {
     for (auto it = targets.begin(); it != targets.end();) {
-      of << " " << qreg[*it].second;
+      of << " " << qubitMap.at(*it).second;
       // only print comma if there are more targets
       if (++it != targets.end()) {
         of << ",";
@@ -489,18 +493,8 @@ void StandardOperation::dumpGateType(std::ostream& of, std::ostringstream& op,
 }
 
 void StandardOperation::dumpOpenQASMTeleportation(
-    std::ostream& of, const RegisterNames& qreg) const {
+    std::ostream& of, const QubitIndexToRegisterMap& qubitMap) const {
   if (!controls.empty() || targets.size() != 3) {
-    std::cerr << "controls = ";
-    for (const auto& c : controls) {
-      std::cerr << qreg.at(c.qubit).second << " ";
-    }
-    std::cerr << "\ntargets = ";
-    for (const auto& t : targets) {
-      std::cerr << qreg.at(t).second << " ";
-    }
-    std::cerr << "\n";
-
     throw QFRException("Teleportation needs three targets");
   }
   /*
@@ -516,8 +510,9 @@ void StandardOperation::dumpOpenQASMTeleportation(
                                                          0           └─────┘
           */
   of << "// teleport q_0, a_0, a_1; q_0 --> a_1  via a_0\n";
-  of << "teleport " << qreg[targets[0]].second << ", "
-     << qreg[targets[1]].second << ", " << qreg[targets[2]].second << ";\n";
+  of << "teleport " << qubitMap.at(targets[0]).second << ", "
+     << qubitMap.at(targets[1]).second << ", " << qubitMap.at(targets[2]).second
+     << ";\n";
 }
 
 auto StandardOperation::commutesAtQubit(const Operation& other,

--- a/src/ir/operations/SymbolicOperation.cpp
+++ b/src/ir/operations/SymbolicOperation.cpp
@@ -15,6 +15,7 @@
 #include "ir/operations/Control.hpp"
 #include "ir/operations/Expression.hpp"
 #include "ir/operations/OpType.hpp"
+#include "ir/operations/Operation.hpp"
 #include "ir/operations/StandardOperation.hpp"
 
 #include <algorithm>

--- a/src/ir/operations/SymbolicOperation.cpp
+++ b/src/ir/operations/SymbolicOperation.cpp
@@ -11,6 +11,7 @@
 
 #include "Definitions.hpp"
 #include "ir/Permutation.hpp"
+#include "ir/Register.hpp"
 #include "ir/operations/Control.hpp"
 #include "ir/operations/Expression.hpp"
 #include "ir/operations/OpType.hpp"
@@ -352,12 +353,11 @@ bool SymbolicOperation::equals(const Operation& op, const Permutation& perm1,
   return true;
 }
 
-[[noreturn]] void
-SymbolicOperation::dumpOpenQASM([[maybe_unused]] std::ostream& of,
-                                [[maybe_unused]] const RegisterNames& qreg,
-                                [[maybe_unused]] const RegisterNames& creg,
-                                [[maybe_unused]] size_t indent,
-                                bool openQASM3) const {
+[[noreturn]] void SymbolicOperation::dumpOpenQASM(
+    [[maybe_unused]] std::ostream& of,
+    [[maybe_unused]] const QubitIndexToRegisterMap& qubitMap,
+    [[maybe_unused]] const BitIndexToRegisterMap& bitMap,
+    [[maybe_unused]] size_t indent, bool openQASM3) const {
   if (openQASM3) {
     throw QFRException(
         "Printing OpenQASM 3.0 parameterized gates is not supported yet!");

--- a/src/ir/parsers/QASM3Parser.cpp
+++ b/src/ir/parsers/QASM3Parser.cpp
@@ -108,17 +108,17 @@ class OpenQasm3Parser final : public InstVisitor {
     if (indexExpr != nullptr) {
       const auto result = evaluatePositiveConstant(indexExpr, debugInfo);
 
-      if (result >= qubit.second) {
+      if (result >= qubit.getSize()) {
         error("Index expression must be smaller than the width of the "
               "quantum register.",
               debugInfo);
       }
-      qubit.first += static_cast<qc::Qubit>(result);
-      qubit.second = 1;
+      qubit.getStartIndex() += static_cast<qc::Qubit>(result);
+      qubit.getSize() = 1;
     }
 
-    for (uint64_t i = 0; i < qubit.second; ++i) {
-      qubits.emplace_back(static_cast<qc::Qubit>(qubit.first + i));
+    for (uint64_t i = 0; i < qubit.getSize(); ++i) {
+      qubits.emplace_back(static_cast<qc::Qubit>(qubit.getStartIndex() + i));
     }
   }
 
@@ -126,26 +126,26 @@ class OpenQasm3Parser final : public InstVisitor {
                            const std::shared_ptr<Expression>& indexExpr,
                            std::vector<qc::Bit>& bits,
                            const std::shared_ptr<DebugInfo>& debugInfo) const {
-    const auto iter = qc->getCregs().find(bitIdentifier);
-    if (iter == qc->getCregs().end()) {
+    const auto iter = qc->getClassicalRegisters().find(bitIdentifier);
+    if (iter == qc->getClassicalRegisters().end()) {
       error("Usage of unknown classical register.", debugInfo);
     }
     auto creg = iter->second;
 
     if (indexExpr != nullptr) {
       const auto index = evaluatePositiveConstant(indexExpr, debugInfo);
-      if (index >= creg.second) {
+      if (index >= creg.getSize()) {
         error("Index expression must be smaller than the width of the "
               "classical register.",
               debugInfo);
       }
 
-      creg.first += index;
-      creg.second = 1;
+      creg.getStartIndex() += index;
+      creg.getSize() = 1;
     }
 
-    for (uint64_t i = 0; i < creg.second; ++i) {
-      bits.emplace_back(creg.first + i);
+    for (uint64_t i = 0; i < creg.getSize(); ++i) {
+      bits.emplace_back(creg.getStartIndex() + i);
     }
   }
 
@@ -365,8 +365,7 @@ public:
 
   void visitGateCallStatement(
       const std::shared_ptr<GateCallStatement> gateCallStatement) override {
-    auto qregs = qc->getQregs();
-
+    const auto& qregs = qc->getQuantumRegisters();
     if (auto op = evaluateGateCall(
             gateCallStatement, gateCallStatement->identifier,
             gateCallStatement->arguments, gateCallStatement->operands, qregs);
@@ -648,9 +647,8 @@ public:
       auto nestedQubits = qc::QuantumRegisterMap{};
       size_t index = 0;
       for (const auto& qubitIdentifier : compoundGate->targetNames) {
-        auto qubit = std::pair{targetBits[index], 1};
-
-        nestedQubits.emplace(qubitIdentifier, qubit);
+        nestedQubits.try_emplace(qubitIdentifier, targetBits[index], 1,
+                                 qubitIdentifier);
         index++;
       }
 
@@ -725,8 +723,8 @@ public:
 
     std::vector<qc::Qubit> qubits{};
     std::vector<qc::Bit> bits{};
-    translateGateOperand(measureExpression->gate, qubits, qc->getQregs(),
-                         debugInfo);
+    translateGateOperand(measureExpression->gate, qubits,
+                         qc->getQuantumRegisters(), debugInfo);
     translateBitOperand(identifier, indexExpression, bits, debugInfo);
 
     if (qubits.size() != bits.size()) {
@@ -745,12 +743,12 @@ public:
 
   void visitBarrierStatement(
       const std::shared_ptr<BarrierStatement> barrierStatement) override {
-    qc->emplace_back(getBarrierOp(barrierStatement, qc->getQregs()));
+    qc->emplace_back(getBarrierOp(barrierStatement, qc->getQuantumRegisters()));
   }
 
   void
   visitResetStatement(std::shared_ptr<ResetStatement> resetStatement) override {
-    qc->emplace_back(getResetOp(resetStatement, qc->getQregs()));
+    qc->emplace_back(getResetOp(resetStatement, qc->getQuantumRegisters()));
   }
 
   void visitIfStatement(std::shared_ptr<IfStatement> ifStatement) override {
@@ -780,8 +778,8 @@ public:
       error("Can only compare to constants.", ifStatement->debugInfo);
     }
 
-    const auto creg = qc->getCregs().find(lhs->identifier);
-    if (creg == qc->getCregs().end()) {
+    const auto creg = qc->getClassicalRegisters().find(lhs->identifier);
+    if (creg == qc->getClassicalRegisters().end()) {
       error("Usage of unknown or invalid identifier '" + lhs->identifier +
                 "' in condition.",
             ifStatement->debugInfo);
@@ -812,7 +810,7 @@ public:
         error("Only quantum statements are supported in blocks.",
               statement->debugInfo);
       }
-      const auto& qregs = qc->getQregs();
+      const auto& qregs = qc->getQuantumRegisters();
 
       auto op =
           evaluateGateCall(gateCall, gateCall->identifier, gateCall->arguments,

--- a/src/mqt/core/ir/__init__.pyi
+++ b/src/mqt/core/ir/__init__.pyi
@@ -87,6 +87,82 @@ class Permutation(MutableMapping[int, int]):
             The list of targets with the permutation applied.
         """
 
+class QuantumRegister:
+    """A class to represent a collection of qubits.
+
+    Args:
+        start: The starting index of the quantum register.
+        size: The number of qubits in the quantum register.
+        name: The name of the quantum register. A name will be generated if not provided.
+    """
+
+    def __init__(self, start: int, size: int, name: str = "") -> None: ...
+    @property
+    def start(self) -> int:
+        """The index of the first qubit in the quantum register."""
+
+    @property
+    def end(self) -> int:
+        """Index of the last qubit in the quantum register."""
+
+    @property
+    def size(self) -> int:
+        """The number of qubits in the quantum register."""
+
+    @property
+    def name(self) -> str:
+        """The name of the quantum register."""
+
+    def __eq__(self, other: object) -> bool:
+        """Check if the quantum register is equal to another quantum register."""
+
+    def __ne__(self, other: object) -> bool:
+        """Check if the quantum register is not equal to another quantum register."""
+
+    def __hash__(self) -> int:
+        """Return the hash of the quantum register."""
+
+    def __contains__(self, qubit: int) -> bool:
+        """Check if the quantum register contains a qubit."""
+
+class ClassicalRegister:
+    """A class to represent a collection of classical bits.
+
+    Args:
+        start: The starting index of the classical register.
+        size: The number of bits in the classical register.
+        name: The name of the classical register. A name will be generated if not provided.
+    """
+
+    def __init__(self, start: int, size: int, name: str = "") -> None: ...
+    @property
+    def start(self) -> int:
+        """The index of the first bit in the classical register."""
+
+    @property
+    def end(self) -> int:
+        """Index of the last bit in the classical register."""
+
+    @property
+    def size(self) -> int:
+        """The number of bits in the classical register."""
+
+    @property
+    def name(self) -> str:
+        """The name of the classical register."""
+
+    def __eq__(self, other: object) -> bool:
+        """Check if the classical register is equal to another classical register."""
+
+    def __ne__(self, other: object) -> bool:
+        """Check if the classical register is not equal to another classical register."""
+
+    def __hash__(self) -> int:
+        """Return the hash of the classical register."""
+
+    def __contains__(self, bit: int) -> bool:
+        """Check if the classical register contains a bit."""
+
 class QuantumComputation(MutableSequence[Operation]):
     """The main class for representing quantum computations within the MQT.
 
@@ -305,12 +381,15 @@ class QuantumComputation(MutableSequence[Operation]):
             name: The name of the ancillary register.
         """
 
-    def add_classical_register(self, n: int, name: str = "c") -> None:
+    def add_classical_register(self, n: int, name: str = "c") -> ClassicalRegister:
         """Add a classical register to the quantum computation.
 
         Args:
             n: The number of bits in the classical register.
             name: The name of the classical register.
+
+        Returns:
+            The classical register added to the quantum computation.
         """
 
     def add_qubit_register(self, n: int, name: str = "q") -> None:
@@ -1762,15 +1841,6 @@ class QuantumComputation(MutableSequence[Operation]):
         """
 
     @overload
-    def measure(self, qubit: int, creg_bit: tuple[str, int]) -> None:
-        """Measure a qubit and store the result in a bit of a classical register.
-
-        Args:
-            qubit: The qubit to measure
-            creg_bit: The classical register and index to store the result
-        """
-
-    @overload
     def measure(self, qubits: Sequence[int], cbits: Sequence[int]) -> None:
         """Measure multiple qubits and store the results in classical bits.
 
@@ -1899,6 +1969,8 @@ class QuantumComputation(MutableSequence[Operation]):
         """
 
 __all__ = [
+    "ClassicalRegister",
     "Permutation",
     "QuantumComputation",
+    "QuantumRegister",
 ]

--- a/src/mqt/core/ir/__init__.pyi
+++ b/src/mqt/core/ir/__init__.pyi
@@ -1906,7 +1906,7 @@ class QuantumComputation(MutableSequence[Operation]):
         self,
         op: OpType,
         target: int,
-        creg: tuple[int, int],
+        creg: ClassicalRegister,
         expected_value: int = 1,
         comparison_kind: ComparisonKind = ComparisonKind.eq,
         params: Sequence[float] = (),
@@ -1916,7 +1916,7 @@ class QuantumComputation(MutableSequence[Operation]):
         Args:
             op: The operation to apply
             target: The target qubit
-            creg: The classical register (index and number of bits)
+            creg: The classical register
             expected_value: The expected value of the classical register
             comparison_kind: The kind of comparison to perform
             params: The parameters of the operation
@@ -1928,7 +1928,7 @@ class QuantumComputation(MutableSequence[Operation]):
         op: OpType,
         target: int,
         control: Control | int,
-        creg: tuple[int, int],
+        creg: ClassicalRegister,
         expected_value: int = 1,
         comparison_kind: ComparisonKind = ComparisonKind.eq,
         params: Sequence[float] = (),
@@ -1939,7 +1939,7 @@ class QuantumComputation(MutableSequence[Operation]):
             op: The operation to apply
             target: The target qubit
             control: The control qubit
-            creg: The classical register (index and number of bits)
+            creg: The classical register
             expected_value: The expected value of the classical register
             comparison_kind: The kind of comparison to perform
             params: The parameters of the operation
@@ -1951,7 +1951,7 @@ class QuantumComputation(MutableSequence[Operation]):
         op: OpType,
         target: int,
         controls: set[Control | int],
-        creg: tuple[int, int],
+        creg: ClassicalRegister,
         expected_value: int = 1,
         comparison_kind: ComparisonKind = ComparisonKind.eq,
         params: Sequence[float] = (),
@@ -1962,7 +1962,74 @@ class QuantumComputation(MutableSequence[Operation]):
             op: The operation to apply
             target: The target qubit
             controls: The control qubits
-            creg: The classical register (index and number of bits)
+            creg: The classical register
+            expected_value: The expected value of the classical register
+            comparison_kind: The kind of comparison to perform
+            params: The parameters of the operation
+        """
+
+    @overload
+    def classic_controlled(
+        self,
+        op: OpType,
+        target: int,
+        cbit: int,
+        expected_value: int = 1,
+        comparison_kind: ComparisonKind = ComparisonKind.eq,
+        params: Sequence[float] = (),
+    ) -> None:
+        """Add a classic-controlled operation to the circuit.
+
+        Args:
+            op: The operation to apply
+            target: The target qubit
+            cbit: The classical bit index
+            expected_value: The expected value of the classical register
+            comparison_kind: The kind of comparison to perform
+            params: The parameters of the operation
+        """
+
+    @overload
+    def classic_controlled(
+        self,
+        op: OpType,
+        target: int,
+        control: Control | int,
+        cbit: int,
+        expected_value: int = 1,
+        comparison_kind: ComparisonKind = ComparisonKind.eq,
+        params: Sequence[float] = (),
+    ) -> None:
+        """Add a classic-controlled operation to the circuit.
+
+        Args:
+            op: The operation to apply
+            target: The target qubit
+            control: The control qubit
+            cbit: The classical bit index
+            expected_value: The expected value of the classical register
+            comparison_kind: The kind of comparison to perform
+            params: The parameters of the operation
+        """
+
+    @overload
+    def classic_controlled(
+        self,
+        op: OpType,
+        target: int,
+        controls: set[Control | int],
+        cbit: int,
+        expected_value: int = 1,
+        comparison_kind: ComparisonKind = ComparisonKind.eq,
+        params: Sequence[float] = (),
+    ) -> None:
+        """Add a classic-controlled operation to the circuit.
+
+        Args:
+            op: The operation to apply
+            target: The target qubit
+            controls: The control qubits
+            cbit: The classical bit index
             expected_value: The expected value of the classical register
             comparison_kind: The kind of comparison to perform
             params: The parameters of the operation

--- a/src/mqt/core/ir/__init__.pyi
+++ b/src/mqt/core/ir/__init__.pyi
@@ -12,7 +12,13 @@ from os import PathLike
 from typing import overload
 
 from .operations import ComparisonKind, Control, Operation, OpType
+from .registers import ClassicalRegister
 from .symbolic import Expression, Variable
+
+__all__ = [
+    "Permutation",
+    "QuantumComputation",
+]
 
 class Permutation(MutableMapping[int, int]):
     """A class to represent a permutation of the qubits in a quantum circuit.
@@ -86,82 +92,6 @@ class Permutation(MutableMapping[int, int]):
         Returns:
             The list of targets with the permutation applied.
         """
-
-class QuantumRegister:
-    """A class to represent a collection of qubits.
-
-    Args:
-        start: The starting index of the quantum register.
-        size: The number of qubits in the quantum register.
-        name: The name of the quantum register. A name will be generated if not provided.
-    """
-
-    def __init__(self, start: int, size: int, name: str = "") -> None: ...
-    @property
-    def start(self) -> int:
-        """The index of the first qubit in the quantum register."""
-
-    @property
-    def end(self) -> int:
-        """Index of the last qubit in the quantum register."""
-
-    @property
-    def size(self) -> int:
-        """The number of qubits in the quantum register."""
-
-    @property
-    def name(self) -> str:
-        """The name of the quantum register."""
-
-    def __eq__(self, other: object) -> bool:
-        """Check if the quantum register is equal to another quantum register."""
-
-    def __ne__(self, other: object) -> bool:
-        """Check if the quantum register is not equal to another quantum register."""
-
-    def __hash__(self) -> int:
-        """Return the hash of the quantum register."""
-
-    def __contains__(self, qubit: int) -> bool:
-        """Check if the quantum register contains a qubit."""
-
-class ClassicalRegister:
-    """A class to represent a collection of classical bits.
-
-    Args:
-        start: The starting index of the classical register.
-        size: The number of bits in the classical register.
-        name: The name of the classical register. A name will be generated if not provided.
-    """
-
-    def __init__(self, start: int, size: int, name: str = "") -> None: ...
-    @property
-    def start(self) -> int:
-        """The index of the first bit in the classical register."""
-
-    @property
-    def end(self) -> int:
-        """Index of the last bit in the classical register."""
-
-    @property
-    def size(self) -> int:
-        """The number of bits in the classical register."""
-
-    @property
-    def name(self) -> str:
-        """The name of the classical register."""
-
-    def __eq__(self, other: object) -> bool:
-        """Check if the classical register is equal to another classical register."""
-
-    def __ne__(self, other: object) -> bool:
-        """Check if the classical register is not equal to another classical register."""
-
-    def __hash__(self) -> int:
-        """Return the hash of the classical register."""
-
-    def __contains__(self, bit: int) -> bool:
-        """Check if the classical register contains a bit."""
 
 class QuantumComputation(MutableSequence[Operation]):
     """The main class for representing quantum computations within the MQT.
@@ -2034,10 +1964,3 @@ class QuantumComputation(MutableSequence[Operation]):
             comparison_kind: The kind of comparison to perform
             params: The parameters of the operation
         """
-
-__all__ = [
-    "ClassicalRegister",
-    "Permutation",
-    "QuantumComputation",
-    "QuantumRegister",
-]

--- a/src/mqt/core/ir/operations.pyi
+++ b/src/mqt/core/ir/operations.pyi
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from typing import ClassVar, overload
 
+from . import ClassicalRegister
 from .symbolic import Expression, Variable
 
 class Control:
@@ -882,10 +883,19 @@ class ClassicControlledOperation(Operation):
         comparison_kind: The kind of comparison (default is equality).
     """
 
+    @overload
     def __init__(
         self,
         operation: Operation,
-        control_register: tuple[int, int],
+        control_register: ClassicalRegister,
+        expected_value: int = 1,
+        comparison_kind: ComparisonKind = ...,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        operation: Operation,
+        control_bit: int,
         expected_value: int = 1,
         comparison_kind: ComparisonKind = ...,
     ) -> None: ...

--- a/src/mqt/core/ir/operations.pyi
+++ b/src/mqt/core/ir/operations.pyi
@@ -9,8 +9,20 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from typing import ClassVar, overload
 
-from . import ClassicalRegister
+from .registers import ClassicalRegister
 from .symbolic import Expression, Variable
+
+__all__ = [
+    "ClassicControlledOperation",
+    "ComparisonKind",
+    "CompoundOperation",
+    "Control",
+    "NonUnitaryOperation",
+    "OpType",
+    "Operation",
+    "StandardOperation",
+    "SymbolicOperation",
+]
 
 class Control:
     """A control is a pair of a qubit and a type. The type can be either positive or negative.
@@ -904,14 +916,12 @@ class ClassicControlledOperation(Operation):
         """The operation that is classically controlled."""
 
     @property
-    def control_register(self) -> tuple[int, int]:
-        """The classical register that controls the operation.
+    def control_register(self) -> ClassicalRegister | None:
+        """The classical register that controls the operation."""
 
-        The register is specified as a tuple of the start index and the length.
-
-        Examples:
-            A register that starts at index 0 and has a length of 2 is specified as ``(0, 2)``.
-        """
+    @property
+    def control_bit(self) -> int | None:
+        """The classical bit that controls the operation."""
 
     @property
     def expected_value(self) -> int:

--- a/src/mqt/core/ir/registers.pyi
+++ b/src/mqt/core/ir/registers.pyi
@@ -1,0 +1,84 @@
+# Copyright (c) 2025 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+__all__ = ["ClassicalRegister", "QuantumRegister"]
+
+class QuantumRegister:
+    """A class to represent a collection of qubits.
+
+    Args:
+        start: The starting index of the quantum register.
+        size: The number of qubits in the quantum register.
+        name: The name of the quantum register. A name will be generated if not provided.
+    """
+
+    def __init__(self, start: int, size: int, name: str = "") -> None: ...
+    @property
+    def start(self) -> int:
+        """The index of the first qubit in the quantum register."""
+
+    @property
+    def end(self) -> int:
+        """Index of the last qubit in the quantum register."""
+
+    @property
+    def size(self) -> int:
+        """The number of qubits in the quantum register."""
+
+    @property
+    def name(self) -> str:
+        """The name of the quantum register."""
+
+    def __eq__(self, other: object) -> bool:
+        """Check if the quantum register is equal to another quantum register."""
+
+    def __ne__(self, other: object) -> bool:
+        """Check if the quantum register is not equal to another quantum register."""
+
+    def __hash__(self) -> int:
+        """Return the hash of the quantum register."""
+
+    def __contains__(self, qubit: int) -> bool:
+        """Check if the quantum register contains a qubit."""
+
+class ClassicalRegister:
+    """A class to represent a collection of classical bits.
+
+    Args:
+        start: The starting index of the classical register.
+        size: The number of bits in the classical register.
+        name: The name of the classical register. A name will be generated if not provided.
+    """
+
+    def __init__(self, start: int, size: int, name: str = "") -> None: ...
+    @property
+    def start(self) -> int:
+        """The index of the first bit in the classical register."""
+
+    @property
+    def end(self) -> int:
+        """Index of the last bit in the classical register."""
+
+    @property
+    def size(self) -> int:
+        """The number of bits in the classical register."""
+
+    @property
+    def name(self) -> str:
+        """The name of the classical register."""
+
+    def __eq__(self, other: object) -> bool:
+        """Check if the classical register is equal to another classical register."""
+
+    def __ne__(self, other: object) -> bool:
+        """Check if the classical register is not equal to another classical register."""
+
+    def __hash__(self) -> int:
+        """Return the hash of the classical register."""
+
+    def __contains__(self, bit: int) -> bool:
+        """Check if the classical register contains a bit."""

--- a/src/mqt/core/ir/symbolic.pyi
+++ b/src/mqt/core/ir/symbolic.pyi
@@ -8,6 +8,8 @@
 from collections.abc import Iterator, Mapping, Sequence
 from typing import overload
 
+__all__ = ["Expression", "Term", "Variable"]
+
 class Variable:
     """A symbolic variable.
 

--- a/src/python/ir/operations/register_classic_controlled_operation.cpp
+++ b/src/python/ir/operations/register_classic_controlled_operation.cpp
@@ -35,14 +35,21 @@ void registerClassicControlledOperation(py::module& m) {
   auto ccop = py::class_<qc::ClassicControlledOperation, qc::Operation>(
       m, "ClassicControlledOperation");
 
-  ccop.def(
-      py::init([](qc::Operation* operation, qc::ClassicalRegister controlReg,
-                  std::uint64_t expectedVal, qc::ComparisonKind cmp) {
-        return std::make_unique<qc::ClassicControlledOperation>(
-            operation->clone(), controlReg, expectedVal, cmp);
-      }),
-      "operation"_a, "control_register"_a, "expected_value"_a = 1U,
-      "comparison_kind"_a = qc::ComparisonKind::Eq);
+  ccop.def(py::init([](qc::Operation* operation,
+                       const qc::ClassicalRegister& controlReg,
+                       std::uint64_t expectedVal, qc::ComparisonKind cmp) {
+             return std::make_unique<qc::ClassicControlledOperation>(
+                 operation->clone(), controlReg, expectedVal, cmp);
+           }),
+           "operation"_a, "control_register"_a, "expected_value"_a = 1U,
+           "comparison_kind"_a = qc::ComparisonKind::Eq);
+  ccop.def(py::init([](qc::Operation* operation, qc::Bit cBit,
+                       std::uint64_t expectedVal, qc::ComparisonKind cmp) {
+             return std::make_unique<qc::ClassicControlledOperation>(
+                 operation->clone(), cBit, expectedVal, cmp);
+           }),
+           "operation"_a, "control_bit"_a, "expected_value"_a = 1U,
+           "comparison_kind"_a = qc::ComparisonKind::Eq);
   ccop.def_property_readonly("operation",
                              &qc::ClassicControlledOperation::getOperation,
                              py::return_value_policy::reference_internal);
@@ -54,11 +61,17 @@ void registerClassicControlledOperation(py::module& m) {
       "comparison_kind", &qc::ClassicControlledOperation::getComparisonKind);
   ccop.def("__repr__", [](const qc::ClassicControlledOperation& op) {
     std::stringstream ss;
-    const auto& controlReg = op.getControlRegister();
-    ss << "ClassicControlledOperation(<...op...>, "
-       << "control_register=(" << controlReg.first << ", " << controlReg.second
-       << "), "
-       << "expected_value=" << op.getExpectedValue() << ", "
+    ss << "ClassicControlledOperation(<...op...>, ";
+    if (const auto& controlReg = op.getControlRegister();
+        controlReg.has_value()) {
+      ss << "control_register=ClassicalRegister(" << controlReg->getSize()
+         << ", " << controlReg->getStartIndex() << ", " << controlReg->getName()
+         << "), ";
+    }
+    if (const auto& controlBit = op.getControlBit(); controlBit.has_value()) {
+      ss << "control_bit=" << controlBit.value() << ", ";
+    }
+    ss << "expected_value=" << op.getExpectedValue() << ", "
        << "comparison_kind='" << op.getComparisonKind() << "')";
     return ss.str();
   });

--- a/src/python/ir/operations/register_classic_controlled_operation.cpp
+++ b/src/python/ir/operations/register_classic_controlled_operation.cpp
@@ -55,6 +55,8 @@ void registerClassicControlledOperation(const py::module& m) {
                              py::return_value_policy::reference_internal);
   ccop.def_property_readonly(
       "control_register", &qc::ClassicControlledOperation::getControlRegister);
+  ccop.def_property_readonly("control_bit",
+                             &qc::ClassicControlledOperation::getControlBit);
   ccop.def_property_readonly("expected_value",
                              &qc::ClassicControlledOperation::getExpectedValue);
   ccop.def_property_readonly(

--- a/src/python/ir/operations/register_classic_controlled_operation.cpp
+++ b/src/python/ir/operations/register_classic_controlled_operation.cpp
@@ -18,7 +18,7 @@
 
 namespace mqt {
 
-void registerClassicControlledOperation(py::module& m) {
+void registerClassicControlledOperation(const py::module& m) {
   py::enum_<qc::ComparisonKind>(m, "ComparisonKind")
       .value("eq", qc::ComparisonKind::Eq)
       .value("neq", qc::ComparisonKind::Neq)
@@ -35,7 +35,7 @@ void registerClassicControlledOperation(py::module& m) {
   auto ccop = py::class_<qc::ClassicControlledOperation, qc::Operation>(
       m, "ClassicControlledOperation");
 
-  ccop.def(py::init([](qc::Operation* operation,
+  ccop.def(py::init([](const qc::Operation* operation,
                        const qc::ClassicalRegister& controlReg,
                        std::uint64_t expectedVal, qc::ComparisonKind cmp) {
              return std::make_unique<qc::ClassicControlledOperation>(
@@ -43,7 +43,7 @@ void registerClassicControlledOperation(py::module& m) {
            }),
            "operation"_a, "control_register"_a, "expected_value"_a = 1U,
            "comparison_kind"_a = qc::ComparisonKind::Eq);
-  ccop.def(py::init([](qc::Operation* operation, qc::Bit cBit,
+  ccop.def(py::init([](const qc::Operation* operation, qc::Bit cBit,
                        std::uint64_t expectedVal, qc::ComparisonKind cmp) {
              return std::make_unique<qc::ClassicControlledOperation>(
                  operation->clone(), cBit, expectedVal, cmp);

--- a/src/python/ir/operations/register_compound_operation.cpp
+++ b/src/python/ir/operations/register_compound_operation.cpp
@@ -22,7 +22,7 @@ namespace mqt {
 using DiffType = std::vector<std::unique_ptr<qc::Operation>>::difference_type;
 using SizeType = std::vector<std::unique_ptr<qc::Operation>>::size_type;
 
-void registerCompoundOperation(py::module& m) {
+void registerCompoundOperation(const py::module& m) {
   auto wrap = [](DiffType i, const SizeType size) {
     if (i < 0) {
       i += static_cast<DiffType>(size);
@@ -35,7 +35,7 @@ void registerCompoundOperation(py::module& m) {
 
   py::class_<qc::CompoundOperation, qc::Operation>(m, "CompoundOperation")
       .def(py::init<>())
-      .def(py::init([](std::vector<qc::Operation*>& ops) {
+      .def(py::init([](const std::vector<qc::Operation*>& ops) {
              std::vector<std::unique_ptr<qc::Operation>> uniqueOps;
              uniqueOps.reserve(ops.size());
              for (auto& op : ops) {
@@ -54,7 +54,7 @@ void registerCompoundOperation(py::module& m) {
           py::return_value_policy::reference_internal, "i"_a)
       .def(
           "__getitem__",
-          [](qc::CompoundOperation& op, const py::slice& slice) {
+          [](const qc::CompoundOperation& op, const py::slice& slice) {
             std::size_t start{};
             std::size_t stop{};
             std::size_t step{};

--- a/src/python/ir/operations/register_control.cpp
+++ b/src/python/ir/operations/register_control.cpp
@@ -15,7 +15,7 @@
 
 namespace mqt {
 
-void registerControl(py::module& m) {
+void registerControl(const py::module& m) {
 
   auto control = py::class_<qc::Control>(m, "Control");
   auto controlType = py::enum_<qc::Control::Type>(control, "Type");

--- a/src/python/ir/operations/register_non_unitary_operation.cpp
+++ b/src/python/ir/operations/register_non_unitary_operation.cpp
@@ -18,7 +18,7 @@
 
 namespace mqt {
 
-void registerNonUnitaryOperation(py::module& m) {
+void registerNonUnitaryOperation(const py::module& m) {
   py::class_<qc::NonUnitaryOperation, qc::Operation>(m, "NonUnitaryOperation")
       .def(py::init<std::vector<qc::Qubit>, std::vector<qc::Bit>>(),
            "targets"_a, "classics"_a)

--- a/src/python/ir/operations/register_operation.cpp
+++ b/src/python/ir/operations/register_operation.cpp
@@ -15,7 +15,7 @@
 
 namespace mqt {
 
-void registerOperation(py::module& m) {
+void registerOperation(const py::module& m) {
   py::class_<qc::Operation>(m, "Operation")
       .def_property_readonly("name", &qc::Operation::getName)
       .def_property("type_", &qc::Operation::getType, &qc::Operation::setGate)

--- a/src/python/ir/operations/register_optype.cpp
+++ b/src/python/ir/operations/register_optype.cpp
@@ -14,7 +14,7 @@
 
 namespace mqt {
 
-void registerOptype(py::module& m) {
+void registerOptype(const py::module& m) {
   py::enum_<qc::OpType>(m, "OpType")
       .value("none", qc::OpType::None)
       .value("gphase", qc::OpType::GPhase)

--- a/src/python/ir/operations/register_standard_operation.cpp
+++ b/src/python/ir/operations/register_standard_operation.cpp
@@ -19,7 +19,7 @@
 
 namespace mqt {
 
-void registerStandardOperation(py::module& m) {
+void registerStandardOperation(const py::module& m) {
   py::class_<qc::StandardOperation, qc::Operation>(m, "StandardOperation")
       .def(py::init<>())
       .def(py::init<qc::Qubit, qc::OpType, std::vector<qc::fp>>(), "target"_a,

--- a/src/python/ir/operations/register_symbolic_operation.cpp
+++ b/src/python/ir/operations/register_symbolic_operation.cpp
@@ -19,7 +19,7 @@
 
 namespace mqt {
 
-void registerSymbolicOperation(py::module& m) {
+void registerSymbolicOperation(const py::module& m) {
   py::class_<qc::SymbolicOperation, qc::StandardOperation>(
       m, "SymbolicOperation",
       "Class representing a symbolic operation."

--- a/src/python/ir/register_ir.cpp
+++ b/src/python/ir/register_ir.cpp
@@ -23,7 +23,8 @@ void registerQuantumComputation(py::module& m);
 
 PYBIND11_MODULE(ir, m, py::mod_gil_not_used()) {
   registerPermutation(m);
-  registerRegisters(m);
+  py::module registers = m.def_submodule("registers");
+  registerRegisters(registers);
 
   py::module symbolic = m.def_submodule("symbolic");
   registerSymbolic(symbolic);

--- a/src/python/ir/register_ir.cpp
+++ b/src/python/ir/register_ir.cpp
@@ -15,6 +15,7 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 // forward declarations
+void registerRegisters(py::module& m);
 void registerPermutation(py::module& m);
 void registerOperations(py::module& m);
 void registerSymbolic(py::module& m);
@@ -22,6 +23,7 @@ void registerQuantumComputation(py::module& m);
 
 PYBIND11_MODULE(ir, m, py::mod_gil_not_used()) {
   registerPermutation(m);
+  registerRegisters(m);
 
   py::module symbolic = m.def_submodule("symbolic");
   registerSymbolic(symbolic);

--- a/src/python/ir/register_operations.cpp
+++ b/src/python/ir/register_operations.cpp
@@ -12,14 +12,14 @@
 namespace mqt {
 
 // forward declarations
-void registerOptype(py::module& m);
-void registerControl(py::module& m);
-void registerOperation(py::module& m);
-void registerStandardOperation(py::module& m);
-void registerCompoundOperation(py::module& m);
-void registerNonUnitaryOperation(py::module& m);
-void registerSymbolicOperation(py::module& m);
-void registerClassicControlledOperation(py::module& m);
+void registerOptype(const py::module& m);
+void registerControl(const py::module& m);
+void registerOperation(const py::module& m);
+void registerStandardOperation(const py::module& m);
+void registerCompoundOperation(const py::module& m);
+void registerNonUnitaryOperation(const py::module& m);
+void registerSymbolicOperation(const py::module& m);
+void registerClassicControlledOperation(const py::module& m);
 
 void registerOperations(py::module& m) {
   registerOptype(m);

--- a/src/python/ir/register_quantum_computation.cpp
+++ b/src/python/ir/register_quantum_computation.cpp
@@ -385,10 +385,6 @@ void registerQuantumComputation(py::module& m) {
              &qc::QuantumComputation::measure),
          "qubit"_a, "cbit"_a);
   qc.def("measure",
-         py::overload_cast<qc::Qubit, const std::pair<std::string, qc::Bit>&>(
-             &qc::QuantumComputation::measure),
-         "qubit"_a, "creg_bit"_a);
-  qc.def("measure",
          py::overload_cast<const std::vector<qc::Qubit>&,
                            const std::vector<qc::Bit>&>(
              &qc::QuantumComputation::measure),

--- a/src/python/ir/register_quantum_computation.cpp
+++ b/src/python/ir/register_quantum_computation.cpp
@@ -432,5 +432,31 @@ void registerQuantumComputation(py::module& m) {
       "op"_a, "target"_a, "controls"_a, "creg"_a, "expected_value"_a = 1U,
       "comparison_kind"_a = qc::ComparisonKind::Eq,
       "params"_a = std::vector<qc::fp>{});
+  qc.def("classic_controlled",
+         py::overload_cast<const qc::OpType, const qc::Qubit, const qc::Bit,
+                           const std::uint64_t, const qc::ComparisonKind,
+                           const std::vector<qc::fp>&>(
+             &qc::QuantumComputation::classicControlled),
+         "op"_a, "target"_a, "cbit"_a, "expected_value"_a = 1U,
+         "comparison_kind"_a = qc::ComparisonKind::Eq,
+         "params"_a = std::vector<qc::fp>{});
+  qc.def(
+      "classic_controlled",
+      py::overload_cast<const qc::OpType, const qc::Qubit, const qc::Control,
+                        const qc::Bit, const std::uint64_t,
+                        const qc::ComparisonKind, const std::vector<qc::fp>&>(
+          &qc::QuantumComputation::classicControlled),
+      "op"_a, "target"_a, "control"_a, "cbit"_a, "expected_value"_a = 1U,
+      "comparison_kind"_a = qc::ComparisonKind::Eq,
+      "params"_a = std::vector<qc::fp>{});
+  qc.def(
+      "classic_controlled",
+      py::overload_cast<const qc::OpType, const qc::Qubit, const qc::Controls&,
+                        const qc::Bit, const std::uint64_t,
+                        const qc::ComparisonKind, const std::vector<qc::fp>&>(
+          &qc::QuantumComputation::classicControlled),
+      "op"_a, "target"_a, "controls"_a, "cbit"_a, "expected_value"_a = 1U,
+      "comparison_kind"_a = qc::ComparisonKind::Eq,
+      "params"_a = std::vector<qc::fp>{});
 }
 } // namespace mqt

--- a/src/python/ir/register_registers.cpp
+++ b/src/python/ir/register_registers.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Chair for Design Automation, TUM
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "Definitions.hpp"
+#include "ir/Register.hpp"
+#include "python/pybind11.hpp"
+
+#include <pybind11/operators.h>
+
+namespace mqt {
+
+void registerRegisters(py::module& m) {
+  py::class_<qc::QuantumRegister>(m, "QuantumRegister")
+      .def(py::init<const qc::Qubit, const std::size_t, const std::string&>(),
+           "start"_a, "size"_a, "name"_a = "")
+      .def_property_readonly("name", &qc::QuantumRegister::getName)
+      .def_property(
+          "start",
+          [](const qc::QuantumRegister& reg) { return reg.getStartIndex(); },
+          [](qc::QuantumRegister& reg, const qc::Qubit start) {
+            reg.getStartIndex() = start;
+          })
+      .def_property(
+          "size", [](const qc::QuantumRegister& reg) { return reg.getSize(); },
+          [](qc::QuantumRegister& reg, const std::size_t size) {
+            reg.getSize() = size;
+          })
+      .def_property_readonly("end", &qc::QuantumRegister::getEndIndex)
+      .def(py::self == py::self)
+      .def(py::self != py::self)
+      .def(hash(py::self))
+      .def("__contains__", &qc::QuantumRegister::contains)
+      .def("__repr__", [](const qc::QuantumRegister& reg) {
+        return "QuantumRegister(name=" + reg.getName() +
+               ", start=" + std::to_string(reg.getStartIndex()) +
+               ", size=" + std::to_string(reg.getSize()) + ")";
+      });
+
+  py::class_<qc::ClassicalRegister>(m, "ClassicalRegister")
+      .def(py::init<const qc::Bit, const std::size_t, const std::string&>(),
+           "start"_a, "size"_a, "name"_a = "")
+      .def_property_readonly("name", &qc::ClassicalRegister::getName)
+      .def_property(
+          "start",
+          [](const qc::ClassicalRegister& reg) { return reg.getStartIndex(); },
+          [](qc::ClassicalRegister& reg, const qc::Bit start) {
+            reg.getStartIndex() = start;
+          })
+      .def_property(
+          "size",
+          [](const qc::ClassicalRegister& reg) { return reg.getSize(); },
+          [](qc::ClassicalRegister& reg, const std::size_t size) {
+            reg.getSize() = size;
+          })
+      .def_property_readonly("end", &qc::ClassicalRegister::getEndIndex)
+      .def(py::self == py::self)
+      .def(py::self != py::self)
+      .def(hash(py::self))
+      .def("__contains__", &qc::ClassicalRegister::contains)
+      .def("__repr__", [](const qc::ClassicalRegister& reg) {
+        return "ClassicalRegister(name=" + reg.getName() +
+               ", start=" + std::to_string(reg.getStartIndex()) +
+               ", size=" + std::to_string(reg.getSize()) + ")";
+      });
+}
+
+} // namespace mqt

--- a/test/algorithms/eval_dynamic_circuits.cpp
+++ b/test/algorithms/eval_dynamic_circuits.cpp
@@ -446,8 +446,8 @@ protected:
     bvNgates = bv.getNindividualOps();
 
     const auto expected = bv.getName().substr(3);
-    dbv =
-        qc::createIterativeBernsteinVazirani(qc::BitString(expected), bitwidth);
+    dbv = qc::createIterativeBernsteinVazirani(qc::BVBitString(expected),
+                                               bitwidth);
     dbvNgates = dbv.getNindividualOps();
     std::cout << "Hidden bitstring: " << expected << " (" << bitwidth
               << " qubits)\n";

--- a/test/algorithms/test_bernsteinvazirani.cpp
+++ b/test/algorithms/test_bernsteinvazirani.cpp
@@ -7,7 +7,6 @@
  * Licensed under the MIT License
  */
 
-#include "Definitions.hpp"
 #include "algorithms/BernsteinVazirani.hpp"
 #include "circuit_optimizer/CircuitOptimizer.hpp"
 #include "dd/Package.hpp"

--- a/test/algorithms/test_bernsteinvazirani.cpp
+++ b/test/algorithms/test_bernsteinvazirani.cpp
@@ -44,7 +44,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(BernsteinVazirani, FunctionTest) {
   // get hidden bitstring
-  auto s = qc::BitString(GetParam());
+  auto s = qc::BVBitString(GetParam());
 
   // construct Bernstein Vazirani circuit
   const auto qc = qc::createBernsteinVazirani(s);
@@ -63,7 +63,7 @@ TEST_P(BernsteinVazirani, FunctionTest) {
 
 TEST_P(BernsteinVazirani, FunctionTestDynamic) {
   // get hidden bitstring
-  const auto s = qc::BitString(GetParam());
+  const auto s = qc::BVBitString(GetParam());
 
   // construct Bernstein Vazirani circuit
   const auto qc = qc::createIterativeBernsteinVazirani(s);
@@ -112,7 +112,7 @@ TEST_F(BernsteinVazirani, DynamicCircuit) {
 
 TEST_P(BernsteinVazirani, DynamicEquivalenceSimulation) {
   // get hidden bitstring
-  const auto s = qc::BitString(GetParam());
+  const auto s = qc::BVBitString(GetParam());
 
   // create standard BV circuit
   auto bv = qc::createBernsteinVazirani(s);

--- a/test/algorithms/test_grover.cpp
+++ b/test/algorithms/test_grover.cpp
@@ -46,7 +46,7 @@ protected:
     // parse expected result from circuit name
     const auto& name = qc.getName();
     expected = name.substr(name.find_last_of('_') + 1);
-    targetValue = qc::BitString(expected);
+    targetValue = qc::GroverBitString(expected);
   }
 
   qc::Qubit nqubits = 0;
@@ -56,7 +56,7 @@ protected:
   qc::VectorDD sim{};
   qc::MatrixDD func{};
   std::string expected;
-  qc::BitString targetValue;
+  qc::GroverBitString targetValue;
 };
 
 constexpr qc::Qubit GROVER_MAX_QUBITS = 15;

--- a/test/circuit_optimizer/test_defer_measurements.cpp
+++ b/test/circuit_optimizer/test_defer_measurements.cpp
@@ -34,10 +34,10 @@ TEST(DeferMeasurements, basicTest) {
 
   QuantumComputation qc{};
   qc.addQubitRegister(2);
-  qc.addClassicalRegister(1);
+  const auto& creg = qc.addClassicalRegister(1);
   qc.h(0);
   qc.measure(0, 0U);
-  qc.classicControlled(qc::X, 1, 0, 1U);
+  qc.classicControlled(qc::X, 1, creg, 1U);
   std::cout << qc << "\n";
 
   EXPECT_TRUE(qc.isDynamic());
@@ -408,6 +408,35 @@ TEST(DeferMeasurements, errorOnImplicitReset) {
   qc.h(0);
   qc.measure(0, 0U);
   qc.classicControlled(qc::X, 0, 0, 1U);
+  std::cout << qc << "\n";
+
+  EXPECT_TRUE(qc.isDynamic());
+
+  EXPECT_THROW(CircuitOptimizer::deferMeasurements(qc), qc::QFRException);
+}
+
+TEST(DeferMeasurements, errorOnMultiQubitRegister) {
+  // Input:
+  // i: 0 1 2
+  // 1: x | |
+  // 2: | x |
+  // 3: 0 | |
+  // 4: | 1 |
+  // 5: | | x c[0...1] == 3
+  // o: 0 1 2
+
+  // Expected Output:
+  // Error, since the classic-controlled operation is controlled by a register
+  // of more than one bit.
+
+  QuantumComputation qc{};
+  qc.addQubitRegister(3);
+  const auto& creg = qc.addClassicalRegister(2);
+  qc.x(0);
+  qc.x(1);
+  qc.measure(0, 0U);
+  qc.measure(1, 1U);
+  qc.classicControlled(qc::X, 2, creg, 3U);
   std::cout << qc << "\n";
 
   EXPECT_TRUE(qc.isDynamic());

--- a/test/circuit_optimizer/test_defer_measurements.cpp
+++ b/test/circuit_optimizer/test_defer_measurements.cpp
@@ -37,7 +37,7 @@ TEST(DeferMeasurements, basicTest) {
   qc.addClassicalRegister(1);
   qc.h(0);
   qc.measure(0, 0U);
-  qc.classicControlled(qc::X, 1, {0, 1U}, 1U);
+  qc.classicControlled(qc::X, 1, 0, 1U);
   std::cout << qc << "\n";
 
   EXPECT_TRUE(qc.isDynamic());
@@ -102,7 +102,7 @@ TEST(DeferMeasurements, measurementBetweenMeasurementAndClassic) {
   qc.h(0);
   qc.measure(0, 0U);
   qc.h(0);
-  qc.classicControlled(qc::X, 1, {0, 1U}, 1U);
+  qc.classicControlled(qc::X, 1, 0, 1U);
   std::cout << qc << "\n";
 
   EXPECT_TRUE(qc.isDynamic());
@@ -176,8 +176,8 @@ TEST(DeferMeasurements, twoClassic) {
   qc.h(0);
   qc.measure(0, 0U);
   qc.h(0);
-  qc.classicControlled(qc::X, 1, {0, 1U}, 1U);
-  qc.classicControlled(qc::Z, 1, {0, 1U}, 1U);
+  qc.classicControlled(qc::X, 1, 0, 1U);
+  qc.classicControlled(qc::Z, 1, 0, 1U);
 
   std::cout << qc << "\n";
 
@@ -259,7 +259,7 @@ TEST(DeferMeasurements, correctOrder) {
   qc.h(0);
   qc.measure(0, 0U);
   qc.h(1);
-  qc.classicControlled(qc::X, 1, {0, 1U}, 1U);
+  qc.classicControlled(qc::X, 1, 0, 1U);
   std::cout << qc << "\n";
 
   EXPECT_TRUE(qc.isDynamic());
@@ -333,8 +333,8 @@ TEST(DeferMeasurements, twoClassicCorrectOrder) {
   qc.h(0);
   qc.measure(0, 0U);
   qc.h(1);
-  qc.classicControlled(qc::X, 1, {0, 1U}, 1U);
-  qc.classicControlled(qc::Z, 1, {0, 1U}, 1U);
+  qc.classicControlled(qc::X, 1, 0, 1U);
+  qc.classicControlled(qc::Z, 1, 0, 1U);
   std::cout << qc << "\n";
 
   EXPECT_TRUE(qc.isDynamic());
@@ -407,7 +407,7 @@ TEST(DeferMeasurements, errorOnImplicitReset) {
   QuantumComputation qc(1U, 1U);
   qc.h(0);
   qc.measure(0, 0U);
-  qc.classicControlled(qc::X, 0, {0, 1U}, 1U);
+  qc.classicControlled(qc::X, 0, 0, 1U);
   std::cout << qc << "\n";
 
   EXPECT_TRUE(qc.isDynamic());

--- a/test/circuit_optimizer/test_eliminate_resets.cpp
+++ b/test/circuit_optimizer/test_eliminate_resets.cpp
@@ -84,7 +84,7 @@ TEST(EliminateResets, eliminateResetsClassicControlled) {
   qc.h(0);
   qc.measure(0, 0U);
   qc.reset(0);
-  qc.classicControlled(qc::X, 0, {0, 1U}, 1U);
+  qc.classicControlled(qc::X, 0, 0, 1U);
   std::cout << qc << "\n";
 
   EXPECT_TRUE(qc.isDynamic());
@@ -180,7 +180,7 @@ TEST(EliminateResets, eliminateResetsCompoundOperation) {
   comp.cx(1, 0);
   comp.reset(0);
   comp.measure(0, 0);
-  comp.classicControlled(qc::X, 0, {0, 1U}, 1U);
+  comp.classicControlled(qc::X, 0, 0, 1U);
   qc.emplace_back(comp.asOperation());
 
   std::cout << qc << "\n";

--- a/test/dd/test_dd_functionality.cpp
+++ b/test/dd/test_dd_functionality.cpp
@@ -472,7 +472,7 @@ TEST_F(DDFunctionality, classicControlledOperationConditions) {
     qc.measure(0, 0);
     // apply a classic-controlled X gate whenever the measured result compares
     // as specified by kind with the previously measured result.
-    qc.classicControlled(qc::X, 0, {0, 1U}, 1U, kind);
+    qc.classicControlled(qc::X, 0, 0, 1U, kind);
     // measure into the same register to check the result.
     qc.measure(0, 0);
 
@@ -503,7 +503,7 @@ TEST_F(DDFunctionality, dynamicCircuitSimulationWithSWAP) {
   qc.x(0);
   qc.swap(0, 1);
   qc.measure(1, 0);
-  qc.classicControlled(qc::X, 0, {0, 1U});
+  qc.classicControlled(qc::X, 0, 0);
   qc.measure(0, 1);
 
   constexpr auto shots = 16U;

--- a/test/dd/test_dd_noise_functionality.cpp
+++ b/test/dd/test_dd_noise_functionality.cpp
@@ -26,7 +26,6 @@
 #include <map>
 #include <memory>
 #include <stdexcept>
-#include <utility>
 
 using namespace qc;
 

--- a/test/dd/test_dd_noise_functionality.cpp
+++ b/test/dd/test_dd_noise_functionality.cpp
@@ -321,8 +321,7 @@ TEST_F(DDNoiseFunctionalityTest, testingUsedQubits) {
   EXPECT_TRUE(compoundOp.getUsedQubits().count(1));
 
   auto classicalControlledOp = qc::ClassicControlledOperation(
-      std::make_unique<qc::StandardOperation>(0, qc::X), std::pair{0, nqubits},
-      1U);
+      std::make_unique<qc::StandardOperation>(0, qc::X), {0, nqubits}, 1U);
   EXPECT_EQ(classicalControlledOp.getUsedQubits().size(), 1);
   EXPECT_TRUE(classicalControlledOp.getUsedQubits().count(0) == 1U);
 }

--- a/test/ir/test_io.cpp
+++ b/test/ir/test_io.cpp
@@ -471,45 +471,6 @@ TEST_F(IO, appendMeasurementsAccordingToOutputPermutation) {
   EXPECT_EQ(meas->getClassics().front(), 0U);
 }
 
-TEST_F(IO, appendMeasurementsAccordingToOutputPermutationAugmentRegister) {
-  *qc = qc::QuantumComputation::fromQASM("// o 0 1\n"
-                                         "qreg q[2];"
-                                         "creg c[1];"
-                                         "x q;");
-  qc->appendMeasurementsAccordingToOutputPermutation();
-  std::cout << *qc << "\n";
-  EXPECT_EQ(qc->getNcbits(), 2U);
-  const auto& op = qc->back();
-  ASSERT_EQ(op->getType(), qc::OpType::Measure);
-  const auto& meas = dynamic_cast<const qc::NonUnitaryOperation*>(op.get());
-  ASSERT_NE(meas, nullptr);
-  EXPECT_EQ(meas->getTargets().size(), 1U);
-  EXPECT_EQ(meas->getTargets().front(), 1U);
-  EXPECT_EQ(meas->getClassics().size(), 1U);
-  EXPECT_EQ(meas->getClassics().front(), 1U);
-  const auto& op2 = *(++qc->rbegin());
-  ASSERT_EQ(op2->getType(), qc::OpType::Measure);
-  const auto& meas2 = dynamic_cast<const qc::NonUnitaryOperation*>(op2.get());
-  ASSERT_NE(meas2, nullptr);
-  EXPECT_EQ(meas2->getTargets().size(), 1U);
-  EXPECT_EQ(meas2->getTargets().front(), 0U);
-  EXPECT_EQ(meas2->getClassics().size(), 1U);
-  EXPECT_EQ(meas2->getClassics().front(), 0U);
-  const auto qasm = qc->toQASM(false);
-  std::cout << qasm << "\n";
-  EXPECT_EQ(qasm, "// i 0 1\n"
-                  "// o 0 1\n"
-                  "OPENQASM 2.0;\n"
-                  "include \"qelib1.inc\";\n"
-                  "qreg q[2];\n"
-                  "creg c[2];\n"
-                  "x q[0];\n"
-                  "x q[1];\n"
-                  "barrier q;\n"
-                  "measure q[0] -> c[0];\n"
-                  "measure q[1] -> c[1];\n");
-}
-
 TEST_F(IO, appendMeasurementsAccordingToOutputPermutationAddRegister) {
   *qc = qc::QuantumComputation::fromQASM("// o 0 1\n"
                                          "qreg q[2];"
@@ -706,9 +667,9 @@ TEST_F(IO, fromCompoundOperation) {
 
 TEST_F(IO, classicalControlledOperationToOpenQASM3) {
   qc->addQubitRegister(2);
-  qc->addClassicalRegister(2);
-  qc->classicControlled(qc::X, 0, {0, 1});
-  qc->classicControlled(qc::X, 1, {0, 2});
+  const auto& creg = qc->addClassicalRegister(2);
+  qc->classicControlled(qc::X, 0, 0);
+  qc->classicControlled(qc::X, 1, creg);
   const std::string expected = "// i 0 1\n"
                                "// o 0 1\n"
                                "OPENQASM 3.0;\n"

--- a/test/ir/test_io.cpp
+++ b/test/ir/test_io.cpp
@@ -686,18 +686,3 @@ TEST_F(IO, classicalControlledOperationToOpenQASM3) {
   const auto actual = qc->toQASM();
   EXPECT_EQ(expected, actual);
 }
-
-TEST_F(IO, classicalControlledOperationToOpenQASM3MoreThanOneRegister) {
-  qc->addQubitRegister(1);
-  qc->addClassicalRegister(1);
-  qc->addClassicalRegister(1, "d");
-  qc->classicControlled(qc::X, 0, {0, 2});
-  EXPECT_THROW(qc->dumpOpenQASM3(std::cout), qc::QFRException);
-}
-
-TEST_F(IO, classicalControlledOperationToOpenQASM3NotEntireRegister) {
-  qc->addQubitRegister(1);
-  qc->addClassicalRegister(3);
-  qc->classicControlled(qc::X, 0, {0, 2});
-  EXPECT_THROW(qc->dumpOpenQASM3(std::cout), qc::QFRException);
-}

--- a/test/ir/test_operation.cpp
+++ b/test/ir/test_operation.cpp
@@ -9,11 +9,13 @@
 
 #include "Definitions.hpp"
 #include "ir/Permutation.hpp"
+#include "ir/Register.hpp"
 #include "ir/operations/AodOperation.hpp"
 #include "ir/operations/CompoundOperation.hpp"
 #include "ir/operations/Expression.hpp"
 #include "ir/operations/NonUnitaryOperation.hpp"
 #include "ir/operations/OpType.hpp"
+#include "ir/operations/Operation.hpp"
 #include "ir/operations/StandardOperation.hpp"
 #include "ir/operations/SymbolicOperation.hpp"
 

--- a/test/ir/test_operation.cpp
+++ b/test/ir/test_operation.cpp
@@ -217,11 +217,11 @@ TEST(AodOperation, Qasm) {
                               {na::Dimension::X, na::Dimension::Y}, {0.0, 1.0},
                               {1.0, 3.0});
   std::stringstream ss;
-  qc::RegisterNames qreg;
-  qreg.emplace_back("q", "q[0]");
-  qreg.emplace_back("q", "q[1]");
-  qc::RegisterNames const creg{{"c", "c"}};
-  move.dumpOpenQASM(ss, qreg, creg, 0, false);
+  qc::QuantumRegister qreg(0, 2, "q");
+  qc::QubitIndexToRegisterMap qubitToReg{};
+  qubitToReg.try_emplace(0, qreg, qreg.toString(0));
+  qubitToReg.try_emplace(1, qreg, qreg.toString(1));
+  move.dumpOpenQASM(ss, qubitToReg, {}, 0, false);
 
   EXPECT_EQ(ss.str(), "aod_move (0, 0, 1; 1, 1, 3;) q[0], q[1];\n");
 }

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -34,7 +34,27 @@
 #include <utility>
 #include <vector>
 
-using namespace qc;
+namespace qc {
+
+namespace {
+void printRegisters(const QuantumComputation& qc) {
+  for (const auto& [name, reg] : qc.getQuantumRegisters()) {
+    std::cout << "QuantumRegister(name=" << name
+              << ", start=" << reg.getStartIndex() << ", size=" << reg.getSize()
+              << ")\n";
+  }
+  for (const auto& [name, reg] : qc.getClassicalRegisters()) {
+    std::cout << "ClassicalRegister(name=" << name
+              << ", start=" << reg.getStartIndex() << ", size=" << reg.getSize()
+              << ")\n";
+  }
+  for (const auto& [name, reg] : qc.getAncillaRegisters()) {
+    std::cout << "AncillaRegister(name=" << name
+              << ", start=" << reg.getStartIndex() << ", size=" << reg.getSize()
+              << ")\n";
+  }
+}
+} // namespace
 
 class QFRFunctionality : public testing::TestWithParam<std::size_t> {
 protected:
@@ -58,8 +78,8 @@ TEST_F(QFRFunctionality, removeTrailingIdleQubits) {
   qc.x(0);
   qc.x(2);
   std::cout << qc;
-  qc::QuantumComputation::printPermutation(qc.outputPermutation);
-  qc.printRegisters();
+  QuantumComputation::printPermutation(qc.outputPermutation);
+  printRegisters(qc);
 
   qc.outputPermutation.erase(1);
   qc.outputPermutation.erase(3);
@@ -67,14 +87,14 @@ TEST_F(QFRFunctionality, removeTrailingIdleQubits) {
   qc.stripIdleQubits();
   EXPECT_EQ(qc.getNqubits(), 2);
   std::cout << qc;
-  qc::QuantumComputation::printPermutation(qc.outputPermutation);
-  qc.printRegisters();
+  QuantumComputation::printPermutation(qc.outputPermutation);
+  printRegisters(qc);
 
   qc.pop_back();
   qc.outputPermutation.erase(2);
   std::cout << qc;
-  qc::QuantumComputation::printPermutation(qc.outputPermutation);
-  qc.printRegisters();
+  QuantumComputation::printPermutation(qc.outputPermutation);
+  printRegisters(qc);
 
   qc.stripIdleQubits();
   EXPECT_EQ(qc.getNqubits(), 1);
@@ -89,44 +109,44 @@ TEST_F(QFRFunctionality, ancillaryQubitAtEnd) {
   EXPECT_EQ(qc.getNqubitsWithoutAncillae(), nqubits);
   EXPECT_EQ(qc.getNqubits(), 3);
   qc.x(2);
-  qc.printRegisters();
+  printRegisters(qc);
   auto p = qc.removeQubit(2);
   EXPECT_EQ(p.first, nqubits);
   EXPECT_EQ(p.second, nqubits);
   EXPECT_EQ(qc.getNancillae(), 0);
   EXPECT_EQ(qc.getNqubitsWithoutAncillae(), nqubits);
   EXPECT_EQ(qc.getNqubits(), nqubits);
-  EXPECT_TRUE(qc.getANCregs().empty());
-  qc.printRegisters();
+  EXPECT_TRUE(qc.getAncillaRegisters().empty());
+  printRegisters(qc);
   qc.addAncillaryQubit(p.first, p.second);
   EXPECT_EQ(qc.getNancillae(), 1);
   EXPECT_EQ(qc.getNqubitsWithoutAncillae(), nqubits);
   EXPECT_EQ(qc.getNqubits(), nqubits + 1);
-  EXPECT_FALSE(qc.getANCregs().empty());
-  qc.printRegisters();
+  EXPECT_FALSE(qc.getAncillaRegisters().empty());
+  printRegisters(qc);
   auto q = qc.removeQubit(2);
   EXPECT_EQ(q.first, nqubits);
   EXPECT_EQ(q.second, nqubits);
   EXPECT_EQ(qc.getNancillae(), 0);
   EXPECT_EQ(qc.getNqubitsWithoutAncillae(), nqubits);
   EXPECT_EQ(qc.getNqubits(), nqubits);
-  EXPECT_TRUE(qc.getANCregs().empty());
-  qc.printRegisters();
+  EXPECT_TRUE(qc.getAncillaRegisters().empty());
+  printRegisters(qc);
   auto rm = qc.removeQubit(1);
   EXPECT_EQ(rm.first, 1);
   EXPECT_EQ(rm.second, 1);
   EXPECT_EQ(qc.getNancillae(), 0);
   EXPECT_EQ(qc.getNqubitsWithoutAncillae(), 1);
   EXPECT_EQ(qc.getNqubits(), 1);
-  qc.printRegisters();
+  printRegisters(qc);
   auto empty = qc.removeQubit(0);
   EXPECT_EQ(empty.first, 0);
   EXPECT_EQ(empty.second, 0);
   EXPECT_EQ(qc.getNancillae(), 0);
   EXPECT_EQ(qc.getNqubitsWithoutAncillae(), 0);
   EXPECT_EQ(qc.getNqubits(), 0);
-  EXPECT_TRUE(qc.getQregs().empty());
-  qc.printRegisters();
+  EXPECT_TRUE(qc.getQuantumRegisters().empty());
+  printRegisters(qc);
   qc.printStatistics(std::cout);
 }
 
@@ -141,7 +161,7 @@ TEST_F(QFRFunctionality, ancillaryQubitRemoveMiddle) {
   EXPECT_EQ(qc.getNancillae(), 2);
   EXPECT_EQ(qc.getNqubitsWithoutAncillae(), 2);
   EXPECT_EQ(qc.getNqubits(), 4);
-  qc.printRegisters();
+  printRegisters(qc);
 }
 
 TEST_F(QFRFunctionality, splitQreg) {
@@ -154,7 +174,7 @@ TEST_F(QFRFunctionality, splitQreg) {
   EXPECT_EQ(qc.getNancillae(), 0);
   EXPECT_EQ(qc.getNqubitsWithoutAncillae(), 2);
   EXPECT_EQ(qc.getNqubits(), 2);
-  qc.printRegisters();
+  printRegisters(qc);
 }
 
 TEST_F(QFRFunctionality, StripIdleAndDump) {
@@ -319,7 +339,7 @@ TEST_F(QFRFunctionality, cloningDifferentOperations) {
   comp.barrier(0);
   comp.h(0);
   qc.emplace_back(comp.asOperation());
-  qc.classicControlled(qc::X, 0, qc.getCregs().at("c"), 1);
+  qc.classicControlled(X, 0, qc.getClassicalRegisters().at("c"), 1);
 
   const auto qcCloned = qc;
   ASSERT_EQ(qc.size(), qcCloned.size());
@@ -973,9 +993,7 @@ TEST_F(QFRFunctionality, measureAll) {
   std::cout << qc << "\n";
   EXPECT_EQ(qc.getNops(), 3U);
   EXPECT_EQ(qc.getNcbits(), 2U);
-  EXPECT_EQ(qc.getCregs().size(), 1U);
-  EXPECT_EQ(qc.getClassicalRegister(0U), "meas");
-  EXPECT_EQ(qc.getClassicalRegister(1U), "meas");
+  EXPECT_EQ(qc.getClassicalRegisters().size(), 1U);
 }
 
 TEST_F(QFRFunctionality, measureAllExistingRegister) {
@@ -984,9 +1002,7 @@ TEST_F(QFRFunctionality, measureAllExistingRegister) {
   std::cout << qc << "\n";
   EXPECT_EQ(qc.getNops(), 3U);
   EXPECT_EQ(qc.getNcbits(), 2U);
-  EXPECT_EQ(qc.getCregs().size(), 1U);
-  EXPECT_EQ(qc.getClassicalRegister(0U), "c");
-  EXPECT_EQ(qc.getClassicalRegister(1U), "c");
+  EXPECT_EQ(qc.getClassicalRegisters().size(), 1U);
 }
 
 TEST_F(QFRFunctionality, measureAllInsufficientRegisterSize) {
@@ -1009,14 +1025,14 @@ TEST_F(QFRFunctionality, MeasurementSanityCheck) {
 
 TEST_F(QFRFunctionality, testSettingAncillariesProperlyCreatesRegisters) {
   // create an empty circuit and assert some properties about its registers
-  qc::QuantumComputation qc(3U);
-  const auto& qregs = qc.getQregs();
+  QuantumComputation qc(3U);
+  const auto& qregs = qc.getQuantumRegisters();
   ASSERT_EQ(qregs.size(), 1U);
   const auto& reg = *qregs.begin();
   const auto name = reg.first;
-  ASSERT_EQ(reg.second.first, 0U);
-  ASSERT_EQ(reg.second.second, 3U);
-  const auto& ancRegs = qc.getANCregs();
+  ASSERT_EQ(reg.second.getStartIndex(), 0U);
+  ASSERT_EQ(reg.second.getSize(), 3U);
+  const auto& ancRegs = qc.getAncillaRegisters();
   ASSERT_TRUE(ancRegs.empty());
   ASSERT_EQ(qc.getNqubitsWithoutAncillae(), 3U);
   ASSERT_EQ(qc.getNancillae(), 0U);
@@ -1025,8 +1041,8 @@ TEST_F(QFRFunctionality, testSettingAncillariesProperlyCreatesRegisters) {
   qc.setLogicalQubitAncillary(2U);
   qc.setLogicalQubitAncillary(1U);
   ASSERT_EQ(qregs.size(), 1U);
-  ASSERT_EQ(reg.second.first, 0U);
-  ASSERT_EQ(reg.second.second, 3U);
+  ASSERT_EQ(reg.second.getStartIndex(), 0U);
+  ASSERT_EQ(reg.second.getSize(), 3U);
   ASSERT_EQ(name, reg.first);
   ASSERT_TRUE(ancRegs.empty());
   ASSERT_EQ(qc.getNqubitsWithoutAncillae(), 1U);
@@ -1040,8 +1056,8 @@ TEST_F(QFRFunctionality, testSettingAncillariesProperlyCreatesRegisters) {
   qc.setLogicalQubitGarbage(2U);
   qc.stripIdleQubits();
   ASSERT_EQ(qregs.size(), 1U);
-  ASSERT_EQ(reg.second.first, 0U);
-  ASSERT_EQ(reg.second.second, 1U);
+  ASSERT_EQ(reg.second.getStartIndex(), 0U);
+  ASSERT_EQ(reg.second.getSize(), 1U);
   ASSERT_EQ(name, reg.first);
   ASSERT_TRUE(ancRegs.empty());
   ASSERT_EQ(qc.getNqubitsWithoutAncillae(), 1U);
@@ -1050,8 +1066,8 @@ TEST_F(QFRFunctionality, testSettingAncillariesProperlyCreatesRegisters) {
 
 TEST_F(QFRFunctionality, testSettingSetMultipleAncillariesAndGarbage) {
   // create an empty circuit and assert some properties about its registers
-  qc::QuantumComputation qc(3U);
-  const auto& ancRegs = qc.getANCregs();
+  QuantumComputation qc(3U);
+  const auto& ancRegs = qc.getAncillaRegisters();
   ASSERT_TRUE(ancRegs.empty());
   ASSERT_EQ(qc.getNqubitsWithoutAncillae(), 3U);
   ASSERT_EQ(qc.getNancillae(), 0U);
@@ -1088,12 +1104,13 @@ TEST_F(QFRFunctionality, StripIdleQubitsInMiddleOfCircuit) {
   qc.x(3);
   qc.x(4);
 
-  const auto& qregs = qc.getQregs();
+  const auto& qregs = qc.getQuantumRegisters();
   ASSERT_EQ(qregs.size(), 1U);
-  const auto& reg = *qregs.begin();
-  ASSERT_EQ(reg.second.first, 0U);
-  ASSERT_EQ(reg.second.second, 5U);
-  const auto& ancRegs = qc.getANCregs();
+  const auto& [name, reg] = *qregs.begin();
+  ASSERT_EQ(name, "q");
+  ASSERT_EQ(reg.getStartIndex(), 0U);
+  ASSERT_EQ(reg.getSize(), 5U);
+  const auto& ancRegs = qc.getAncillaRegisters();
   ASSERT_TRUE(ancRegs.empty());
   ASSERT_EQ(qc.getNqubitsWithoutAncillae(), 3U);
   ASSERT_EQ(qc.getNancillae(), 2U);
@@ -1101,12 +1118,12 @@ TEST_F(QFRFunctionality, StripIdleQubitsInMiddleOfCircuit) {
   qc.stripIdleQubits();
 
   ASSERT_EQ(qregs.size(), 2U);
-  const auto& regAfter = *qregs.begin();
-  ASSERT_EQ(regAfter.second.first, 1U);
-  ASSERT_EQ(regAfter.second.second, 1U);
-  const auto& reg2After = *(++qregs.begin());
-  ASSERT_EQ(reg2After.second.first, 3U);
-  ASSERT_EQ(reg2After.second.second, 2U);
+  const auto& regAfter = qregs.at("q_l");
+  ASSERT_EQ(regAfter.getStartIndex(), 1U);
+  ASSERT_EQ(regAfter.getSize(), 1U);
+  const auto& reg2After = qregs.at("q_h");
+  ASSERT_EQ(reg2After.getStartIndex(), 3U);
+  ASSERT_EQ(reg2After.getSize(), 2U);
   ASSERT_TRUE(ancRegs.empty());
   ASSERT_EQ(qc.getNqubitsWithoutAncillae(), 3U);
   ASSERT_EQ(qc.getNancillae(), 0U);
@@ -1172,129 +1189,107 @@ TEST_F(QFRFunctionality, NoRegisterOnEmptyCircuit) {
   QuantumComputation qc(0U);
   qc.addQubitRegister(1U, "p");
   EXPECT_NO_THROW(qc.addQubitRegister(1U, "q"));
-  EXPECT_EQ(qc.getQregs().size(), 2U);
+  EXPECT_EQ(qc.getQuantumRegisters().size(), 2U);
 }
 
 TEST_F(QFRFunctionality, AddQubitAtFrontOfRegister) {
   QuantumComputation qc{};
   qc.addQubitRegister(2, "q");
-  const auto& qregs = qc.getQregs();
+  const auto& qregs = qc.getQuantumRegisters();
   EXPECT_EQ(qregs.size(), 1U);
-  const auto& [name, reg] = *qregs.begin();
-  const auto& [start, size] = reg;
-  EXPECT_EQ(name, "q");
-  EXPECT_EQ(start, 0U);
-  EXPECT_EQ(size, 2U);
+  const auto& reg = qregs.at("q");
+  EXPECT_EQ(reg.getStartIndex(), 0U);
+  EXPECT_EQ(reg.getSize(), 2U);
 
   // first remove the qubit
   const auto& [physicalIndex, outputIndex] = qc.removeQubit(0);
   EXPECT_EQ(physicalIndex, 0U);
   EXPECT_EQ(outputIndex, 0U);
 
-  const auto& qregsAfter = qc.getQregs();
+  const auto& qregsAfter = qc.getQuantumRegisters();
   EXPECT_EQ(qregsAfter.size(), 1U);
-  const auto& [nameAfter, regAfter] = *qregsAfter.begin();
-  const auto& [startAfter, sizeAfter] = regAfter;
-  EXPECT_EQ(nameAfter, "q");
-  EXPECT_EQ(startAfter, 1U);
-  EXPECT_EQ(sizeAfter, 1U);
+  const auto& regAfter = qregsAfter.at("q");
+  EXPECT_EQ(regAfter.getStartIndex(), 1U);
+  EXPECT_EQ(regAfter.getSize(), 1U);
 
   // add the qubit back at the front
   qc.addQubit(0, physicalIndex, outputIndex);
-  const auto& qregsAfterAdd = qc.getQregs();
+  const auto& qregsAfterAdd = qc.getQuantumRegisters();
   EXPECT_EQ(qregsAfterAdd.size(), 1U);
-  const auto& [nameAfterAdd, regAfterAdd] = *qregsAfterAdd.begin();
-  const auto& [startAfterAdd, sizeAfterAdd] = regAfterAdd;
-  EXPECT_EQ(nameAfterAdd, "q");
-  EXPECT_EQ(startAfterAdd, 0U);
-  EXPECT_EQ(sizeAfterAdd, 2U);
+  const auto& regAfterAdd = qregsAfterAdd.at("q");
+  EXPECT_EQ(regAfterAdd.getStartIndex(), 0U);
+  EXPECT_EQ(regAfterAdd.getSize(), 2U);
 }
 
 TEST_F(QFRFunctionality, AddQubitAtEndOfRegister) {
   QuantumComputation qc{};
   qc.addQubitRegister(2, "q");
-  const auto& qregs = qc.getQregs();
+  const auto& qregs = qc.getQuantumRegisters();
   EXPECT_EQ(qregs.size(), 1U);
-  const auto& [name, reg] = *qregs.begin();
-  const auto& [start, size] = reg;
-  EXPECT_EQ(name, "q");
-  EXPECT_EQ(start, 0U);
-  EXPECT_EQ(size, 2U);
+  const auto& reg = qregs.at("q");
+  EXPECT_EQ(reg.getStartIndex(), 0U);
+  EXPECT_EQ(reg.getSize(), 2U);
 
   // first remove the qubit
   const auto& [physicalIndex, outputIndex] = qc.removeQubit(1);
   EXPECT_EQ(physicalIndex, 1U);
   EXPECT_EQ(outputIndex, 1U);
 
-  const auto& qregsAfter = qc.getQregs();
+  const auto& qregsAfter = qc.getQuantumRegisters();
   EXPECT_EQ(qregsAfter.size(), 1U);
-  const auto& [nameAfter, regAfter] = *qregsAfter.begin();
-  const auto& [startAfter, sizeAfter] = regAfter;
-  EXPECT_EQ(nameAfter, "q");
-  EXPECT_EQ(startAfter, 0U);
-  EXPECT_EQ(sizeAfter, 1U);
+  const auto& regAfter = qregsAfter.at("q");
+  EXPECT_EQ(regAfter.getStartIndex(), 0U);
+  EXPECT_EQ(regAfter.getSize(), 1U);
 
   // add the qubit back at the end
   qc.addQubit(1, physicalIndex, outputIndex);
-  const auto& qregsAfterAdd = qc.getQregs();
+  const auto& qregsAfterAdd = qc.getQuantumRegisters();
   EXPECT_EQ(qregsAfterAdd.size(), 1U);
-  const auto& [nameAfterAdd, regAfterAdd] = *qregsAfterAdd.begin();
-  const auto& [startAfterAdd, sizeAfterAdd] = regAfterAdd;
-  EXPECT_EQ(nameAfterAdd, "q");
-  EXPECT_EQ(startAfterAdd, 0U);
-  EXPECT_EQ(sizeAfterAdd, 2U);
+  const auto& regAfterAdd = qregsAfterAdd.at("q");
+  EXPECT_EQ(regAfterAdd.getStartIndex(), 0U);
+  EXPECT_EQ(regAfterAdd.getSize(), 2U);
 }
 
 TEST_F(QFRFunctionality, AddQubitInMiddleOfSplitRegister) {
   QuantumComputation qc{};
   qc.addQubitRegister(3, "q");
-  const auto& qregs = qc.getQregs();
+  const auto& qregs = qc.getQuantumRegisters();
   EXPECT_EQ(qregs.size(), 1U);
-  const auto& [name, reg] = *qregs.begin();
-  const auto& [start, size] = reg;
-  EXPECT_EQ(name, "q");
-  EXPECT_EQ(start, 0U);
-  EXPECT_EQ(size, 3U);
+  const auto& reg = qregs.at("q");
+  EXPECT_EQ(reg.getStartIndex(), 0U);
+  EXPECT_EQ(reg.getSize(), 3U);
 
   // remove the middle qubit -> splits the register into q_l and q_h
   const auto& [physicalIndex, outputIndex] = qc.removeQubit(1);
   EXPECT_EQ(physicalIndex, 1U);
   EXPECT_EQ(outputIndex, 1U);
 
-  const auto& qregsAfter = qc.getQregs();
+  const auto& qregsAfter = qc.getQuantumRegisters();
   EXPECT_EQ(qregsAfter.size(), 2U);
-  const auto& [nameLow, regLow] = *qregsAfter.begin();
-  const auto& [startLow, sizeLow] = regLow;
-  EXPECT_EQ(nameLow, "q_l");
-  EXPECT_EQ(startLow, 0U);
-  EXPECT_EQ(sizeLow, 1U);
-  const auto& [nameHigh, regHigh] = *qregsAfter.rbegin();
-  const auto& [startHigh, sizeHigh] = regHigh;
-  EXPECT_EQ(nameHigh, "q_h");
-  EXPECT_EQ(startHigh, 2U);
-  EXPECT_EQ(sizeHigh, 1U);
+  const auto& regLow = qregsAfter.at("q_l");
+  EXPECT_EQ(regLow.getStartIndex(), 0U);
+  EXPECT_EQ(regLow.getSize(), 1U);
+  const auto& regHigh = qregsAfter.at("q_h");
+  EXPECT_EQ(regHigh.getStartIndex(), 2U);
+  EXPECT_EQ(regHigh.getSize(), 1U);
 
   // add back the qubit. should consolidate the registers again
   qc.addQubit(1, physicalIndex, outputIndex);
-  const auto& qregsAfterAdd = qc.getQregs();
+  const auto& qregsAfterAdd = qc.getQuantumRegisters();
   EXPECT_EQ(qregsAfterAdd.size(), 1U);
-  const auto& [nameConsolidated, regConsolidated] = *qregsAfterAdd.begin();
-  const auto& [startConsolidated, sizeConsolidated] = regConsolidated;
-  EXPECT_EQ(nameConsolidated, "q");
-  EXPECT_EQ(startConsolidated, 0U);
-  EXPECT_EQ(sizeConsolidated, 3U);
+  const auto& regConsolidated = qregsAfterAdd.at("q");
+  EXPECT_EQ(regConsolidated.getStartIndex(), 0U);
+  EXPECT_EQ(regConsolidated.getSize(), 3U);
 }
 
 TEST_F(QFRFunctionality, AddQubitWithoutNeighboringQubits) {
   QuantumComputation qc{};
   qc.addQubitRegister(5, "q");
-  const auto& qregs = qc.getQregs();
+  const auto& qregs = qc.getQuantumRegisters();
   EXPECT_EQ(qregs.size(), 1U);
-  const auto& [name, reg] = *qregs.begin();
-  const auto& [start, size] = reg;
-  EXPECT_EQ(name, "q");
-  EXPECT_EQ(start, 0U);
-  EXPECT_EQ(size, 5U);
+  const auto& reg = qregs.at("q");
+  EXPECT_EQ(reg.getStartIndex(), 0U);
+  EXPECT_EQ(reg.getSize(), 5U);
 
   // remove the middle 3 qubits -> splits the register into q_l and q_h with one
   // qubit each.
@@ -1308,32 +1303,27 @@ TEST_F(QFRFunctionality, AddQubitWithoutNeighboringQubits) {
   EXPECT_EQ(physicalIndex3, 3U);
   EXPECT_EQ(outputIndex3, 3U);
 
-  const auto& qregsAfter = qc.getQregs();
+  const auto& qregsAfter = qc.getQuantumRegisters();
   EXPECT_EQ(qregsAfter.size(), 2U);
-  const auto& [nameLow, regLow] = *qregsAfter.begin();
-  const auto& [startLow, sizeLow] = regLow;
-  EXPECT_EQ(nameLow, "q_l");
-  EXPECT_EQ(startLow, 0U);
-  EXPECT_EQ(sizeLow, 1U);
+  const auto& regLow = qregsAfter.at("q_l");
+  EXPECT_EQ(regLow.getStartIndex(), 0U);
+  EXPECT_EQ(regLow.getSize(), 1U);
 
-  const auto& [nameHigh, regHigh] = *qregsAfter.rbegin();
-  const auto& [startHigh, sizeHigh] = regHigh;
-  EXPECT_EQ(nameHigh, "q_h");
-  EXPECT_EQ(startHigh, 4U);
-  EXPECT_EQ(sizeHigh, 1U);
+  const auto& regHigh = qregsAfter.at("q_h");
+  EXPECT_EQ(regHigh.getStartIndex(), 4U);
+  EXPECT_EQ(regHigh.getSize(), 1U);
 
   // add back the middle qubit. should create a new register for the qubit
   qc.addQubit(2, physicalIndex2, outputIndex2);
-  const auto& qregsAfterAdd = qc.getQregs();
+  const auto& qregsAfterAdd = qc.getQuantumRegisters();
   EXPECT_EQ(qregsAfterAdd.size(), 3U);
   // expect to find a `q_2` register with 1 qubit starting at index 2
   const auto& it = qregsAfterAdd.find("q_2");
   ASSERT_NE(it, qregsAfterAdd.end());
   const auto& [nameMiddle, regMiddle] = *it;
-  const auto& [startMiddle, sizeMiddle] = regMiddle;
   EXPECT_EQ(nameMiddle, "q_2");
-  EXPECT_EQ(startMiddle, 2U);
-  EXPECT_EQ(sizeMiddle, 1U);
+  EXPECT_EQ(regMiddle.getStartIndex(), 2U);
+  EXPECT_EQ(regMiddle.getSize(), 1U);
 }
 
 TEST_F(QFRFunctionality, CopyConstructor) {

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -395,26 +395,21 @@ TEST_F(QFRFunctionality, OperationEquality) {
   EXPECT_TRUE(measure0.equals(measure2, perm0, {}));
   EXPECT_TRUE(measure0.equals(measure2, {}, perm0));
 
-  const auto controlRegister0 = qc::QuantumRegister{0, 1U};
-  const auto controlRegister1 = qc::QuantumRegister{1, 1U};
   const auto expectedValue0 = 0U;
   const auto expectedValue1 = 1U;
 
-  std::unique_ptr<Operation> xp0 =
-      std::make_unique<StandardOperation>(0, qc::X);
-  std::unique_ptr<Operation> xp1 =
-      std::make_unique<StandardOperation>(0, qc::X);
-  std::unique_ptr<Operation> xp2 =
-      std::make_unique<StandardOperation>(0, qc::X);
-  const auto classic0 = ClassicControlledOperation(
-      std::move(xp0), controlRegister0, expectedValue0);
-  const auto classic1 = ClassicControlledOperation(
-      std::move(xp1), controlRegister0, expectedValue1);
-  const auto classic2 = ClassicControlledOperation(
-      std::move(xp2), controlRegister1, expectedValue0);
-  std::unique_ptr<Operation> zp = std::make_unique<StandardOperation>(0, qc::Z);
-  const auto classic3 = ClassicControlledOperation(
-      std::move(zp), controlRegister0, expectedValue0);
+  std::unique_ptr<Operation> xp0 = std::make_unique<StandardOperation>(0, X);
+  std::unique_ptr<Operation> xp1 = std::make_unique<StandardOperation>(0, X);
+  std::unique_ptr<Operation> xp2 = std::make_unique<StandardOperation>(0, X);
+  const auto classic0 =
+      ClassicControlledOperation(std::move(xp0), 0, expectedValue0);
+  const auto classic1 =
+      ClassicControlledOperation(std::move(xp1), 0, expectedValue1);
+  const auto classic2 =
+      ClassicControlledOperation(std::move(xp2), 1, expectedValue0);
+  std::unique_ptr<Operation> zp = std::make_unique<StandardOperation>(0, Z);
+  const auto classic3 =
+      ClassicControlledOperation(std::move(zp), 0, expectedValue0);
   EXPECT_FALSE(classic0.equals(x));
   EXPECT_NE(classic0, x);
   EXPECT_TRUE(classic0.equals(classic0));
@@ -753,11 +748,9 @@ TEST_F(QFRFunctionality, addControlSymbolicOperation) {
 }
 
 TEST_F(QFRFunctionality, addControlClassicControlledOperation) {
-  std::unique_ptr<Operation> xp = std::make_unique<StandardOperation>(0, qc::X);
-  const auto controlRegister = qc::QuantumRegister{0, 1U};
+  std::unique_ptr<Operation> xp = std::make_unique<StandardOperation>(0, X);
   const auto expectedValue = 0U;
-  auto op =
-      ClassicControlledOperation(std::move(xp), controlRegister, expectedValue);
+  auto op = ClassicControlledOperation(std::move(xp), 0, expectedValue);
 
   op.addControl(1);
   op.addControl(2);
@@ -820,8 +813,7 @@ TEST_F(QFRFunctionality, addControlTwice) {
   op->addControl(control);
   EXPECT_THROW(op->addControl(control), QFRException);
 
-  auto classicControlledOp =
-      ClassicControlledOperation(std::move(op), qc::QuantumRegister{0, 1U}, 0U);
+  auto classicControlledOp = ClassicControlledOperation(std::move(op), 0, 0U);
   EXPECT_THROW(classicControlledOp.addControl(control), QFRException);
 
   auto symbolicOp = SymbolicOperation(Targets{1}, OpType::X);
@@ -837,8 +829,7 @@ TEST_F(QFRFunctionality, addTargetAsControl) {
       std::make_unique<StandardOperation>(Targets{1}, OpType::X);
   EXPECT_THROW(op->addControl(control), QFRException);
 
-  auto classicControlledOp =
-      ClassicControlledOperation(std::move(op), qc::QuantumRegister{0, 1U}, 0U);
+  auto classicControlledOp = ClassicControlledOperation(std::move(op), 0, 0U);
   EXPECT_THROW(classicControlledOp.addControl(control), QFRException);
 
   auto symbolicOp = SymbolicOperation(Targets{1}, OpType::X);
@@ -1011,16 +1002,8 @@ TEST_F(QFRFunctionality, measureAllInsufficientRegisterSize) {
 }
 
 TEST_F(QFRFunctionality, checkClassicalRegisters) {
-  qc::QuantumComputation qc(1U, 1U);
-  EXPECT_THROW(qc.classicControlled(qc::X, 0U, {0U, 2U}), QFRException);
-}
-
-TEST_F(QFRFunctionality, MeasurementSanityCheck) {
-  qc::QuantumComputation qc(1U);
-  qc.addClassicalRegister(1U, "c");
-
-  EXPECT_THROW(qc.measure(0, {"c", 1U}), QFRException);
-  EXPECT_THROW(qc.measure(0, {"d", 0U}), QFRException);
+  QuantumComputation qc(1U, 1U);
+  EXPECT_THROW(qc.classicControlled(X, 0U, {0U, 2U}), QFRException);
 }
 
 TEST_F(QFRFunctionality, testSettingAncillariesProperlyCreatesRegisters) {

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -16,6 +16,7 @@
 #include "ir/operations/Expression.hpp"
 #include "ir/operations/NonUnitaryOperation.hpp"
 #include "ir/operations/OpType.hpp"
+#include "ir/operations/Operation.hpp"
 #include "ir/operations/StandardOperation.hpp"
 #include "ir/operations/SymbolicOperation.hpp"
 

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -1447,4 +1447,49 @@ TEST_F(QFRFunctionality, InequalityDifferentAdditionalOperations) {
   EXPECT_NE(qc1, qc2);
 }
 
+TEST_F(QFRFunctionality, TryAddingExistingQuantumRegister) {
+  QuantumComputation qc{};
+  qc.addQubitRegister(2, "q");
+  EXPECT_THROW(qc.addQubitRegister(2, "q"), QFRException);
+}
+
+TEST_F(QFRFunctionality, TryAddingExistingAncillaryRegister) {
+  QuantumComputation qc{};
+  qc.addAncillaryRegister(2, "a");
+  EXPECT_THROW(qc.addAncillaryRegister(2, "a"), QFRException);
+}
+
+TEST_F(QFRFunctionality, TryAddingExistingClassicalRegister) {
+  QuantumComputation qc{};
+  qc.addClassicalRegister(2, "c");
+  EXPECT_THROW(qc.addClassicalRegister(2, "c"), QFRException);
+}
+
+TEST_F(QFRFunctionality, TryAddingQubitRegisterAfterAncillaryRegister) {
+  QuantumComputation qc{};
+  qc.addAncillaryRegister(2, "a");
+  EXPECT_THROW(qc.addQubitRegister(2, "q"), QFRException);
+}
+
+TEST_F(QFRFunctionality, TryAddingZeroSizeQuantumRegister) {
+  QuantumComputation qc{};
+  EXPECT_THROW(qc.addQubitRegister(0, "q"), QFRException);
+}
+
+TEST_F(QFRFunctionality, TryAddingZeroSizeAncillaryRegister) {
+  QuantumComputation qc{};
+  EXPECT_THROW(qc.addAncillaryRegister(0, "a"), QFRException);
+}
+
+TEST_F(QFRFunctionality, TryAddingZeroSizeClassicalRegister) {
+  QuantumComputation qc{};
+  EXPECT_THROW(qc.addClassicalRegister(0, "c"), QFRException);
+}
+
+TEST_F(QFRFunctionality, TryGettingRegisterForQubitNotInRegister) {
+  QuantumComputation qc{};
+  qc.addQubitRegister(1, "q");
+  EXPECT_THROW(std::ignore = qc.getQubitRegister(2), QFRException);
+}
+
 } // namespace qc

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -172,18 +172,18 @@ TEST_F(QFRFunctionality, StripIdleAndDump) {
                                "cx q[0],q[4];\n";
 
   ss << testfile;
-  auto qc = qc::QuantumComputation();
-  qc.import(ss, qc::Format::OpenQASM2);
+  auto qc = QuantumComputation();
+  qc.import(ss, Format::OpenQASM2);
   qc.print(std::cout);
   qc.stripIdleQubits();
   qc.print(std::cout);
   std::stringstream goal{};
   qc.print(goal);
   std::stringstream test{};
-  qc.dump(test, qc::Format::OpenQASM2);
+  qc.dump(test, Format::OpenQASM2);
   std::cout << test.str() << "\n";
   qc.reset();
-  qc.import(test, qc::Format::OpenQASM2);
+  qc.import(test, Format::OpenQASM2);
   qc.print(std::cout);
   qc.stripIdleQubits();
   qc.print(std::cout);
@@ -332,15 +332,15 @@ TEST_F(QFRFunctionality, wrongRegisterSizes) {
 }
 
 TEST_F(QFRFunctionality, OperationEquality) {
-  const auto x = StandardOperation(0, qc::X);
-  const auto z = StandardOperation(0, qc::Z);
+  const auto x = StandardOperation(0, X);
+  const auto z = StandardOperation(0, Z);
   EXPECT_TRUE(x.equals(x));
   EXPECT_EQ(x, x);
   EXPECT_FALSE(x.equals(z));
   EXPECT_NE(x, z);
 
-  const auto x0 = StandardOperation(0, qc::X);
-  const auto x1 = StandardOperation(1, qc::X);
+  const auto x0 = StandardOperation(0, X);
+  const auto x1 = StandardOperation(1, X);
   EXPECT_FALSE(x0.equals(x1));
   EXPECT_NE(x0, x1);
   Permutation perm0{};
@@ -349,15 +349,15 @@ TEST_F(QFRFunctionality, OperationEquality) {
   EXPECT_TRUE(x0.equals(x1, perm0, {}));
   EXPECT_TRUE(x0.equals(x1, {}, perm0));
 
-  const auto cx01 = StandardOperation(0, 1, qc::X);
-  const auto cx10 = StandardOperation(1, 0, qc::X);
+  const auto cx01 = StandardOperation(0, 1, X);
+  const auto cx10 = StandardOperation(1, 0, X);
   EXPECT_FALSE(cx01.equals(cx10));
   EXPECT_NE(cx01, cx10);
   EXPECT_FALSE(x0.equals(cx01));
   EXPECT_NE(x0, cx01);
 
-  const auto p = StandardOperation(0, qc::P, {2.0});
-  const auto pm = StandardOperation(0, qc::P, {-2.0});
+  const auto p = StandardOperation(0, P, {2.0});
+  const auto pm = StandardOperation(0, P, {-2.0});
   EXPECT_FALSE(p.equals(pm));
   EXPECT_NE(p, pm);
 
@@ -407,14 +407,14 @@ TEST_F(QFRFunctionality, OperationEquality) {
   EXPECT_NE(classic0, classic3);
 
   auto compound0 = CompoundOperation();
-  compound0.emplace_back<StandardOperation>(0, qc::X);
+  compound0.emplace_back<StandardOperation>(0, X);
 
   auto compound1 = CompoundOperation();
-  compound1.emplace_back<StandardOperation>(0, qc::X);
-  compound1.emplace_back<StandardOperation>(0, qc::Z);
+  compound1.emplace_back<StandardOperation>(0, X);
+  compound1.emplace_back<StandardOperation>(0, Z);
 
   auto compound2 = CompoundOperation();
-  compound2.emplace_back<StandardOperation>(0, qc::Z);
+  compound2.emplace_back<StandardOperation>(0, Z);
 
   EXPECT_FALSE(compound0.equals(x));
   EXPECT_NE(compound0, x);
@@ -428,7 +428,7 @@ TEST_F(QFRFunctionality, OperationEquality) {
 
 TEST_F(QFRFunctionality, IndexOutOfRange) {
   QuantumComputation qc(2);
-  qc::Permutation layout{};
+  Permutation layout{};
   layout[0] = 0;
   layout[2] = 1;
   qc.initialLayout = layout;
@@ -521,16 +521,16 @@ TEST_F(QFRFunctionality, CircuitToOperation) {
   qc.x(0);
   const auto& op = qc.asOperation();
   ASSERT_NE(op, nullptr);
-  EXPECT_EQ(op->getType(), qc::X);
+  EXPECT_EQ(op->getType(), X);
   EXPECT_EQ(op->getNcontrols(), 0U);
   EXPECT_EQ(op->getTargets().front(), 0U);
   EXPECT_TRUE(qc.empty());
   qc.x(0);
   qc.h(0);
-  qc.classicControlled(qc::X, 0, 1, {0, 1U}, 1U);
+  qc.classicControlled(X, 0, 1, {0, 1U}, 1U);
   const auto& op2 = qc.asOperation();
   ASSERT_NE(op2, nullptr);
-  EXPECT_EQ(op2->getType(), qc::Compound);
+  EXPECT_EQ(op2->getType(), Compound);
   EXPECT_TRUE(qc.empty());
 }
 
@@ -585,7 +585,7 @@ TEST_F(QFRFunctionality, RzAndPhaseDifference) {
                            "cp(1/8) q[0],q[1];\n";
   std::stringstream ss;
   ss << qasm;
-  qc.import(ss, qc::Format::OpenQASM2);
+  qc.import(ss, Format::OpenQASM2);
   std::cout << qc << "\n";
   std::stringstream oss;
   qc.dumpOpenQASM2(oss);
@@ -599,12 +599,12 @@ TEST_F(QFRFunctionality, U3toU2Gate) {
   qc.u(PI_2, PI_2, -PI_2, 0); // Vdag = RX(-pi/2)
   qc.u(PI_2, 0.25, 0.5, 0);   // U2(0.25, 0.5)
   std::cout << qc << "\n";
-  EXPECT_EQ(qc.at(0)->getType(), qc::H);
-  EXPECT_EQ(qc.at(1)->getType(), qc::RY);
+  EXPECT_EQ(qc.at(0)->getType(), H);
+  EXPECT_EQ(qc.at(1)->getType(), RY);
   EXPECT_EQ(qc.at(1)->getParameter().at(0), PI_2);
-  EXPECT_EQ(qc.at(2)->getType(), qc::V);
-  EXPECT_EQ(qc.at(3)->getType(), qc::Vdg);
-  EXPECT_EQ(qc.at(4)->getType(), qc::U2);
+  EXPECT_EQ(qc.at(2)->getType(), V);
+  EXPECT_EQ(qc.at(3)->getType(), Vdg);
+  EXPECT_EQ(qc.at(4)->getType(), U2);
   EXPECT_EQ(qc.at(4)->getParameter().at(0), 0.25);
   EXPECT_EQ(qc.at(4)->getParameter().at(1), 0.5);
 }
@@ -620,13 +620,13 @@ TEST_F(QFRFunctionality, U3toU1Gate) {
   qc.u(0., 0., 0.5, 0);   // p(0.5)
 
   std::cout << qc << "\n";
-  EXPECT_EQ(qc.at(0)->getType(), qc::I);
-  EXPECT_EQ(qc.at(1)->getType(), qc::Z);
-  EXPECT_EQ(qc.at(2)->getType(), qc::S);
-  EXPECT_EQ(qc.at(3)->getType(), qc::Sdg);
-  EXPECT_EQ(qc.at(4)->getType(), qc::T);
-  EXPECT_EQ(qc.at(5)->getType(), qc::Tdg);
-  EXPECT_EQ(qc.at(6)->getType(), qc::P);
+  EXPECT_EQ(qc.at(0)->getType(), I);
+  EXPECT_EQ(qc.at(1)->getType(), Z);
+  EXPECT_EQ(qc.at(2)->getType(), S);
+  EXPECT_EQ(qc.at(3)->getType(), Sdg);
+  EXPECT_EQ(qc.at(4)->getType(), T);
+  EXPECT_EQ(qc.at(5)->getType(), Tdg);
+  EXPECT_EQ(qc.at(6)->getType(), P);
   EXPECT_EQ(qc.at(6)->getParameter().at(0), 0.5);
 }
 
@@ -640,15 +640,15 @@ TEST_F(QFRFunctionality, U3SpecialCases) {
   qc.u(0.5, 0.25, 0.125, 0); // U3(0.5, 0.25, 0.125)
 
   std::cout << qc << "\n";
-  EXPECT_EQ(qc.at(0)->getType(), qc::RY);
+  EXPECT_EQ(qc.at(0)->getType(), RY);
   EXPECT_EQ(qc.at(0)->getParameter().at(0), 0.5);
-  EXPECT_EQ(qc.at(1)->getType(), qc::RX);
+  EXPECT_EQ(qc.at(1)->getType(), RX);
   EXPECT_EQ(qc.at(1)->getParameter().at(0), 0.5);
-  EXPECT_EQ(qc.at(2)->getType(), qc::RX);
+  EXPECT_EQ(qc.at(2)->getType(), RX);
   EXPECT_EQ(qc.at(2)->getParameter().at(0), -0.5);
-  EXPECT_EQ(qc.at(3)->getType(), qc::Y);
-  EXPECT_EQ(qc.at(4)->getType(), qc::X);
-  EXPECT_EQ(qc.at(5)->getType(), qc::U);
+  EXPECT_EQ(qc.at(3)->getType(), Y);
+  EXPECT_EQ(qc.at(4)->getType(), X);
+  EXPECT_EQ(qc.at(5)->getType(), U);
   EXPECT_EQ(qc.at(5)->getParameter().at(0), 0.5);
   EXPECT_EQ(qc.at(5)->getParameter().at(1), 0.25);
   EXPECT_EQ(qc.at(5)->getParameter().at(2), 0.125);
@@ -664,19 +664,19 @@ TEST_F(QFRFunctionality, GlobalPhaseNormalization) {
 }
 
 TEST_F(QFRFunctionality, OpNameToTypeSimple) {
-  EXPECT_EQ(qc::OpType::X, qc::opTypeFromString("x"));
-  EXPECT_EQ(qc::OpType::Y, qc::opTypeFromString("y"));
-  EXPECT_EQ(qc::OpType::Z, qc::opTypeFromString("z"));
+  EXPECT_EQ(OpType::X, opTypeFromString("x"));
+  EXPECT_EQ(OpType::Y, opTypeFromString("y"));
+  EXPECT_EQ(OpType::Z, opTypeFromString("z"));
 
-  EXPECT_EQ(qc::OpType::H, qc::opTypeFromString("h"));
-  EXPECT_EQ(qc::OpType::S, qc::opTypeFromString("s"));
-  EXPECT_EQ(qc::OpType::Sdg, qc::opTypeFromString("sdg"));
-  EXPECT_EQ(qc::OpType::T, qc::opTypeFromString("t"));
-  EXPECT_EQ(qc::OpType::Tdg, qc::opTypeFromString("tdg"));
+  EXPECT_EQ(OpType::H, opTypeFromString("h"));
+  EXPECT_EQ(OpType::S, opTypeFromString("s"));
+  EXPECT_EQ(OpType::Sdg, opTypeFromString("sdg"));
+  EXPECT_EQ(OpType::T, opTypeFromString("t"));
+  EXPECT_EQ(OpType::Tdg, opTypeFromString("tdg"));
 
-  EXPECT_EQ(qc::OpType::X, qc::opTypeFromString("cnot"));
+  EXPECT_EQ(OpType::X, opTypeFromString("cnot"));
 
-  EXPECT_THROW([[maybe_unused]] const auto type = qc::opTypeFromString("foo"),
+  EXPECT_THROW([[maybe_unused]] const auto type = opTypeFromString("foo"),
                std::invalid_argument);
 }
 
@@ -688,7 +688,7 @@ TEST_F(QFRFunctionality, dumpAndImportTeleportation) {
   EXPECT_TRUE(ss.str().find("teleport") != std::string::npos);
 
   QuantumComputation qcImported(3);
-  qcImported.import(ss, qc::Format::OpenQASM2);
+  qcImported.import(ss, Format::OpenQASM2);
   ASSERT_EQ(qcImported.size(), 1);
   EXPECT_EQ(qcImported.at(0)->getType(), OpType::Teleportation);
 }
@@ -968,7 +968,7 @@ TEST_F(QFRFunctionality, invertSymbolicOpParamChange) {
 }
 
 TEST_F(QFRFunctionality, measureAll) {
-  qc::QuantumComputation qc(2U);
+  QuantumComputation qc(2U);
   qc.measureAll();
   std::cout << qc << "\n";
   EXPECT_EQ(qc.getNops(), 3U);
@@ -979,7 +979,7 @@ TEST_F(QFRFunctionality, measureAll) {
 }
 
 TEST_F(QFRFunctionality, measureAllExistingRegister) {
-  qc::QuantumComputation qc(2U, 2U);
+  QuantumComputation qc(2U, 2U);
   qc.measureAll(false);
   std::cout << qc << "\n";
   EXPECT_EQ(qc.getNops(), 3U);
@@ -990,7 +990,7 @@ TEST_F(QFRFunctionality, measureAllExistingRegister) {
 }
 
 TEST_F(QFRFunctionality, measureAllInsufficientRegisterSize) {
-  qc::QuantumComputation qc(2U, 1U);
+  QuantumComputation qc(2U, 1U);
   EXPECT_THROW(qc.measureAll(false), QFRException);
 }
 
@@ -1067,7 +1067,8 @@ TEST_F(QFRFunctionality, testSettingSetMultipleAncillariesAndGarbage) {
 }
 
 TEST_F(QFRFunctionality, StripIdleQubitsInMiddleOfCircuit) {
-  qc::QuantumComputation qc(5U);
+  QuantumComputation qc{};
+  qc.addQubitRegister(5, "q");
   qc.setLogicalQubitAncillary(3U);
   qc.setLogicalQubitAncillary(4U);
   qc.setLogicalQubitGarbage(3U);
@@ -1168,7 +1169,7 @@ TEST_F(QFRFunctionality, emptyPermutation) {
 TEST_F(QFRFunctionality, NoRegisterOnEmptyCircuit) {
   // This is a regression test. Previously, the following code would throw an
   // exception because even zero-qubit circuits had an empty register named "q".
-  qc::QuantumComputation qc(0U);
+  QuantumComputation qc(0U);
   qc.addQubitRegister(1U, "p");
   EXPECT_NO_THROW(qc.addQubitRegister(1U, "q"));
   EXPECT_EQ(qc.getQregs().size(), 2U);
@@ -1471,3 +1472,5 @@ TEST_F(QFRFunctionality, InequalityDifferentAdditionalOperations) {
   qc2.barrier(); // qc2 has an additional barrier
   EXPECT_NE(qc1, qc2);
 }
+
+} // namespace qc


### PR DESCRIPTION
## Description

This PR originated out of working on #729. It refactors certain aspects of how registers are handled in MQT Core. In particular:
- Registers are now no longer typedefs, but proper structs with some convenience methods that make the code more legible.
- Classic-controlled operations now either take a full `ClassicalRegister` or a single bit. This closely matches the kind of operations we actually support and defines some errors out of existance.
- The QASM dump functionality has been made more robust and can now, in principle, handle discontinuous registers.

In addition to that,
- a couple of redundant functions have been removed
- some general typedefs have been moved to more explicit places, and
- some clang-tidy recommendations have been implemented.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
