### PR TITLE
🔧 Handle empty quantum and classical registers in qiskit to MQT translation

### DIFF
--- a/src/mqt/core/plugins/qiskit.py
+++ b/src/mqt/core/plugins/qiskit.py
@@ -50,6 +50,8 @@ def qiskit_to_mqt(circ: QuantumCircuit) -> QuantumComputation:
     qubit_map: dict[Qubit, int] = {}
     for reg in circ.qregs:
         size = reg.size
+        if size == 0:
+            continue
         if isinstance(reg, AncillaRegister):
             qc.add_ancillary_register(size, reg.name)
         else:
@@ -62,6 +64,8 @@ def qiskit_to_mqt(circ: QuantumCircuit) -> QuantumComputation:
     clbit_map: dict[Clbit, int] = {}
     for reg in circ.cregs:
         size = reg.size
+        if size == 0:
+            continue
         qc.add_classical_register(size, reg.name)
         for bit in reg:
             clbit_map[bit] = clbit_index

--- a/test/python/plugins/test_qiskit.py
+++ b/test/python/plugins/test_qiskit.py
@@ -394,3 +394,21 @@ def test_final_layout_with_permutation_ancilla_in_front_and_back(backend: Generi
 
     # Check that output_permutation matches the result of applying the routing permutation to input_layout
     assert mqt_qc.output_permutation == {idx: routing_permutation[key] for idx, key in enumerate(initial_layout)}
+
+
+def test_empty_quantum_register() -> None:
+    """Test an empty quantum register (valid in Qiskit) is handled correctly."""
+    qr = QuantumRegister(0)
+    qc = QuantumCircuit(qr)
+    mqt_qc = qiskit_to_mqt(qc)
+    assert mqt_qc.num_qubits == 0
+    assert mqt_qc.num_ops == 0
+
+
+def test_empty_classical_register() -> None:
+    """Test an empty classical register (valid in Qiskit) is handled correctly."""
+    cr = ClassicalRegister(0)
+    qc = QuantumCircuit(cr)
+    mqt_qc = qiskit_to_mqt(qc)
+    assert mqt_qc.num_classical_bits == 0
+    assert mqt_qc.num_ops == 0


### PR DESCRIPTION
## Description

This pull request adds support for handling empty quantum and classical registers during the translation process from Qiskit to MQT. This update ensures proper translation and eliminates any potential errors caused by empty registers.

This has come up while working on https://github.com/cda-tum/mqt-ddsim/pull/336

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.