### PR TITLE
🐛 fix permutation handling in QASM dump

### DIFF
--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -721,12 +721,17 @@ void QuantumComputation::dump(const std::string& filename) const {
 
 void QuantumComputation::dumpOpenQASM(std::ostream& of, bool openQASM3) const {
   // dump initial layout and output permutation
+
   // since it might happen that the physical qubit indices are not consecutive,
   // due to qubit removals, we need to adjust them accordingly.
+  Permutation qubitToIndex{};
+
   Permutation inverseInitialLayout{};
-  std::size_t idx = 0;
+  Qubit idx = 0;
   for (const auto& [physical, logical] : initialLayout) {
-    inverseInitialLayout.emplace(logical, idx++);
+    inverseInitialLayout.emplace(logical, idx);
+    qubitToIndex[physical] = idx;
+    ++idx;
   }
   of << "// i";
   for (const auto& [logical, physical] : inverseInitialLayout) {
@@ -735,9 +740,8 @@ void QuantumComputation::dumpOpenQASM(std::ostream& of, bool openQASM3) const {
   of << "\n";
 
   Permutation inverseOutputPermutation{};
-  idx = 0;
   for (const auto& [physical, logical] : outputPermutation) {
-    inverseOutputPermutation.emplace(logical, idx++);
+    inverseOutputPermutation.emplace(logical, qubitToIndex[physical]);
   }
   of << "// o";
   for (const auto& [logical, physical] : inverseOutputPermutation) {

--- a/test/ir/test_io.cpp
+++ b/test/ir/test_io.cpp
@@ -686,3 +686,14 @@ TEST_F(IO, classicalControlledOperationToOpenQASM3) {
   const auto actual = qc->toQASM();
   EXPECT_EQ(expected, actual);
 }
+
+TEST_F(IO, dumpingIncompleteOutputPermutationNotStartingAtZero) {
+  qc->addQubitRegister(2);
+  qc->addClassicalRegister(1);
+  qc->measure(1, 0);
+  qc->initializeIOMapping();
+  const auto qasm = qc->toQASM();
+  std::cout << qasm << "\n";
+  const auto qc2 = qc::QuantumComputation::fromQASM(qasm);
+  EXPECT_EQ(*qc, qc2);
+}


### PR DESCRIPTION
## Description

This PR fixes an oversight in #753 where the respective changes would sometimes create invalid output permutation dumps.
This surfaced as part of https://github.com/cda-tum/mqt-qmap/pull/418.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
