### PR TITLE
🔧 Only enable IPO per default for Release builds outside of deployment

### DIFF
--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -57,7 +57,8 @@ if(DEPLOY)
       CACHE STRING "" FORCE)
 endif()
 
-if(NOT DEPLOY)
+# try to enable inter-procedural optimization per default for Release builds outside of deployment
+if(NOT DEPLOY AND CMAKE_BUILD_TYPE STREQUAL "Release")
   option(ENABLE_IPO "Enable Interprocedural Optimization, aka Link Time Optimization (LTO)" ON)
 else()
   option(ENABLE_IPO "Enable Interprocedural Optimization, aka Link Time Optimization (LTO)" OFF)


### PR DESCRIPTION
## Description

Basically the PR title. From past experience, IPO can make debugging quite hard.
This PR ensures that, at least in non-release builds, IPO is not enabled by default.
As such, no manual workarounds should be necessary anymore for debugging.

This change transitively propagates to all dependants of MQT Core once they update to the latest version.

@ystade tagging for awareness

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines