### PR TITLE
🚸 Allow indexed registers as operation arguments

### DIFF
--- a/docs/mqt_core_ir.md
+++ b/docs/mqt_core_ir.md
@@ -47,35 +47,35 @@ precision = 3
 qc = QuantumComputation()
 
 # Counting register
-qc.add_qubit_register(1, "q")
+q = qc.add_qubit_register(1, "q")
 
 # Eigenstate register
-qc.add_qubit_register(1, "psi")
+psi = qc.add_qubit_register(1, "psi")
 
 # Classical register for the result, the estimated phase is `0.c_2 c_1 c_0 * pi`
-qc.add_classical_register(precision, "c")
+c = qc.add_classical_register(precision, "c")
 
 # Prepare psi in the eigenstate |1>
-qc.x(1)
+qc.x(psi[0])
 
 for i in range(precision):
   # Hadamard on the working qubit
-  qc.h(0)
+  qc.h(q[0])
 
   # Controlled phase gate
-  qc.cp(2**(precision - i - 1) * theta, 0, 1)
+  qc.cp(2**(precision - i - 1) * theta, q[0], psi[0])
 
   # Iterative inverse QFT
   for j in range(i):
-    qc.classic_controlled(op="p", target=0, cbit=j, params=[-pi / 2**(i - j)])
-  qc.h(0)
+    qc.classic_controlled(op="p", target=q[0], cbit=c[j], params=[-pi / 2**(i - j)])
+  qc.h(q[0])
 
   # Measure the result
-  qc.measure(0, i)
+  qc.measure(q[0], c[i])
 
   # Reset the qubit if not finished
   if i < precision - 1:
-    qc.reset(0)
+    qc.reset(q[0])
 ```
 
 The circuit class provides lots of flexibility when it comes to the kind of gates that can be applied.

--- a/include/mqt-core/ir/QuantumComputation.hpp
+++ b/include/mqt-core/ir/QuantumComputation.hpp
@@ -371,13 +371,16 @@ public:
       const std::string& registerName = "c");
 
   // this function augments a given circuit by additional registers
-  void addQubitRegister(std::size_t nq, const std::string& regName = "q");
+  const QuantumRegister& addQubitRegister(std::size_t nq,
+                                          const std::string& regName = "q");
   const ClassicalRegister&
   addClassicalRegister(std::size_t nc, const std::string& regName = "c");
-  void addAncillaryRegister(std::size_t nq, const std::string& regName = "anc");
+  const QuantumRegister&
+  addAncillaryRegister(std::size_t nq, const std::string& regName = "anc");
   // a function to combine all quantum registers (qregs and ancregs) into a
   // single register (useful for circuits mapped to a device)
-  void unifyQuantumRegisters(const std::string& regName = "q");
+  const QuantumRegister&
+  unifyQuantumRegisters(const std::string& regName = "q");
 
   /**
    * @brief Removes a logical qubit

--- a/include/mqt-core/ir/Register.hpp
+++ b/include/mqt-core/ir/Register.hpp
@@ -54,8 +54,19 @@ public:
     return globalIndex - startIndex;
   }
 
+  [[nodiscard]] BitType getGlobalIndex(const BitType localIndex) const {
+    if (localIndex >= size) {
+      throw std::out_of_range("Index out of range");
+    }
+    return startIndex + localIndex;
+  }
+
   [[nodiscard]] std::string toString(const BitType globalIndex) const {
     return name + "[" + std::to_string(getLocalIndex(globalIndex)) + "]";
+  }
+
+  [[nodiscard]] BitType operator[](const BitType localIndex) const {
+    return getGlobalIndex(localIndex);
   }
 
 private:

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -344,8 +344,9 @@ void QuantumComputation::initializeIOMapping() {
   }
 }
 
-void QuantumComputation::addQubitRegister(std::size_t nq,
-                                          const std::string& regName) {
+const QuantumRegister&
+QuantumComputation::addQubitRegister(std::size_t nq,
+                                     const std::string& regName) {
   if (quantumRegisters.count(regName) != 0) {
     throw QFRException("[addQubitRegister] Register " + regName +
                        " already exists");
@@ -372,6 +373,7 @@ void QuantumComputation::addQubitRegister(std::size_t nq,
   nqubits += nq;
   ancillary.resize(nqubits + nancillae);
   garbage.resize(nqubits + nancillae);
+  return quantumRegisters.at(regName);
 }
 
 const ClassicalRegister&
@@ -393,8 +395,9 @@ QuantumComputation::addClassicalRegister(std::size_t nc,
   return it->second;
 }
 
-void QuantumComputation::addAncillaryRegister(std::size_t nq,
-                                              const std::string& regName) {
+const QuantumRegister&
+QuantumComputation::addAncillaryRegister(std::size_t nq,
+                                         const std::string& regName) {
   if (ancillaRegisters.count(regName) != 0) {
     throw QFRException("[addAncillaryRegister] Register " + regName +
                        " already exists");
@@ -416,6 +419,7 @@ void QuantumComputation::addAncillaryRegister(std::size_t nq,
     ancillary[j] = true;
   }
   nancillae += nq;
+  return ancillaRegisters.at(regName);
 }
 
 std::pair<Qubit, std::optional<Qubit>>
@@ -938,12 +942,14 @@ bool QuantumComputation::isLastOperationOnQubit(
   return true;
 }
 
-void QuantumComputation::unifyQuantumRegisters(const std::string& regName) {
+const QuantumRegister&
+QuantumComputation::unifyQuantumRegisters(const std::string& regName) {
   ancillaRegisters.clear();
   quantumRegisters.clear();
   nqubits += nancillae;
   nancillae = 0;
   quantumRegisters.try_emplace(regName, 0, nqubits, regName);
+  return quantumRegisters.at(regName);
 }
 
 void QuantumComputation::appendMeasurementsAccordingToOutputPermutation(

--- a/src/mqt/core/ir/__init__.pyi
+++ b/src/mqt/core/ir/__init__.pyi
@@ -12,7 +12,7 @@ from os import PathLike
 from typing import overload
 
 from .operations import ComparisonKind, Control, Operation, OpType
-from .registers import ClassicalRegister
+from .registers import ClassicalRegister, QuantumRegister
 from .symbolic import Expression, Variable
 
 __all__ = [
@@ -307,12 +307,15 @@ class QuantumComputation(MutableSequence[Operation]):
     #                          (Qu)Bit Registers
     # --------------------------------------------------------------------------
 
-    def add_ancillary_register(self, n: int, name: str = "anc") -> None:
+    def add_ancillary_register(self, n: int, name: str = "anc") -> QuantumRegister:
         """Add an ancillary register to the quantum computation.
 
         Args:
             n: The number of qubits in the ancillary register.
             name: The name of the ancillary register.
+
+        Returns:
+            The ancillary register added to the quantum computation.
         """
 
     def add_classical_register(self, n: int, name: str = "c") -> ClassicalRegister:
@@ -326,19 +329,25 @@ class QuantumComputation(MutableSequence[Operation]):
             The classical register added to the quantum computation.
         """
 
-    def add_qubit_register(self, n: int, name: str = "q") -> None:
+    def add_qubit_register(self, n: int, name: str = "q") -> QuantumRegister:
         """Add a qubit register to the quantum computation.
 
         Args:
             n: The number of qubits in the qubit register.
             name: The name of the qubit register.
+
+        Returns:
+            The qubit register added to the quantum computation.
         """
 
-    def unify_quantum_registers(self, name: str = "q") -> None:
+    def unify_quantum_registers(self, name: str = "q") -> QuantumRegister:
         """Unify all quantum registers in the quantum computation.
 
         Args:
             name: The name of the unified quantum register.
+
+        Returns:
+            The unified quantum register.
         """
 
     # --------------------------------------------------------------------------

--- a/src/mqt/core/ir/registers.pyi
+++ b/src/mqt/core/ir/registers.pyi
@@ -42,6 +42,9 @@ class QuantumRegister:
     def __hash__(self) -> int:
         """Return the hash of the quantum register."""
 
+    def __getitem__(self, key: int) -> int:
+        """Get the qubit at the specified index."""
+
     def __contains__(self, qubit: int) -> bool:
         """Check if the quantum register contains a qubit."""
 
@@ -79,6 +82,9 @@ class ClassicalRegister:
 
     def __hash__(self) -> int:
         """Return the hash of the classical register."""
+
+    def __getitem__(self, key: int) -> int:
+        """Get the bit at the specified index."""
 
     def __contains__(self, bit: int) -> bool:
         """Check if the classical register contains a bit."""

--- a/src/python/ir/register_registers.cpp
+++ b/src/python/ir/register_registers.cpp
@@ -11,7 +11,9 @@
 #include "ir/Register.hpp"
 #include "python/pybind11.hpp"
 
+#include <cstddef>
 #include <pybind11/operators.h>
+#include <string>
 
 namespace mqt {
 
@@ -35,6 +37,7 @@ void registerRegisters(py::module& m) {
       .def(py::self == py::self)
       .def(py::self != py::self)
       .def(hash(py::self))
+      .def("__getitem__", &qc::QuantumRegister::getGlobalIndex, "key"_a)
       .def("__contains__", &qc::QuantumRegister::contains)
       .def("__repr__", [](const qc::QuantumRegister& reg) {
         return "QuantumRegister(name=" + reg.getName() +
@@ -62,6 +65,7 @@ void registerRegisters(py::module& m) {
       .def(py::self == py::self)
       .def(py::self != py::self)
       .def(hash(py::self))
+      .def("__getitem__", &qc::ClassicalRegister::getGlobalIndex, "key"_a)
       .def("__contains__", &qc::ClassicalRegister::contains)
       .def("__repr__", [](const qc::ClassicalRegister& reg) {
         return "ClassicalRegister(name=" + reg.getName() +

--- a/test/ir/test_io.cpp
+++ b/test/ir/test_io.cpp
@@ -661,3 +661,26 @@ TEST_F(IO, dumpingIncompleteOutputPermutationNotStartingAtZero) {
   const auto qc2 = qasm3::Importer::imports(qasm);
   EXPECT_EQ(qc, qc2);
 }
+
+TEST_F(IO, indexedRegisterOperands) {
+  const auto& q = qc.addQubitRegister(2);
+  const auto& c = qc.addClassicalRegister(2);
+
+  qc.h(q[0]);
+  qc.cx(q[0], q[1]);
+  qc.measure(q[0], c[0]);
+  qc.measure(q[1], c[1]);
+
+  const auto qasm = qc.toQASM();
+  const auto* const expected = "// i 0 1\n"
+                               "// o 0 1\n"
+                               "OPENQASM 3.0;\n"
+                               "include \"stdgates.inc\";\n"
+                               "qubit[2] q;\n"
+                               "bit[2] c;\n"
+                               "h q[0];\n"
+                               "cx q[0], q[1];\n"
+                               "c[0] = measure q[0];\n"
+                               "c[1] = measure q[1];\n";
+  EXPECT_EQ(qasm, expected);
+}

--- a/test/python/ir/test_ir.py
+++ b/test/python/ir/test_ir.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2025 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Test the quantum computation IR."""
+
+from __future__ import annotations
+
+from mqt.core.ir import QuantumComputation
+
+
+def test_bell_state_circuit() -> None:
+    """Test the creation of a Bell state circuit."""
+    qc = QuantumComputation()
+    q = qc.add_qubit_register(2)
+    c = qc.add_classical_register(2)
+
+    qc.h(q[0])
+    qc.cx(q[0], q[1])
+    qc.measure(q[0], c[0])
+    qc.measure(q[1], c[1])
+
+    qasm = qc.qasm3_str()
+    expected = """
+        // i 0 1
+        // o 0 1
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit[2] q;
+        bit[2] c;
+        h q[0];
+        cx q[0], q[1];
+        c[0] = measure q[0];
+        c[1] = measure q[1];
+    """
+    # Remove all whitespace from both strings before comparison
+    assert "".join(qasm.split()) == "".join(expected.split())


### PR DESCRIPTION
## Description

This update enables the use of indexed registers as arguments for operations. 
For example, in Python:
```python
from mqt.core.ir import QuantumComputation

qc = QuantumComputation()
q = qc.add_qubit_register(2)
c = qc.add_classical_register(2)

qc.h(q[0])
qc.cx(q[0], q[1])
qc.measure(q[0], c[0])
qc.measure(q[1], c[1])
```
In C++:
```c++
#include "ir/QuantumComputation.hpp"

auto qc = qc::QuantumComputation();
const auto& q = qc.addQubitRegister(2);
const auto& c = qc.addClassicalRegister(2);

qc.h(q[0]);
qc.cx(q[0], q[1]);
qc.measure(q[0], c[0]);
qc.measure(q[1], c[1]);
```

This improvement expands the usability of the IR as it no longer requires users to track the order in which registers were added to infer their qubits' indices.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.