### PR TITLE
⬆️ Update googletest and Boost Multiprecision dependencies

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -79,7 +79,7 @@ if(BUILD_MQT_CORE_TESTS)
       ON
       CACHE BOOL "" FORCE)
   set(GTEST_VERSION
-      1.14.0
+      1.16.0
       CACHE STRING "Google Test version")
   set(GTEST_URL https://github.com/google/googletest/archive/refs/tags/v${GTEST_VERSION}.tar.gz)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -57,7 +57,7 @@ else()
       ON
       CACHE INTERNAL "Use standalone boost multiprecision")
   set(BOOST_VERSION
-      1_84_0
+      1_86_0
       CACHE INTERNAL "Boost version")
   set(BOOST_URL
       https://github.com/boostorg/multiprecision/archive/refs/tags/Boost_${BOOST_VERSION}.tar.gz)


### PR DESCRIPTION
## Description

This pull request updates the following dependencies to their latest stable versions:
- `googletest`: from `1.14.0` to `1.16.0`
- `Boost Multiprecision`: from `1_84_0` to `1_86_0`

These updates bring in the latest fixes, performance improvements, and compatibility enhancements. No new dependencies are introduced.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.