### PR TITLE
🚸 Add support for indexed identifiers and improve OpenQASM handling

### DIFF
--- a/include/mqt-core/qasm3/Importer.hpp
+++ b/include/mqt-core/qasm3/Importer.hpp
@@ -99,11 +99,10 @@ private:
                                          type_checking::InferredType>>
   initializeBuiltins();
 
-  static void
-  translateGateOperand(const std::shared_ptr<GateOperand>& gateOperand,
-                       std::vector<qc::Qubit>& qubits,
-                       const qc::QuantumRegisterMap& qregs,
-                       const std::shared_ptr<DebugInfo>& debugInfo);
+  void translateGateOperand(const std::shared_ptr<GateOperand>& gateOperand,
+                            std::vector<qc::Qubit>& qubits,
+                            const qc::QuantumRegisterMap& qregs,
+                            const std::shared_ptr<DebugInfo>& debugInfo) const;
 
   void translateBitOperand(
       const std::shared_ptr<IndexedIdentifier>& indexedIdentifier,

--- a/include/mqt-core/qasm3/InstVisitor.hpp
+++ b/include/mqt-core/qasm3/InstVisitor.hpp
@@ -78,6 +78,8 @@ public:
       std::shared_ptr<IdentifierExpression> identifierExpression) = 0;
   virtual T
   visitIdentifierList(std::shared_ptr<IdentifierList> identifierList) = 0;
+  virtual T visitIndexedIdentifier(
+      std::shared_ptr<IndexedIdentifier> indexedIdentifier) = 0;
   virtual T visitMeasureExpression(
       std::shared_ptr<MeasureExpression> measureExpression) = 0;
 
@@ -107,6 +109,10 @@ public:
     if (const auto identifierList =
             std::dynamic_pointer_cast<IdentifierList>(expression)) {
       return visitIdentifierList(identifierList);
+    }
+    if (const auto indexedIdentifier =
+            std::dynamic_pointer_cast<IndexedIdentifier>(expression)) {
+      return visitIndexedIdentifier(indexedIdentifier);
     }
     if (const auto measureExpression =
             std::dynamic_pointer_cast<MeasureExpression>(expression)) {

--- a/include/mqt-core/qasm3/Parser.hpp
+++ b/include/mqt-core/qasm3/Parser.hpp
@@ -123,6 +123,10 @@ public:
 
   std::shared_ptr<GateModifier> parseGateModifier();
 
+  std::shared_ptr<IndexOperator> parseIndexOperator();
+
+  std::shared_ptr<IndexedIdentifier> parseIndexedIdentifier();
+
   std::shared_ptr<GateOperand> parseGateOperand();
 
   std::shared_ptr<DeclarationExpression> parseDeclarationExpression();

--- a/include/mqt-core/qasm3/Statement_fwd.hpp
+++ b/include/mqt-core/qasm3/Statement_fwd.hpp
@@ -23,6 +23,8 @@ class AssignmentStatement;
 class VersionDeclaration;
 class DeclarationExpression;
 class DeclarationStatement;
+class IndexOperator;
+class IndexedIdentifier;
 class GateOperand;
 class GateModifier;
 class QuantumStatement;

--- a/include/mqt-core/qasm3/Types.hpp
+++ b/include/mqt-core/qasm3/Types.hpp
@@ -44,6 +44,7 @@ public:
   virtual bool isUint() { return false; }
   virtual bool isBit() { return false; }
 
+  virtual bool isConvertibleToBool() { return isBool(); }
   virtual bool fits(const Type& other) { return *this == other; }
 
   virtual std::string toString() = 0;
@@ -116,6 +117,14 @@ public:
   bool isBit() override { return type == Bit; }
 
   bool isFP() override { return type == Float; }
+
+  bool isConvertibleToBool() override {
+    if constexpr (std::is_integral_v<T>) {
+      return type == Bit && designator == 1;
+    } else {
+      return false;
+    }
+  }
 
   bool fits(const Type<T>& other) override;
 

--- a/include/mqt-core/qasm3/passes/ConstEvalPass.hpp
+++ b/include/mqt-core/qasm3/passes/ConstEvalPass.hpp
@@ -86,6 +86,8 @@ public:
       std::shared_ptr<IdentifierExpression> identifierExpression) override;
   std::optional<ConstEvalValue>
   visitIdentifierList(std::shared_ptr<IdentifierList> identifierList) override;
+  std::optional<ConstEvalValue> visitIndexedIdentifier(
+      std::shared_ptr<IndexedIdentifier> indexedIdentifier) override;
   std::optional<ConstEvalValue> visitMeasureExpression(
       std::shared_ptr<MeasureExpression> measureExpression) override;
 

--- a/include/mqt-core/qasm3/passes/TypeCheckPass.hpp
+++ b/include/mqt-core/qasm3/passes/TypeCheckPass.hpp
@@ -58,6 +58,7 @@ class TypeCheckPass final : public CompilerPass,
                             public InstVisitor,
                             public ExpressionVisitor<InferredType> {
   bool hasError = false;
+  std::string errMessage;
   std::map<std::string, InferredType> env;
   // We need a reference to a const eval pass to evaluate types before type
   // checking.
@@ -78,6 +79,8 @@ public:
 
   void processStatement(Statement& statement) override;
 
+  void checkIndexOperator(const IndexOperator& indexOperator);
+  void checkIndexedIdentifier(const IndexedIdentifier& id);
   void checkGateOperand(const GateOperand& operand);
 
   // Types
@@ -112,6 +115,8 @@ public:
       std::shared_ptr<IdentifierExpression> identifierExpression) override;
   InferredType
   visitIdentifierList(std::shared_ptr<IdentifierList> identifierList) override;
+  InferredType visitIndexedIdentifier(
+      std::shared_ptr<IndexedIdentifier> indexedIdentifier) override;
   InferredType visitMeasureExpression(
       std::shared_ptr<MeasureExpression> measureExpression) override;
 };

--- a/src/ir/operations/ClassicControlledOperation.cpp
+++ b/src/ir/operations/ClassicControlledOperation.cpp
@@ -72,6 +72,11 @@ ClassicControlledOperation::ClassicControlledOperation(
         "Expected value for single bit comparison must be 0 or 1.");
   }
   name = "c_" + shortName(op->getType());
+  // Canonicalize comparisons on a single bit.
+  if (comparisonKind == Neq) {
+    comparisonKind = Eq;
+    expectedValue = 1 - expectedValue;
+  }
   if (comparisonKind != Eq) {
     throw std::invalid_argument(
         "Inequality comparisons on a single bit are not supported.");

--- a/src/ir/operations/ClassicControlledOperation.cpp
+++ b/src/ir/operations/ClassicControlledOperation.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <memory>
 #include <ostream>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -66,7 +67,15 @@ ClassicControlledOperation::ClassicControlledOperation(
     const std::uint64_t expectedVal, const ComparisonKind kind)
     : op(std::move(operation)), controlBit(cBit), expectedValue(expectedVal),
       comparisonKind(kind) {
+  if (expectedVal > 1) {
+    throw std::invalid_argument(
+        "Expected value for single bit comparison must be 0 or 1.");
+  }
   name = "c_" + shortName(op->getType());
+  if (comparisonKind != Eq) {
+    throw std::invalid_argument(
+        "Inequality comparisons on a single bit are not supported.");
+  }
   parameter.reserve(2);
   parameter.emplace_back(static_cast<fp>(cBit));
   parameter.emplace_back(static_cast<fp>(expectedValue));

--- a/src/ir/operations/ClassicControlledOperation.cpp
+++ b/src/ir/operations/ClassicControlledOperation.cpp
@@ -134,14 +134,14 @@ void ClassicControlledOperation::dumpOpenQASM(
   of << "if (";
   if (controlRegister.has_value()) {
     assert(!controlBit.has_value());
-    of << controlRegister->getName();
+    of << controlRegister->getName() << " " << comparisonKind << " "
+       << expectedValue;
   }
   if (controlBit.has_value()) {
     assert(!controlRegister.has_value());
-    const auto& creg = bitMap.at(*controlBit);
-    of << creg.second;
+    of << (expectedValue == 0 ? "!" : "") << bitMap.at(*controlBit).second;
   }
-  of << " " << comparisonKind << " " << expectedValue << ") ";
+  of << ") ";
   if (openQASM3) {
     of << "{\n";
   }

--- a/src/ir/operations/ClassicControlledOperation.cpp
+++ b/src/ir/operations/ClassicControlledOperation.cpp
@@ -51,7 +51,7 @@ std::ostream& operator<<(std::ostream& os, const ComparisonKind& kind) {
 
 ClassicControlledOperation::ClassicControlledOperation(
     std::unique_ptr<Operation>&& operation, ClassicalRegister controlReg,
-    const std::uint64_t expectedVal, ComparisonKind kind)
+    const std::uint64_t expectedVal, const ComparisonKind kind)
     : op(std::move(operation)), controlRegister(std::move(controlReg)),
       expectedValue(expectedVal), comparisonKind(kind) {
   name = "c_" + shortName(op->getType());
@@ -63,7 +63,7 @@ ClassicControlledOperation::ClassicControlledOperation(
 }
 ClassicControlledOperation::ClassicControlledOperation(
     std::unique_ptr<Operation>&& operation, const Bit cBit,
-    const std::uint64_t expectedVal, ComparisonKind kind)
+    const std::uint64_t expectedVal, const ComparisonKind kind)
     : op(std::move(operation)), controlBit(cBit), expectedValue(expectedVal),
       comparisonKind(kind) {
   name = "c_" + shortName(op->getType());

--- a/src/qasm3/Importer.cpp
+++ b/src/qasm3/Importer.cpp
@@ -100,8 +100,16 @@ Importer::initializeBuiltins() {
 void Importer::translateGateOperand(
     const std::shared_ptr<GateOperand>& gateOperand,
     std::vector<qc::Qubit>& qubits, const qc::QuantumRegisterMap& qregs,
-    const std::shared_ptr<DebugInfo>& debugInfo) {
+    const std::shared_ptr<DebugInfo>& debugInfo) const {
   if (gateOperand->isHardwareQubit()) {
+    const auto hardwareQubit = gateOperand->getHardwareQubit();
+    // Ensure that the circuit has enough qubits.
+    // Currently, we emulate hardware qubits via a single quantum register q.
+    for (size_t i = qc->getNqubits(); i <= hardwareQubit; ++i) {
+      const auto q = static_cast<qc::Qubit>(i);
+      qc->addQubit(q, q, q);
+    }
+
     qubits.emplace_back(
         static_cast<qc::Qubit>(gateOperand->getHardwareQubit()));
     return;

--- a/src/qasm3/Importer.cpp
+++ b/src/qasm3/Importer.cpp
@@ -38,8 +38,10 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <unordered_set>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace qasm3 {
@@ -99,65 +101,157 @@ void Importer::translateGateOperand(
     const std::shared_ptr<GateOperand>& gateOperand,
     std::vector<qc::Qubit>& qubits, const qc::QuantumRegisterMap& qregs,
     const std::shared_ptr<DebugInfo>& debugInfo) {
-  translateGateOperand(gateOperand->identifier, gateOperand->expression, qubits,
-                       qregs, debugInfo);
-}
-
-void Importer::translateGateOperand(
-    const std::string& gateIdentifier,
-    const std::shared_ptr<Expression>& indexExpr,
-    std::vector<qc::Qubit>& qubits, const qc::QuantumRegisterMap& qregs,
-    const std::shared_ptr<DebugInfo>& debugInfo) {
-  const auto qubitIter = qregs.find(gateIdentifier);
-  if (qubitIter == qregs.end()) {
+  if (gateOperand->isHardwareQubit()) {
+    qubits.emplace_back(
+        static_cast<qc::Qubit>(gateOperand->getHardwareQubit()));
+    return;
+  }
+  const auto indexedIdentifier = gateOperand->getIdentifier();
+  const auto qregIterator = qregs.find(indexedIdentifier->identifier);
+  if (qregIterator == qregs.end()) {
     throw CompilerError("Usage of unknown quantum register.", debugInfo);
   }
-  auto qubit = qubitIter->second;
+  const auto& qreg = qregIterator->second;
 
-  if (indexExpr != nullptr) {
-    const auto result = evaluatePositiveConstant(indexExpr, debugInfo);
-
-    if (result >= qubit.getSize()) {
-      throw CompilerError(
-          "Index expression must be smaller than the width of the "
-          "quantum register.",
-          debugInfo);
+  // full register
+  if (indexedIdentifier->indices.empty()) {
+    for (size_t i = 0; i < qreg.getSize(); ++i) {
+      qubits.emplace_back(static_cast<qc::Qubit>(qreg.getStartIndex() + i));
     }
-    qubit.getStartIndex() += static_cast<qc::Qubit>(result);
-    qubit.getSize() = 1;
+    return;
   }
 
-  for (uint64_t i = 0; i < qubit.getSize(); ++i) {
-    qubits.emplace_back(static_cast<qc::Qubit>(qubit.getStartIndex() + i));
+  if (indexedIdentifier->indices.size() > 1) {
+    throw CompilerError("Only single index expressions are supported.",
+                        debugInfo);
   }
+  const auto indexOperator = indexedIdentifier->indices[0];
+  if (indexOperator->indexExpressions.size() > 1) {
+    throw CompilerError("Only single index expressions are supported.",
+                        debugInfo);
+  }
+  const auto indexExpression = indexOperator->indexExpressions[0];
+  const auto result = evaluatePositiveConstant(indexExpression, debugInfo);
+
+  if (result >= qreg.getSize()) {
+    throw CompilerError(
+        "Index expression must be smaller than the width of the "
+        "quantum register.",
+        debugInfo);
+  }
+  qubits.emplace_back(qreg.getStartIndex() + static_cast<qc::Qubit>(result));
 }
 
 void Importer::translateBitOperand(
-    const std::string& bitIdentifier,
-    const std::shared_ptr<Expression>& indexExpr, std::vector<qc::Bit>& bits,
+    const std::shared_ptr<IndexedIdentifier>& indexedIdentifier,
+    std::vector<qc::Bit>& bits,
     const std::shared_ptr<DebugInfo>& debugInfo) const {
-  const auto iter = qc->getClassicalRegisters().find(bitIdentifier);
+  const auto iter =
+      qc->getClassicalRegisters().find(indexedIdentifier->identifier);
   if (iter == qc->getClassicalRegisters().end()) {
     throw CompilerError("Usage of unknown classical register.", debugInfo);
   }
-  auto creg = iter->second;
+  const auto& creg = iter->second;
+  const auto& indices = indexedIdentifier->indices;
+  // full register
+  if (indices.empty()) {
+    for (size_t i = 0; i < creg.getSize(); ++i) {
+      bits.emplace_back(creg.getStartIndex() + i);
+    }
+    return;
+  }
 
-  if (indexExpr != nullptr) {
-    const auto index = evaluatePositiveConstant(indexExpr, debugInfo);
-    if (index >= creg.getSize()) {
-      throw CompilerError(
-          "Index expression must be smaller than the width of the "
-          "classical register.",
-          debugInfo);
+  if (indices.size() > 1) {
+    throw CompilerError("Only single index expressions are supported.",
+                        debugInfo);
+  }
+  const auto& indexExpressions = indices[0]->indexExpressions;
+  if (indexExpressions.size() > 1) {
+    throw CompilerError("Only single index expressions are supported.",
+                        debugInfo);
+  }
+  const auto& indexExpression = indexExpressions[0];
+  const auto index = evaluatePositiveConstant(indexExpression, debugInfo);
+  if (index >= creg.getSize()) {
+    throw CompilerError(
+        "Index expression must be smaller than the width of the "
+        "classical register.",
+        debugInfo);
+  }
+  bits.emplace_back(creg.getStartIndex() + index);
+}
+
+std::variant<std::pair<qc::Bit, bool>,
+             std::tuple<qc::ClassicalRegister, qc::ComparisonKind, uint64_t>>
+Importer::translateCondition(
+    const std::shared_ptr<Expression>& condition,
+    const std::shared_ptr<DebugInfo>& debugInfo) const {
+  if (const auto binaryExpression =
+          std::dynamic_pointer_cast<BinaryExpression>(condition);
+      binaryExpression != nullptr) {
+    const auto comparisonKind = getComparisonKind(binaryExpression->op);
+    if (!comparisonKind) {
+      throw CompilerError("Unsupported comparison operator.", debugInfo);
+    }
+    auto lhsIsIdentifier = true;
+    std::shared_ptr<Expression> lhs =
+        std::dynamic_pointer_cast<IndexedIdentifier>(binaryExpression->lhs);
+    if (lhs == nullptr) {
+      lhsIsIdentifier = false;
+      lhs = std::dynamic_pointer_cast<Constant>(binaryExpression->lhs);
+    }
+    std::shared_ptr<Expression> rhs{};
+    if (lhsIsIdentifier) {
+      rhs = std::dynamic_pointer_cast<Constant>(binaryExpression->rhs);
+    } else {
+      rhs = std::dynamic_pointer_cast<IndexedIdentifier>(binaryExpression->rhs);
+    }
+    if (lhs == nullptr || rhs == nullptr) {
+      throw CompilerError("Only classical registers and constants are "
+                          "supported in conditions.",
+                          debugInfo);
     }
 
-    creg.getStartIndex() += index;
-    creg.getSize() = 1;
-  }
+    const auto& indexedIdentifier =
+        lhsIsIdentifier ? std::dynamic_pointer_cast<IndexedIdentifier>(lhs)
+                        : std::dynamic_pointer_cast<IndexedIdentifier>(rhs);
+    const auto& identifier = indexedIdentifier->identifier;
+    const auto val = lhsIsIdentifier
+                         ? std::dynamic_pointer_cast<Constant>(rhs)->getUInt()
+                         : std::dynamic_pointer_cast<Constant>(lhs)->getUInt();
 
-  for (uint64_t i = 0; i < creg.getSize(); ++i) {
-    bits.emplace_back(creg.getStartIndex() + i);
+    const auto creg = qc->getClassicalRegisters().find(identifier);
+    if (creg == qc->getClassicalRegisters().end()) {
+      throw CompilerError("Usage of unknown or invalid identifier '" +
+                              identifier + "' in condition.",
+                          debugInfo);
+    }
+    return std::tuple{creg->second, *comparisonKind, val};
   }
+  if (const auto unaryExpression =
+          std::dynamic_pointer_cast<UnaryExpression>(condition);
+      unaryExpression != nullptr) {
+    // This should already be caught by the type checker.
+    assert(unaryExpression->op == UnaryExpression::LogicalNot ||
+           unaryExpression->op == UnaryExpression::BitwiseNot);
+    const auto& indexedIdentifier =
+        std::dynamic_pointer_cast<IndexedIdentifier>(unaryExpression->operand);
+    std::vector<qc::Bit> bits{};
+    translateBitOperand(indexedIdentifier, bits, debugInfo);
+    // This should already be caught by the type checker.
+    assert(bits.size() == 1);
+    return std::pair{bits[0], false};
+  }
+  // must be a single bit at this point
+  const auto& indexedIdentifier =
+      std::dynamic_pointer_cast<IndexedIdentifier>(condition);
+  // should also be caught by the type checker
+  assert(indexedIdentifier != nullptr);
+  std::vector<qc::Bit> bits{};
+  translateBitOperand(indexedIdentifier, bits, debugInfo);
+  // This should already be caught by the type checker.
+  assert(bits.size() == 1);
+  return std::pair{bits[0], true};
 }
 
 uint64_t
@@ -261,8 +355,8 @@ void Importer::visitDeclarationStatement(
               declarationStatement->expression->expression)) {
     assert(!declarationStatement->isConst &&
            "Type check pass should catch this");
-    visitMeasureAssignment(identifier, nullptr, measureExpression,
-                           declarationStatement->debugInfo);
+    visitMeasureAssignment(std::make_shared<IndexedIdentifier>(identifier),
+                           measureExpression, declarationStatement->debugInfo);
     return;
   }
   if (declarationStatement->isConst) {
@@ -285,8 +379,8 @@ void Importer::visitAssignmentStatement(
   if (const auto measureExpression =
           std::dynamic_pointer_cast<MeasureExpression>(
               assignmentStatement->expression->expression)) {
-    visitMeasureAssignment(identifier, assignmentStatement->indexExpression,
-                           measureExpression, assignmentStatement->debugInfo);
+    visitMeasureAssignment(assignmentStatement->identifier, measureExpression,
+                           assignmentStatement->debugInfo);
     return;
   }
 
@@ -550,42 +644,38 @@ std::unique_ptr<qc::Operation> Importer::evaluateGateCall(
     i++;
   }
 
-  // check if any of the bits are duplicate
-  std::unordered_set<qc::Qubit> allQubits;
-  for (const auto& control : controlBits) {
-    if (allQubits.find(control.qubit) != allQubits.end()) {
-      throw CompilerError("Duplicate qubit in control list.",
-                          gateCallStatement->debugInfo);
-    }
-    allQubits.emplace(control.qubit);
-  }
-  for (const auto& qubit : targetBits) {
-    if (allQubits.find(qubit) != allQubits.end()) {
-      throw CompilerError("Duplicate qubit in target list.",
-                          gateCallStatement->debugInfo);
-    }
-    allQubits.emplace(qubit);
-  }
-
-  if (broadcastingWidth == 1) {
-    return applyQuantumOperation(gate, targetBits, controlBits,
-                                 evaluatedParameters, invertOperation,
-                                 gateCallStatement->debugInfo);
-  }
-
-  // if we are broadcasting, we need to create a compound operation
   auto op = std::make_unique<qc::CompoundOperation>();
   for (size_t j = 0; j < broadcastingWidth; ++j) {
+    // check if any of the bits are duplicate
+    std::unordered_set<qc::Qubit> allQubits;
+    for (const auto& control : controlBits) {
+      if (allQubits.find(control.qubit) != allQubits.end()) {
+        throw CompilerError("Duplicate qubit in control list.",
+                            gateCallStatement->debugInfo);
+      }
+      allQubits.emplace(control.qubit);
+    }
+    for (const auto& qubit : targetBits) {
+      if (allQubits.find(qubit) != allQubits.end()) {
+        throw CompilerError("Duplicate qubit in target list.",
+                            gateCallStatement->debugInfo);
+      }
+      allQubits.emplace(qubit);
+    }
+
     // first we apply the operation
     auto nestedOp = applyQuantumOperation(gate, targetBits, controlBits,
                                           evaluatedParameters, invertOperation,
                                           gateCallStatement->debugInfo);
-    if (nestedOp == nullptr) {
-      return nullptr;
+    if (nestedOp == nullptr || broadcastingWidth == 1) {
+      return nestedOp;
     }
     op->getOps().emplace_back(std::move(nestedOp));
 
     // after applying the operation, we update the broadcast bits
+    if (j == broadcastingWidth - 1) {
+      break;
+    }
     for (auto index : targetBroadcastingIndices) {
       targetBits[index] = qc::Qubit{targetBits[index] + 1};
     }
@@ -610,8 +700,8 @@ Importer::getMcGateDefinition(const std::string& identifier, size_t operandSize,
   for (size_t i = 0; i < operandSize; ++i) {
     targetParams.emplace_back("q" + std::to_string(i));
     if (i < nTargets) {
-      operands.emplace_back(
-          std::make_shared<GateOperand>("q" + std::to_string(i), nullptr));
+      operands.emplace_back(std::make_shared<GateOperand>(
+          std::make_shared<IndexedIdentifier>("q" + std::to_string(i))));
     }
   }
   const size_t nControls = nTargets - 1;
@@ -645,12 +735,11 @@ std::unique_ptr<qc::Operation> Importer::applyQuantumOperation(
     const std::shared_ptr<DebugInfo>& debugInfo) {
   if (auto* standardGate = dynamic_cast<StandardGate*>(gate.get())) {
     auto op = std::make_unique<qc::StandardOperation>(
-        qc::Controls{}, targetBits, standardGate->info.type,
-        evaluatedParameters);
+        qc::Controls{controlBits.begin(), controlBits.end()}, targetBits,
+        standardGate->info.type, evaluatedParameters);
     if (invertOperation) {
       op->invert();
     }
-    op->setControls(qc::Controls{controlBits.begin(), controlBits.end()});
     return op;
   }
   if (auto* compoundGate = dynamic_cast<CompoundGate*>(gate.get())) {
@@ -691,10 +780,15 @@ std::unique_ptr<qc::Operation> Importer::applyQuantumOperation(
                      std::dynamic_pointer_cast<GateCallStatement>(nestedGate);
                  gateCallStatement != nullptr) {
         for (const auto& operand : gateCallStatement->operands) {
+          if (operand->isHardwareQubit()) {
+            continue;
+          }
+          const auto& identifier = operand->getIdentifier();
           // OpenQASM 3.0 doesn't support indexing of gate arguments.
-          if (operand->expression != nullptr &&
+          if (!identifier->indices.empty() &&
               std::find(compoundGate->targetNames.begin(),
-                        compoundGate->targetNames.end(), operand->identifier) !=
+                        compoundGate->targetNames.end(),
+                        identifier->identifier) !=
                   compoundGate->targetNames.end()) {
             throw CompilerError(
                 "Gate arguments cannot be indexed within gate body.",
@@ -732,10 +826,10 @@ std::unique_ptr<qc::Operation> Importer::applyQuantumOperation(
 }
 
 void Importer::visitMeasureAssignment(
-    const std::string& identifier,
-    const std::shared_ptr<Expression>& indexExpression,
+    const std::shared_ptr<IndexedIdentifier>& indexedIdentifier,
     const std::shared_ptr<MeasureExpression>& measureExpression,
     const std::shared_ptr<DebugInfo>& debugInfo) {
+  const auto& identifier = indexedIdentifier->identifier;
   const auto decl = declarations.find(identifier);
   if (!decl.has_value()) {
     throw CompilerError("Usage of unknown identifier '" + identifier + "'.",
@@ -752,7 +846,7 @@ void Importer::visitMeasureAssignment(
   std::vector<qc::Bit> bits{};
   translateGateOperand(measureExpression->gate, qubits,
                        qc->getQuantumRegisters(), debugInfo);
-  translateBitOperand(identifier, indexExpression, bits, debugInfo);
+  translateBitOperand(indexedIdentifier, bits, debugInfo);
 
   if (qubits.size() != bits.size()) {
     throw CompilerError(
@@ -760,7 +854,7 @@ void Importer::visitMeasureAssignment(
         "measure statement. Classical register '" +
             identifier + "' has " + std::to_string(bits.size()) +
             " bits, but quantum register '" +
-            measureExpression->gate->identifier + "' has " +
+            measureExpression->gate->getName() + "' has " +
             std::to_string(qubits.size()) + " qubits.",
         debugInfo);
   }
@@ -788,55 +882,40 @@ void Importer::visitResetStatement(
 
 void Importer::visitIfStatement(
     const std::shared_ptr<IfStatement> ifStatement) {
-  // TODO: for now we only support statements comparing a classical bit reg
-  // to a constant.
-  const auto condition =
-      std::dynamic_pointer_cast<BinaryExpression>(ifStatement->condition);
-  if (condition == nullptr) {
-    throw CompilerError("Condition not supported for if statement.",
-                        ifStatement->debugInfo);
-  }
-
-  const auto comparisonKind = getComparisonKind(condition->op);
-  if (!comparisonKind) {
-    throw CompilerError("Unsupported comparison operator.",
-                        ifStatement->debugInfo);
-  }
-
-  const auto lhs =
-      std::dynamic_pointer_cast<IdentifierExpression>(condition->lhs);
-  const auto rhs = std::dynamic_pointer_cast<Constant>(condition->rhs);
-
-  if (lhs == nullptr) {
-    throw CompilerError("Only classical registers are supported in conditions.",
-                        ifStatement->debugInfo);
-  }
-  if (rhs == nullptr) {
-    throw CompilerError("Can only compare to constants.",
-                        ifStatement->debugInfo);
-  }
-
-  const auto creg = qc->getClassicalRegisters().find(lhs->identifier);
-  if (creg == qc->getClassicalRegisters().end()) {
-    throw CompilerError("Usage of unknown or invalid identifier '" +
-                            lhs->identifier + "' in condition.",
-                        ifStatement->debugInfo);
-  }
+  const auto& condition =
+      translateCondition(ifStatement->condition, ifStatement->debugInfo);
 
   // translate statements in then/else blocks
   if (!ifStatement->thenStatements.empty()) {
     auto thenOps = translateBlockOperations(ifStatement->thenStatements);
-    qc->emplace_back<qc::ClassicControlledOperation>(
-        std::move(thenOps), creg->second, rhs->getUInt(), *comparisonKind);
+    if (std::holds_alternative<std::pair<qc::Bit, bool>>(condition)) {
+      const auto& [bit, val] = std::get<std::pair<qc::Bit, bool>>(condition);
+      qc->emplace_back<qc::ClassicControlledOperation>(std::move(thenOps), bit,
+                                                       val ? 1 : 0);
+    } else {
+      const auto& [creg, comparisonKind, rhs] = std::get<
+          std::tuple<qc::ClassicalRegister, qc::ComparisonKind, uint64_t>>(
+          condition);
+      qc->emplace_back<qc::ClassicControlledOperation>(std::move(thenOps), creg,
+                                                       rhs, comparisonKind);
+    }
   }
 
   if (!ifStatement->elseStatements.empty()) {
-    const auto invertedComparisonKind =
-        qc::getInvertedComparisonKind(*comparisonKind);
     auto elseOps = translateBlockOperations(ifStatement->elseStatements);
-    qc->emplace_back<qc::ClassicControlledOperation>(
-        std::move(elseOps), creg->second, rhs->getUInt(),
-        invertedComparisonKind);
+    if (std::holds_alternative<std::pair<qc::Bit, bool>>(condition)) {
+      const auto& [bit, val] = std::get<std::pair<qc::Bit, bool>>(condition);
+      qc->emplace_back<qc::ClassicControlledOperation>(std::move(elseOps), bit,
+                                                       val ? 0 : 1);
+    } else {
+      const auto& [creg, comparisonKind, rhs] = std::get<
+          std::tuple<qc::ClassicalRegister, qc::ComparisonKind, uint64_t>>(
+          condition);
+      const auto invertedComparisonKind =
+          qc::getInvertedComparisonKind(comparisonKind);
+      qc->emplace_back<qc::ClassicControlledOperation>(
+          std::move(elseOps), creg, rhs, invertedComparisonKind);
+    }
   }
 }
 

--- a/src/qasm3/Parser.cpp
+++ b/src/qasm3/Parser.cpp
@@ -17,6 +17,7 @@
 #include "qasm3/Token.hpp"
 #include "qasm3/Types.hpp"
 
+#include <cstdint>
 #include <fstream>
 #include <istream>
 #include <memory>
@@ -279,20 +280,8 @@ void Parser::parseInclude() {
 }
 
 std::shared_ptr<AssignmentStatement> Parser::parseAssignmentStatement() {
-  auto identifierToken = expect(Token::Kind::Identifier);
-  auto identifier = std::make_shared<IdentifierExpression>(identifierToken.str);
-  std::shared_ptr<Expression> indexExpression{nullptr};
-
-  if (current().kind == Token::Kind::LBracket) {
-    scan();
-    indexExpression = parseExpression();
-    expect(Token::Kind::RBracket);
-  }
-
-  if (current().kind == Token::Kind::LBracket) {
-    error(current(), "Multidimensional indexing not supported yet.");
-  }
-
+  const auto indexedIdentifierToken = current();
+  auto indexedIdentifier = parseIndexedIdentifier();
   AssignmentStatement::Type type{};
   switch (current().kind) {
   case Token::Kind::Equals:
@@ -345,7 +334,7 @@ std::shared_ptr<AssignmentStatement> Parser::parseAssignmentStatement() {
   auto const tEnd = expect(Token::Kind::Semicolon);
 
   return std::make_shared<AssignmentStatement>(
-      makeDebugInfo(identifierToken, tEnd), type, identifier, indexExpression,
+      makeDebugInfo(indexedIdentifierToken, tEnd), type, indexedIdentifier,
       declarationExpression);
 }
 
@@ -356,14 +345,7 @@ std::shared_ptr<AssignmentStatement> Parser::parseMeasureStatement() {
 
   expect(Token::Kind::Arrow);
 
-  auto cbitIdentifier = std::make_shared<IdentifierExpression>(
-      expect(Token::Kind::Identifier).str);
-  std::shared_ptr<Expression> cbitIndexExpr{nullptr};
-  if (current().kind == Token::Kind::LBracket) {
-    scan();
-    cbitIndexExpr = parseExpression();
-    expect(Token::Kind::RBracket);
-  }
+  auto cbitIdentifier = parseIndexedIdentifier();
 
   auto const tEnd = expect(Token::Kind::Semicolon);
 
@@ -371,8 +353,7 @@ std::shared_ptr<AssignmentStatement> Parser::parseMeasureStatement() {
       std::make_shared<MeasureExpression>(gateOperand)};
   return std::make_shared<AssignmentStatement>(
       makeDebugInfo(tBegin, tEnd), AssignmentStatement::Type::Assignment,
-      cbitIdentifier, cbitIndexExpr,
-      std::make_shared<DeclarationExpression>(gateOperandExpr));
+      cbitIdentifier, std::make_shared<DeclarationExpression>(gateOperandExpr));
 }
 
 std::shared_ptr<ResetStatement> Parser::parseResetStatement() {
@@ -534,18 +515,35 @@ std::shared_ptr<GateModifier> Parser::parseGateModifier() {
   error(current(), "Expected gate modifier");
 }
 
-std::shared_ptr<GateOperand> Parser::parseGateOperand() {
-  // TODO: support hardware qubits
-  const auto identifier = expect(Token::Kind::Identifier);
-
-  std::shared_ptr<Expression> expression{nullptr};
-  if (current().kind == Token::Kind::LBracket) {
-    scan();
-    expression = parseExpression();
-    expect(Token::Kind::RBracket);
+std::shared_ptr<IndexOperator> Parser::parseIndexOperator() {
+  expect(Token::Kind::LBracket);
+  std::vector<std::shared_ptr<Expression>> indices{};
+  while (current().kind != Token::Kind::RBracket) {
+    indices.push_back(parseExpression());
+    if (current().kind != Token::Kind::RBracket) {
+      expect(Token::Kind::Comma);
+    }
   }
+  expect(Token::Kind::RBracket);
+  return std::make_shared<IndexOperator>(indices);
+}
 
-  return std::make_shared<GateOperand>(GateOperand{identifier.str, expression});
+std::shared_ptr<IndexedIdentifier> Parser::parseIndexedIdentifier() {
+  const auto identifier = expect(Token::Kind::Identifier);
+  std::vector<std::shared_ptr<IndexOperator>> indexOperators{};
+  while (current().kind == Token::Kind::LBracket) {
+    indexOperators.push_back(parseIndexOperator());
+  }
+  return std::make_shared<IndexedIdentifier>(identifier.str, indexOperators);
+}
+
+std::shared_ptr<GateOperand> Parser::parseGateOperand() {
+  if (current().kind == Token::Kind::HardwareQubit) {
+    const auto qubit = current().val;
+    scan();
+    return std::make_shared<GateOperand>(static_cast<uint64_t>(qubit));
+  }
+  return std::make_shared<GateOperand>(parseIndexedIdentifier());
 }
 
 std::shared_ptr<Statement> Parser::parseDeclaration(bool isConst) {
@@ -672,9 +670,7 @@ std::shared_ptr<Expression> Parser::exponentiation() {
     return std::make_shared<Constant>(Constant{val, isSigned});
   }
   case Token::Kind::Identifier: {
-    auto const str = current().str;
-    scan();
-    return std::make_shared<IdentifierExpression>(IdentifierExpression{str});
+    return parseIndexedIdentifier();
   }
   case Token::Kind::False: {
     scan();
@@ -736,8 +732,7 @@ std::shared_ptr<Expression> Parser::factor() {
   while (current().kind == Token::Kind::Caret) {
     scan();
     const auto y = exponentiation();
-    x = std::make_shared<BinaryExpression>(
-        BinaryExpression{BinaryExpression::Op::Power, x, y});
+    x = std::make_shared<BinaryExpression>(BinaryExpression::Op::Power, x, y);
   }
   return x;
 }
@@ -751,7 +746,7 @@ std::shared_ptr<Expression> Parser::term() {
                         : BinaryExpression::Op::Divide;
     scan();
     const auto y = factor();
-    x = std::make_shared<BinaryExpression>(BinaryExpression{op, x, y});
+    x = std::make_shared<BinaryExpression>(op, x, y);
   }
   return x;
 }
@@ -789,7 +784,7 @@ std::shared_ptr<Expression> Parser::comparison() {
     }
     scan();
     const auto y = term();
-    x = std::make_shared<BinaryExpression>(BinaryExpression{op, x, y});
+    x = std::make_shared<BinaryExpression>(op, x, y);
   }
   return x;
 }

--- a/src/qasm3/passes/TypeCheckPass.cpp
+++ b/src/qasm3/passes/TypeCheckPass.cpp
@@ -31,6 +31,7 @@ InferredType TypeCheckPass::error(const std::string& msg,
     std::cerr << "  " << debugInfo->toString() << '\n';
   }
   hasError = true;
+  errMessage = msg;
   return InferredType::error();
 }
 
@@ -39,22 +40,36 @@ void TypeCheckPass::processStatement(Statement& statement) {
     statement.accept(this);
 
     if (hasError) {
-      throw TypeCheckError("Type check failed.");
+      throw TypeCheckError(errMessage);
     }
   } catch (const TypeCheckError& e) {
     throw CompilerError(e.what(), statement.debugInfo);
   }
 }
 
+void TypeCheckPass::checkIndexOperator(const IndexOperator& indexOperator) {
+  for (const auto& index : indexOperator.indexExpressions) {
+    if (const auto type = visit(index); !type.isError && !type.type->isUint()) {
+      error("Index must be an unsigned integer");
+    }
+  }
+}
+
+void TypeCheckPass::checkIndexedIdentifier(const IndexedIdentifier& id) {
+
+  if (const auto it = env.find(id.identifier); it == env.end()) {
+    error("Unknown identifier '" + id.identifier + "'.");
+  }
+  for (const auto& index : id.indices) {
+    checkIndexOperator(*index);
+  }
+}
+
 void TypeCheckPass::checkGateOperand(const GateOperand& operand) {
-  if (operand.expression == nullptr) {
+  if (operand.isHardwareQubit()) {
     return;
   }
-
-  if (const auto type = visit(operand.expression);
-      !type.isError && !type.type->isUint()) {
-    error("Index must be an unsigned integer");
-  }
+  checkIndexedIdentifier(*operand.getIdentifier());
 }
 
 void TypeCheckPass::visitGateStatement(
@@ -138,14 +153,7 @@ void TypeCheckPass::visitGateCallStatement(
 
 void TypeCheckPass::visitAssignmentStatement(
     const std::shared_ptr<AssignmentStatement> assignmentStatement) {
-  if (assignmentStatement->indexExpression != nullptr) {
-    auto indexTy = visit(assignmentStatement->indexExpression);
-    if (!indexTy.isError && !indexTy.type->isUint()) {
-      error("Index must be an unsigned integer.",
-            assignmentStatement->debugInfo);
-      return;
-    }
-  }
+  checkIndexedIdentifier(*assignmentStatement->identifier);
 
   const auto exprTy = visit(assignmentStatement->expression->expression);
   const auto idTy = env.find(assignmentStatement->identifier->identifier);
@@ -171,9 +179,6 @@ void TypeCheckPass::visitAssignmentStatement(
 void TypeCheckPass::visitBarrierStatement(
     const std::shared_ptr<BarrierStatement> barrierStatement) {
   for (auto& gate : barrierStatement->gates) {
-    if (!gate->expression) {
-      continue;
-    }
     checkGateOperand(*gate);
   }
 }
@@ -195,7 +200,9 @@ InferredType TypeCheckPass::visitBinaryExpression(
   }
 
   auto ty = lhs;
-  if (lhs.type->isNumber() && rhs.type->isNumber()) {
+  if (lhs.type->isConvertibleToBool() && rhs.type->isConvertibleToBool()) {
+    ty = InferredType{UnsizedType<uint64_t>::getBoolTy()};
+  } else if (lhs.type->isNumber() && rhs.type->isNumber()) {
     if (rhs.type->isFP() || lhs.type->isUint()) {
       // coerce to float or signed int
       ty = rhs;
@@ -266,7 +273,7 @@ InferredType TypeCheckPass::visitUnaryExpression(
     }
     break;
   case UnaryExpression::LogicalNot:
-    if (!type.type->isBool()) {
+    if (!type.type->isConvertibleToBool()) {
       return error("Cannot apply logical not to non-boolean type.");
     }
     break;
@@ -329,21 +336,38 @@ InferredType TypeCheckPass::visitIdentifierList(
   throw TypeCheckError("TypeCheckPass::visitIdentifierList not implemented");
 }
 
+InferredType TypeCheckPass::visitIndexedIdentifier(
+    const std::shared_ptr<IndexedIdentifier> indexedIdentifier) {
+  auto type = visitIdentifierExpression(
+      std::make_shared<IdentifierExpression>(indexedIdentifier->identifier));
+  if (indexedIdentifier->indices.empty()) {
+    return type;
+  }
+  // Assume that indexed access always results in a single element
+  type.type->setDesignator(1);
+  return type;
+}
+
 InferredType TypeCheckPass::visitMeasureExpression(
     const std::shared_ptr<MeasureExpression> measureExpression) {
-  size_t width = 1;
-  if (measureExpression->gate->expression != nullptr) {
-    visit(measureExpression->gate->expression);
-  } else {
-    const auto gate = env.find(measureExpression->gate->identifier);
-    if (gate == env.end()) {
-      error("Unknown identifier '" + measureExpression->gate->identifier +
-            "'.");
-      return InferredType::error();
-    }
-    width = gate->second.type->getDesignator();
+  if (measureExpression->gate->isHardwareQubit()) {
+    return InferredType{std::dynamic_pointer_cast<ResolvedType>(
+        DesignatedType<uint64_t>::getBitTy(1))};
   }
 
+  const auto indexedIdentifier = measureExpression->gate->getIdentifier();
+  checkIndexedIdentifier(*indexedIdentifier);
+  if (!indexedIdentifier->indices.empty()) {
+    // This will need modification once we want to support index ranges.
+    return InferredType{std::dynamic_pointer_cast<ResolvedType>(
+        DesignatedType<uint64_t>::getBitTy(1))};
+  }
+  const auto it = env.find(indexedIdentifier->identifier);
+  if (it == env.end()) {
+    error("Unknown identifier '" + indexedIdentifier->identifier + "'.");
+    return InferredType::error();
+  }
+  const auto width = it->second.type->getDesignator();
   return InferredType{std::dynamic_pointer_cast<ResolvedType>(
       DesignatedType<uint64_t>::getBitTy(width))};
 }
@@ -351,8 +375,8 @@ InferredType TypeCheckPass::visitMeasureExpression(
 void TypeCheckPass::visitIfStatement(
     const std::shared_ptr<IfStatement> ifStatement) {
   // We support ifs on bits and bools
-  const auto ty = visit(ifStatement->condition);
-  if (!ty.isError && !ty.type->isBool()) {
+  if (const auto ty = visit(ifStatement->condition);
+      !ty.isError && !ty.type->isConvertibleToBool()) {
     error("Condition expression must be bool.");
   }
 

--- a/test/dd/test_dd_functionality.cpp
+++ b/test/dd/test_dd_functionality.cpp
@@ -462,9 +462,7 @@ TEST_F(DDFunctionality, FuseSingleQubitGatesAcrossOtherGates) {
 }
 
 TEST_F(DDFunctionality, classicControlledOperationConditions) {
-  const auto cmpKinds = {ComparisonKind::Eq, ComparisonKind::Neq,
-                         ComparisonKind::Lt, ComparisonKind::Leq,
-                         ComparisonKind::Gt, ComparisonKind::Geq};
+  const auto cmpKinds = {ComparisonKind::Eq, ComparisonKind::Neq};
   for (const auto kind : cmpKinds) {
     QuantumComputation qc(1U, 1U);
     // ensure that the state is |1>.
@@ -483,8 +481,7 @@ TEST_F(DDFunctionality, classicControlledOperationConditions) {
     EXPECT_EQ(hist.size(), 1);
     const auto& [key, value] = *hist.begin();
     EXPECT_EQ(value, shots);
-    if (kind == ComparisonKind::Eq || kind == ComparisonKind::Leq ||
-        kind == ComparisonKind::Geq) {
+    if (kind == ComparisonKind::Eq) {
       EXPECT_EQ(key, "0");
     } else {
       EXPECT_EQ(key, "1");

--- a/test/ir/test_io.cpp
+++ b/test/ir/test_io.cpp
@@ -9,6 +9,7 @@
 
 #include "Definitions.hpp"
 #include "ir/QuantumComputation.hpp"
+#include "ir/operations/ClassicControlledOperation.hpp"
 #include "ir/operations/CompoundOperation.hpp"
 #include "ir/operations/NonUnitaryOperation.hpp"
 #include "ir/operations/OpType.hpp"
@@ -27,6 +28,7 @@
 #include <iterator>
 #include <memory>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -113,12 +115,6 @@ TEST_F(IO, importFromStringQASM) {
                                 "U(pi/2,0,pi) q[0];"
                                 "CX q[0],q[1];");
   std::cout << qc << "\n";
-}
-
-TEST_F(IO, controlledOpActingOnWholeRegister) {
-  EXPECT_THROW(qc = qasm3::Importer::imports("qreg q[2];"
-                                             "cx q,q[1];"),
-               qasm3::CompilerError);
 }
 
 TEST_F(IO, insufficientRegistersQelib) {
@@ -298,16 +294,6 @@ TEST_F(IO, CommentInDeclaration) {
   EXPECT_EQ(comp->size(), 2);
   EXPECT_EQ(comp->at(0)->getType(), qc::H);
   EXPECT_EQ(comp->at(1)->getType(), qc::H);
-}
-
-TEST_F(IO, classicControlled) {
-  qc = qasm3::Importer::imports("qreg q[1];"
-                                "creg c[1];"
-                                "h q[0];"
-                                "measure q->c;"
-                                "// test classic controlled operation\n"
-                                "if (c==1) x q[0];");
-  std::cout << qc << "\n";
 }
 
 TEST_F(IO, iSWAPDumpIsValid) {
@@ -633,6 +619,36 @@ TEST_F(IO, classicalControlledOperationToOpenQASM3) {
 
   const auto actual = qc.toQASM();
   EXPECT_EQ(expected, actual);
+}
+
+TEST_F(IO, classicalControlledOperationExpectedValueTooLarge) {
+  qc.addQubitRegister(1);
+  qc.addClassicalRegister(1);
+  try {
+    qc.classicControlled(qc::X, 0, 0, 2);
+    FAIL() << "Expected an exception for invalid expected value.";
+  } catch (const std::invalid_argument& e) {
+    EXPECT_STREQ(e.what(),
+                 "Expected value for single bit comparison must be 0 or 1.");
+    SUCCEED();
+  } catch (...) {
+    FAIL() << "Expected an invalid_argument exception.";
+  }
+}
+
+TEST_F(IO, classicalControlledOperationInvalidBitComparison) {
+  qc.addQubitRegister(1);
+  qc.addClassicalRegister(1);
+  try {
+    qc.classicControlled(qc::X, 0, 0, 1, qc::Lt);
+    FAIL() << "Expected an exception for invalid expected value.";
+  } catch (const std::invalid_argument& e) {
+    EXPECT_STREQ(e.what(),
+                 "Inequality comparisons on a single bit are not supported.");
+    SUCCEED();
+  } catch (...) {
+    FAIL() << "Expected an invalid_argument exception.";
+  }
 }
 
 TEST_F(IO, dumpingIncompleteOutputPermutationNotStartingAtZero) {

--- a/test/ir/test_io.cpp
+++ b/test/ir/test_io.cpp
@@ -118,7 +118,7 @@ TEST_F(IO, importFromStringQASM) {
 TEST_F(IO, controlledOpActingOnWholeRegister) {
   EXPECT_THROW(qc = qasm3::Importer::imports("qreg q[2];"
                                              "cx q,q[1];"),
-               qc::QFRException);
+               qasm3::CompilerError);
 }
 
 TEST_F(IO, insufficientRegistersQelib) {
@@ -624,7 +624,7 @@ TEST_F(IO, classicalControlledOperationToOpenQASM3) {
                                "include \"stdgates.inc\";\n"
                                "qubit[2] q;\n"
                                "bit[2] c;\n"
-                               "if (c[0] == 1) {\n"
+                               "if (c[0]) {\n"
                                "  x q[0];\n"
                                "}\n"
                                "if (c == 1) {\n"

--- a/test/ir/test_qasm3_parser.cpp
+++ b/test/ir/test_qasm3_parser.cpp
@@ -64,7 +64,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3GateDecl) {
                                "  x q2;\n"
                                "}\n"
                                "my_x q[0], q[1];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1\n"
@@ -97,7 +97,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3CtrlModifier) {
       "ctrl @ swap q[0], q[1], q[2];\n"
       "ctrl @ rxx(pi) q[0], q[1], q[2];\n"
       "ctrl @ negctrl @ x q[0], q[1], q[2];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected =
@@ -129,7 +129,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3InvModifier) {
                                "include \"stdgates.inc\";\n"
                                "qubit[1] q;\n"
                                "inv @ s q[0];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0\n"
@@ -151,7 +151,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3CompoundGate) {
                                "  h q;\n"
                                "}\n"
                                "my_compound_gate q;";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0\n"
@@ -172,7 +172,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3ControlledCompoundGate) {
                                "  x q;\n"
                                "}\n"
                                "ctrl @ my_compound_gate q[0], q[1];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1\n"
@@ -192,7 +192,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3ParamCompoundGate) {
                                "  rz(a) q;\n"
                                "}\n"
                                "my_compound_gate(1.0 * pi) q[0];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1\n"
@@ -216,7 +216,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3Measure) {
                                "r2 = measure q;\n"
                                "measure q[1] -> r1;\n"
                                "measure q[1] -> r2[0];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1\n"
@@ -242,7 +242,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3InitialLayout) {
                                "OPENQASM 3.0;\n"
                                "include \"stdgates.inc\";\n"
                                "qubit[2] q;\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 1 0\n"
@@ -262,7 +262,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3ConstEval) {
       "qubit[N * 2] q;\n"
       "ctrl @ x q[0], q[N * 2 - 1];\n"
       "x q;";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1 2 3 4 5 6 7\n"
@@ -292,7 +292,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3NonUnitary) {
                                "barrier q1, q2;\n"
                                "reset q1;\n"
                                "bit c = measure q1[0];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1 2 3\n"
@@ -315,10 +315,10 @@ TEST_F(Qasm3ParserTest, ImportQasm3IfStatement) {
                                "qubit[2] q;\n"
                                "h q[0];\n"
                                "bit c = measure q[0];\n"
-                               "if (c == 1) {\n"
+                               "if (c) {\n"
                                "  x q[1];\n"
                                "}";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1\n"
@@ -329,56 +329,95 @@ TEST_F(Qasm3ParserTest, ImportQasm3IfStatement) {
                                "bit[1] c;\n"
                                "h q[0];\n"
                                "c[0] = measure q[0];\n"
-                               "if (c == 1) {\n"
+                               "if (c[0]) {\n"
                                "  x q[1];\n"
                                "}\n";
   EXPECT_EQ(out, expected);
 }
 
+TEST_F(Qasm3ParserTest, ImportQasm3SingleBitIfStatement) {
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[1] q;\n"
+                               "h q[0];\n"
+                               "bit c = measure q[0];\n"
+                               "if (c[0]) {\n"
+                               "  x q[0];\n"
+                               "}";
+  const auto qc = qasm3::Importer::imports(testfile);
+
+  const std::string out = qc.toQASM();
+  const std::string expected = "// i 0\n"
+                               "// o 0\n"
+                               "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[1] q;\n"
+                               "bit[1] c;\n"
+                               "h q[0];\n"
+                               "c = measure q;\n"
+                               "if (c[0]) {\n"
+                               "  x q[0];\n"
+                               "}\n";
+  EXPECT_EQ(out, expected);
+}
+
+TEST_F(Qasm3ParserTest, ImportQasm3InvertedSingleBitIfStatement) {
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[1] q;\n"
+                               "h q[0];\n"
+                               "bit c = measure q[0];\n"
+                               "if (!c[0]) {\n"
+                               "  x q[0];\n"
+                               "}";
+  const auto qc = qasm3::Importer::imports(testfile);
+
+  const std::string out = qc.toQASM();
+  const std::string expected = "// i 0\n"
+                               "// o 0\n"
+                               "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[1] q;\n"
+                               "bit[1] c;\n"
+                               "h q[0];\n"
+                               "c = measure q;\n"
+                               "if (!c[0]) {\n"
+                               "  x q[0];\n"
+                               "}\n";
+  EXPECT_EQ(out, expected);
+}
+
 TEST_F(Qasm3ParserTest, ImportQasm3IfElseStatement) {
-  const auto comparisonKinds = {ComparisonKind::Eq, ComparisonKind::Neq,
-                                ComparisonKind::Lt, ComparisonKind::Leq,
-                                ComparisonKind::Gt, ComparisonKind::Geq};
+  const std::string testfile = "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[2] q;\n"
+                               "h q[0];\n"
+                               "bit c = measure q[0];\n"
+                               "if (c) {\n"
+                               "  x q[1];\n"
+                               "} else {\n"
+                               "  x q[0];\n"
+                               "  x q[1];\n"
+                               "}";
+  const auto qc = qasm3::Importer::imports(testfile);
 
-  for (const auto comparisonKind : comparisonKinds) {
-    const std::string testfile = "OPENQASM 3.0;\n"
-                                 "include \"stdgates.inc\";\n"
-                                 "qubit[2] q;\n"
-                                 "h q[0];\n"
-                                 "bit c = measure q[0];\n"
-                                 "if (c " +
-                                 toString(comparisonKind) +
-                                 " 1) {\n"
-                                 "  x q[1];\n"
-                                 "} else {\n"
-                                 "  x q[0];\n"
-                                 "  x q[1];\n"
-                                 "}";
-    auto qc = qasm3::Importer::imports(testfile);
-
-    const std::string out = qc.toQASM();
-    const std::string expected =
-        "// i 0 1\n"
-        "// o 0\n"
-        "OPENQASM 3.0;\n"
-        "include \"stdgates.inc\";\n"
-        "qubit[2] q;\n"
-        "bit[1] c;\n"
-        "h q[0];\n"
-        "c[0] = measure q[0];\n"
-        "if (c " +
-        toString(comparisonKind) +
-        " 1) {\n"
-        "  x q[1];\n"
-        "}\n"
-        "if (c " +
-        toString(getInvertedComparisonKind(comparisonKind)) +
-        " 1) {\n"
-        "  x q[0];\n"
-        "  x q[1];\n"
-        "}\n";
-    EXPECT_EQ(out, expected);
-  }
+  const std::string out = qc.toQASM();
+  const std::string expected = "// i 0 1\n"
+                               "// o 0\n"
+                               "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[2] q;\n"
+                               "bit[1] c;\n"
+                               "h q[0];\n"
+                               "c[0] = measure q[0];\n"
+                               "if (c[0]) {\n"
+                               "  x q[1];\n"
+                               "}\n"
+                               "if (!c[0]) {\n"
+                               "  x q[0];\n"
+                               "  x q[1];\n"
+                               "}\n";
+  EXPECT_EQ(out, expected);
 }
 
 TEST_F(Qasm3ParserTest, ImportQasm3EmptyIfElse) {
@@ -387,10 +426,10 @@ TEST_F(Qasm3ParserTest, ImportQasm3EmptyIfElse) {
                                "qubit[2] q;\n"
                                "h q[0];\n"
                                "bit c = measure q[0];\n"
-                               "if (c == 1) {\n"
+                               "if (c) {\n"
                                "} else {\n"
                                "}";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1\n"
@@ -402,6 +441,33 @@ TEST_F(Qasm3ParserTest, ImportQasm3EmptyIfElse) {
                                "h q[0];\n"
                                "c[0] = measure q[0];\n";
   EXPECT_EQ(out, expected);
+}
+
+TEST_F(Qasm3ParserTest, ImportQasm3UnsupportedSingleBitIfStatement) {
+  const auto comparisonKinds = {ComparisonKind::Lt, ComparisonKind::Leq,
+                                ComparisonKind::Gt, ComparisonKind::Geq};
+
+  for (const auto comparisonKind : comparisonKinds) {
+    const std::string testfile = "OPENQASM 3.0;\n"
+                                 "include \"stdgates.inc\";\n"
+                                 "qubit[1] q;\n"
+                                 "h q[0];\n"
+                                 "bit c = measure q[0];\n"
+                                 "if (c " +
+                                 toString(comparisonKind) +
+                                 " true) {\n"
+                                 "  x q[0];\n"
+                                 "}";
+    EXPECT_THROW(
+        try {
+          const auto qc = qasm3::Importer::imports(testfile);
+        } catch (const qasm3::CompilerError& e) {
+          EXPECT_EQ(e.message,
+                    "Type Check Error: Cannot compare boolean types.");
+          throw;
+        },
+        qasm3::CompilerError);
+  }
 }
 
 TEST_F(Qasm3ParserTest, ImportQasm3OutputPerm) {
@@ -439,10 +505,10 @@ TEST_F(Qasm3ParserTest, ImportQasm3IfElseNoBlock) {
                                "qubit[2] q;\n"
                                "h q[0];\n"
                                "bit c = measure q[0];\n"
-                               "if (c == 1) {} else \n"
+                               "if (c) {} else \n"
                                "  x q[1];\n"
                                "x q[0];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1\n"
@@ -453,7 +519,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3IfElseNoBlock) {
                                "bit[1] c;\n"
                                "h q[0];\n"
                                "c[0] = measure q[0];\n"
-                               "if (c != 1) {\n"
+                               "if (!c[0]) {\n"
                                "  x q[1];\n"
                                "}\n"
                                "x q[0];\n";
@@ -465,7 +531,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3InvalidStatementInBlock) {
                                "include \"stdgates.inc\";\n"
                                "qubit q;\n"
                                "bit c = measure q;\n"
-                               "if (c == 1) {\n"
+                               "if (c) {\n"
                                "  qubit invalid;\n"
                                "}";
   EXPECT_THROW(
@@ -482,7 +548,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3InvalidStatementInBlock) {
 TEST_F(Qasm3ParserTest, ImportQasm3ImplicitInclude) {
   const std::string testfile = "qubit q;\n"
                                "h q[0];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0\n"
@@ -499,7 +565,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3Qelib1) {
                                "include \"qelib1.inc\";\n"
                                "qubit q;\n"
                                "h q[0];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0\n"
@@ -517,7 +583,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3Teleportation) {
                                "opaque teleport src, anc, tgt;\n"
                                "qubit[3] q;\n"
                                "teleport q[0], q[1], q[2];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected =
@@ -550,7 +616,7 @@ TEST_F(Qasm3ParserTest, ImportQasm3AlternatingControl) {
                                "qubit[7] q;\n"
                                "ctrl @ negctrl(2) @ negctrl @ ctrl @ ctrl @ x "
                                "q[0], q[1], q[2], q[3], q[4], q[5], q[6];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1 2 3 4 5 6\n"
@@ -569,7 +635,7 @@ TEST_F(Qasm3ParserTest, ImportQasmConstEval) {
                                "const uint N_1 = 0xa;\n"
                                "const uint N_2 = 8;\n"
                                "qubit[N_1 - N_2] q;\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1\n"
@@ -590,7 +656,7 @@ TEST_F(Qasm3ParserTest, ImportQasmBroadcasting) {
                                "h q1;\n"
                                "reset q2;\n"
                                "cx q1, q2;\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1 2 3\n"
@@ -611,16 +677,16 @@ TEST_F(Qasm3ParserTest, ImportQasmComparison) {
   const std::string testfile = "OPENQASM 3.0;\n"
                                "include \"stdgates.inc\";\n"
                                "qubit[2] q;\n"
-                               "bit c1;\n"
+                               "bit[2] c;\n"
                                "h q;\n"
-                               "c1 = measure q[0];\n"
-                               "if (c1 < 0) { x q[0]; }\n"
-                               "if (c1 <= 0) { x q[0]; }\n"
-                               "if (c1 > 0) { x q[0]; }\n"
-                               "if (c1 >= 0) { x q[0]; }\n"
-                               "if (c1 == 0) { x q[0]; }\n"
-                               "if (c1 != 0) { x q[0]; }\n";
-  auto qc = qasm3::Importer::imports(testfile);
+                               "c[0] = measure q[0];\n"
+                               "if (c < 0) { x q[0]; }\n"
+                               "if (c <= 0) { x q[0]; }\n"
+                               "if (c > 0) { x q[0]; }\n"
+                               "if (c >= 0) { x q[0]; }\n"
+                               "if (c == 0) { x q[0]; }\n"
+                               "if (c != 0) { x q[0]; }\n";
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1\n"
@@ -628,26 +694,26 @@ TEST_F(Qasm3ParserTest, ImportQasmComparison) {
                                "OPENQASM 3.0;\n"
                                "include \"stdgates.inc\";\n"
                                "qubit[2] q;\n"
-                               "bit[1] c1;\n"
+                               "bit[2] c;\n"
                                "h q[0];\n"
                                "h q[1];\n"
-                               "c1[0] = measure q[0];\n"
-                               "if (c1 < 0) {\n"
+                               "c[0] = measure q[0];\n"
+                               "if (c < 0) {\n"
                                "  x q[0];\n"
                                "}\n"
-                               "if (c1 <= 0) {\n"
+                               "if (c <= 0) {\n"
                                "  x q[0];\n"
                                "}\n"
-                               "if (c1 > 0) {\n"
+                               "if (c > 0) {\n"
                                "  x q[0];\n"
                                "}\n"
-                               "if (c1 >= 0) {\n"
+                               "if (c >= 0) {\n"
                                "  x q[0];\n"
                                "}\n"
-                               "if (c1 == 0) {\n"
+                               "if (c == 0) {\n"
                                "  x q[0];\n"
                                "}\n"
-                               "if (c1 != 0) {\n"
+                               "if (c != 0) {\n"
                                "  x q[0];\n"
                                "}\n";
   EXPECT_EQ(out, expected);
@@ -661,7 +727,7 @@ TEST_F(Qasm3ParserTest, ImportQasmNativeRedeclaration) {
                                "gate h q { U(pi/2, 0, pi) q; }\n"
                                "h q;\n"
                                "c1 = measure q;\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0\n"
@@ -682,7 +748,7 @@ TEST_F(Qasm3ParserTest, ImportQasm2CPrefix) {
                                "gate ccccx q1, q2, q3, q4, q5 {\n"
                                "}\n"
                                "ccccx q[0], q[1], q[2], q[3], q[4];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1 2 3 4\n"
@@ -698,7 +764,7 @@ TEST_F(Qasm3ParserTest, ImportMCXGate) {
   const std::string testfile = "OPENQASM 3.0;\n"
                                "qubit[4] q;\n"
                                "mcx q[0], q[1], q[2], q[3];\n";
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1 2 3\n"
@@ -768,7 +834,7 @@ TEST_F(Qasm3ParserTest, ImportMSGate) {
                                "ms(0.844396) q[0], q[1], q[2];"
                                "c = measure q;";
 
-  auto qc = qasm3::Importer::imports(testfile);
+  const auto qc = qasm3::Importer::imports(testfile);
 
   const std::string out = qc.toQASM();
   const std::string expected = "// i 0 1 2\n"
@@ -1065,7 +1131,7 @@ TEST_F(Qasm3ParserTest, ImportQasmAssignmentUnknownIdentifier) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Unknown identifier 'c'.");
           throw;
         }
       },
@@ -1083,7 +1149,9 @@ TEST_F(Qasm3ParserTest, ImportQasmAssignmentConstVar) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
+          EXPECT_EQ(e.message,
+                    "Type Check Error: Type mismatch in declaration statement: "
+                    "Expected 'bit[1]', found 'uint[32]'.");
           throw;
         }
       },
@@ -1259,8 +1327,9 @@ TEST_F(Qasm3ParserTest, ImportQasmGateCallNonConst) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Only const expressions are supported as gate "
-                               "parameters, but found 'IdentifierExpr (c)'.");
+          EXPECT_EQ(e.message,
+                    "Only const expressions are supported as gate "
+                    "parameters, but found 'IndexedIdentifier (c)'.");
           throw;
         }
       },
@@ -1316,10 +1385,11 @@ TEST_F(Qasm3ParserTest, ImportQasmGateMeasureInvalidSizes) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message,
-                    "Classical and quantum register must have the same width "
-                    "in measure statement. Classical register 'c' has 3 bits, "
-                    "but quantum register 'q' has 2 qubits.");
+          EXPECT_EQ(
+              e.message,
+              "Classical and quantum register must have the same width "
+              "in measure statement. Classical register 'c' has 3 bits, "
+              "but quantum register 'IndexedIdentifier (q)' has 2 qubits.");
           throw;
         }
       },
@@ -1401,7 +1471,8 @@ TEST_F(Qasm3ParserTest, ImportQasmTypeMismatchAssignment) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type mismatch in assignment. "
+                               "Expected 'bit[1]', found 'uint[32]'.");
           throw;
         }
       },
@@ -1417,7 +1488,9 @@ TEST_F(Qasm3ParserTest, ImportQasmTypeMismatchBinaryExpr) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
+          EXPECT_EQ(e.message,
+                    "Type Check Error: Type mismatch in declaration statement: "
+                    "Expected 'bit[1]', found 'uint[32]'.");
           throw;
         }
       },
@@ -1449,7 +1522,8 @@ TEST_F(Qasm3ParserTest, ImportQasmUnaryTypeMismatchLogicalNot) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Cannot apply logical not to "
+                               "non-boolean type.");
           throw;
         }
       },
@@ -1465,7 +1539,8 @@ TEST_F(Qasm3ParserTest, ImportQasmUnaryTypeMismatchBitwiseNot) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Cannot apply bitwise not to "
+                               "non-numeric type.");
           throw;
         }
       },
@@ -1480,7 +1555,8 @@ TEST_F(Qasm3ParserTest, ImportQasmBinaryTypeMismatch) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type mismatch in binary "
+                               "expression: uint[32], bool.");
           throw;
         }
       },
@@ -1496,7 +1572,8 @@ TEST_F(Qasm3ParserTest, ImportQasmAssignmentIndexType) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Type mismatch in assignment. "
+                               "Expected 'bit[16]', found 'uint[32]'.");
           throw;
         }
       },
@@ -1511,7 +1588,7 @@ TEST_F(Qasm3ParserTest, ImportQasmUnknownIdentifier) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Unknown identifier 'y'.");
           throw;
         }
       },
@@ -1526,7 +1603,7 @@ TEST_F(Qasm3ParserTest, ImportQasmUnknownQubit) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
+          EXPECT_EQ(e.message, "Type Check Error: Unknown identifier 'q'.");
           throw;
         }
       },
@@ -1541,7 +1618,9 @@ TEST_F(Qasm3ParserTest, ImportQasmNegativeTypeDesignator) {
         try {
           const auto qc = qasm3::Importer::imports(testfile);
         } catch (const qasm3::CompilerError& e) {
-          EXPECT_EQ(e.message, "Type Check Error: Type check failed.");
+          EXPECT_EQ(
+              e.message,
+              "Type Check Error: Designator expression type check failed.");
           throw;
         }
       },


### PR DESCRIPTION
## Description

This pull request introduces the following enhancements and fixes for the OpenQASM parser and type checker:
- Adds support for indexed identifiers and index operators in the OpenQASM parser and type checker.
- Fixes incorrect OpenQASM 3 dump for single-bit classic-controlled operations.
- Canonicalizes single-bit classic-controlled operations for consistency.
- Implements dedicated sanity checks on single-bit classic-controlled operations.
- Addresses several Clang-Tidy suggestions to improve code quality.

These changes aim to enhance functionality, ensure correctness, and improve maintainability of the OpenQASM implementation.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
