### PR TITLE
🐛 Fix and enhance Qiskit layout and permutation handling

### DIFF
--- a/src/mqt/core/ir/__init__.pyi
+++ b/src/mqt/core/ir/__init__.pyi
@@ -71,6 +71,9 @@ class Permutation(MutableMapping[int, int]):
     def __hash__(self) -> int:
         """Return the hash of the permutation."""
 
+    def clear(self) -> None:
+        """Clear the permutation of all indices and values."""
+
     @overload
     def apply(self, controls: set[Control]) -> set[Control]:
         """Apply the permutation to a set of controls.

--- a/src/mqt/core/ir/__init__.pyi
+++ b/src/mqt/core/ir/__init__.pyi
@@ -28,7 +28,7 @@ class Permutation(MutableMapping[int, int]):
 
     """
 
-    def __init__(self, permutation: dict[int, int] | None = None) -> None:
+    def __init__(self, permutation: dict[int, int]) -> None:
         """Initialize the permutation."""
 
     def __getitem__(self, idx: int) -> int:

--- a/src/python/ir/register_permutation.cpp
+++ b/src/python/ir/register_permutation.cpp
@@ -35,6 +35,7 @@ void registerPermutation(py::module& m) {
            py::overload_cast<const qc::Targets&>(&qc::Permutation::apply,
                                                  py::const_),
            "targets"_a)
+      .def("clear", [](qc::Permutation& p) { p.clear(); })
       .def("__getitem__",
            [](const qc::Permutation& p, const qc::Qubit q) { return p.at(q); })
       .def("__setitem__", [](qc::Permutation& p, const qc::Qubit q,

--- a/src/python/ir/register_permutation.cpp
+++ b/src/python/ir/register_permutation.cpp
@@ -55,8 +55,11 @@ void registerPermutation(py::module& m) {
            [](const qc::Permutation& p) {
              std::stringstream ss;
              ss << "{";
-             for (const auto& [k, v] : p) {
-               ss << k << ": " << v << ", ";
+             for (auto it = p.cbegin(); it != p.cend(); ++it) {
+               ss << it->first << ": " << it->second;
+               if (std::next(it) != p.cend()) {
+                 ss << ", ";
+               }
              }
              ss << "}";
              return ss.str();
@@ -64,8 +67,11 @@ void registerPermutation(py::module& m) {
       .def("__repr__", [](const qc::Permutation& p) {
         std::stringstream ss;
         ss << "Permutation({";
-        for (const auto& [k, v] : p) {
-          ss << k << ": " << v << ", ";
+        for (auto it = p.cbegin(); it != p.cend(); ++it) {
+          ss << it->first << ": " << it->second;
+          if (std::next(it) != p.cend()) {
+            ss << ", ";
+          }
         }
         ss << "})";
         return ss.str();

--- a/src/python/ir/register_permutation.cpp
+++ b/src/python/ir/register_permutation.cpp
@@ -38,7 +38,7 @@ void registerPermutation(py::module& m) {
       .def("__getitem__",
            [](const qc::Permutation& p, const qc::Qubit q) { return p.at(q); })
       .def("__setitem__", [](qc::Permutation& p, const qc::Qubit q,
-                             const qc::Qubit r) { p.at(q) = r; })
+                             const qc::Qubit r) { p[q] = r; })
       .def("__delitem__",
            [](qc::Permutation& p, const qc::Qubit q) { p.erase(q); })
       .def("__len__", &qc::Permutation::size)

--- a/test/python/plugins/test_qiskit.py
+++ b/test/python/plugins/test_qiskit.py
@@ -372,6 +372,8 @@ def test_final_layout_with_permutation(backend: GenericBackendV2) -> None:
     qc_transpiled = transpile(qc, backend, initial_layout=initial_layout, seed_transpiler=seed)
     final_index_layout = qc_transpiled.layout.final_index_layout()
     mqt_qc = qiskit_to_mqt(qc_transpiled)
+    # Check the initial layout is properly translated
+    assert mqt_qc.initial_layout == {0: 1, 1: 0, 3: 2, 2: 3, 4: 4}
     # Check initialize_io_mapping doesn't change the final_layout
     assert mqt_qc.output_permutation == dict(enumerate(final_index_layout))
 
@@ -391,7 +393,8 @@ def test_final_layout_with_permutation_ancilla_in_front_and_back(backend: Generi
     qc_transpiled = transpile(qc, backend, initial_layout=initial_layout, seed_transpiler=seed)
     routing_permutation = qc_transpiled.layout.routing_permutation()
     mqt_qc = qiskit_to_mqt(qc_transpiled)
-
+    # Check the initial layout is properly translated
+    assert mqt_qc.initial_layout == {0: 1, 1: 0, 3: 2, 2: 3, 4: 4}
     # Check that output_permutation matches the result of applying the routing permutation to input_layout
     assert mqt_qc.output_permutation == {idx: routing_permutation[key] for idx, key in enumerate(initial_layout)}
 


### PR DESCRIPTION
## Description

This pull request includes several improvements and fixes to the Qiskit layout and permutation handling logic. Key changes:

- Fixed and simplified the Qiskit layout handling mechanism.
- Fixed type stubs for the permutation constructor to ensure type safety.
- Added a new `clear` method to the permutation class for easier reset functionality.
- Corrected issues with the permutation setter.
- Enhanced the permutation representation for cleaner and more intuitive display.

These changes aim to improve functionality, maintainability, and user experience in working with layouts and permutations.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines