### PR TITLE
🐛 do not invalidate iterator in block collection

### DIFF
--- a/src/circuit_optimizer/CircuitOptimizer.cpp
+++ b/src/circuit_optimizer/CircuitOptimizer.cpp
@@ -1399,7 +1399,10 @@ struct DSU {
     } else {
       *currentBlockInCircuit[block] = std::move(compoundOp);
     }
-    for (auto i : bitBlocks[block]) {
+    // need to make a copy here because otherwise the updates in the loop might
+    // invalidate the iterator
+    const auto blockBits = bitBlocks[block];
+    for (auto i : blockBits) {
       parent[i] = i;
       bitBlocks[i] = {i};
       currentBlockInCircuit[i] = nullptr;


### PR DESCRIPTION
## Description

This fixes a small bug observed as part of #803, which only surfaced on Windows in Debug mode when compiling using Clang 🤯 
Part of the block collection code in the circuit optimizer would invalidate an iterator due to an update of the respective container being iterated over within the loop.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
