### PR TITLE
✨ Add Python interface improvements and Qiskit export support

### DIFF
--- a/include/mqt-core/ir/operations/CompoundOperation.hpp
+++ b/include/mqt-core/ir/operations/CompoundOperation.hpp
@@ -189,7 +189,16 @@ public:
     return ops.insert(iter, std::forward<decltype(op)>(op));
   }
 
+  // Element access (pass-through)
   [[nodiscard]] const auto& at(const std::size_t i) const { return ops.at(i); }
+  [[nodiscard]] auto& operator[](const std::size_t i) { return ops[i]; }
+  [[nodiscard]] const auto& operator[](const std::size_t i) const {
+    return ops[i];
+  }
+  [[nodiscard]] auto& front() { return ops.front(); }
+  [[nodiscard]] const auto& front() const { return ops.front(); }
+  [[nodiscard]] auto& back() { return ops.back(); }
+  [[nodiscard]] const auto& back() const { return ops.back(); }
 };
 } // namespace qc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ filterwarnings = [
   # Qiskit 1.3 deprecations
   'ignore:.*``qiskit.dagcircuit.dagcircuit.DAGCircuit.*`` is deprecated as of qiskit 1.3.0.*:DeprecationWarning:',
   'ignore:.*``qiskit.circuit.library.standard_gates.x.*`` is pending deprecation as of qiskit 1.3.*:PendingDeprecationWarning:',
+  'ignore:.*``qiskit.circuit.instruction.Instruction.condition`` is deprecated as of qiskit 1.3.0.*:DeprecationWarning:',
 ]
 log_cli_level = "info"
 testpaths = ["test/python"]

--- a/src/mqt/core/ir/__init__.pyi
+++ b/src/mqt/core/ir/__init__.pyi
@@ -7,7 +7,7 @@
 
 """MQT Core IR  - The MQT Core Intermediate Representation (IR) module."""
 
-from collections.abc import Iterable, Iterator, Mapping, MutableMapping, MutableSequence, Sequence
+from collections.abc import ItemsView, Iterable, Iterator, Mapping, MutableMapping, MutableSequence, Sequence
 from os import PathLike
 from typing import overload
 
@@ -58,6 +58,9 @@ class Permutation(MutableMapping[int, int]):
 
     def __iter__(self) -> Iterator[int]:
         """Return an iterator over the indices of the permutation."""
+
+    def items(self) -> ItemsView[int, int]:
+        """Return an iterable over the items of the permutation."""
 
     def __len__(self) -> int:
         """Return the number of indices in the permutation."""

--- a/src/mqt/core/ir/__init__.pyi
+++ b/src/mqt/core/ir/__init__.pyi
@@ -353,6 +353,18 @@ class QuantumComputation(MutableSequence[Operation]):
             The unified quantum register.
         """
 
+    @property
+    def qregs(self) -> dict[str, QuantumRegister]:
+        """The quantum registers in the quantum computation."""
+
+    @property
+    def cregs(self) -> dict[str, ClassicalRegister]:
+        """The classical registers in the quantum computation."""
+
+    @property
+    def ancregs(self) -> dict[str, QuantumRegister]:
+        """The ancillary registers in the quantum computation."""
+
     # --------------------------------------------------------------------------
     #                  Initial Layout and Output Permutation
     # --------------------------------------------------------------------------

--- a/src/mqt/core/ir/operations.pyi
+++ b/src/mqt/core/ir/operations.pyi
@@ -6,7 +6,7 @@
 # Licensed under the MIT License
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, MutableSequence, Sequence
 from typing import ClassVar, overload
 
 from .registers import ClassicalRegister
@@ -665,7 +665,7 @@ class NonUnitaryOperation(Operation):
     def invert(self) -> None:
         """Non-unitary operations are, per definition, not invertible."""
 
-class CompoundOperation(Operation):
+class CompoundOperation(Operation, MutableSequence[Operation]):
     """Compound quantum operation.
 
     This class is used to aggregate and group multiple operations into a single
@@ -712,11 +712,56 @@ class CompoundOperation(Operation):
             This gives direct access to the operations in the compound operation.
         """
 
+    @overload
+    def __setitem__(self, idx: int, op: Operation) -> None:
+        """Set the operation at the given index.
+
+        Args:
+            idx: The index of the operation to set.
+            op: The operation to set at the given index.
+        """
+
+    @overload
+    def __setitem__(self, idx: slice, ops: Iterable[Operation]) -> None:
+        """Set the operations in the given slice.
+
+        Args:
+            idx: The slice of operations to set.
+            ops: The operations to set in the given slice.
+        """
+
+    @overload
+    def __delitem__(self, idx: int) -> None:
+        """Delete the operation at the given index.
+
+        Args:
+            idx: The index of the operation to delete.
+        """
+
+    @overload
+    def __delitem__(self, idx: slice) -> None:
+        """Delete the operations in the given slice.
+
+        Args:
+            idx: The slice of operations to delete.
+        """
+
+    def insert(self, idx: int, op: Operation) -> None:
+        """Insert an operation at the given index.
+
+        Args:
+            idx: The index to insert the operation at.
+            op: The operation to insert.
+        """
+
     def append(self, op: Operation) -> None:
         """Append an operation to the compound operation."""
 
     def empty(self) -> bool:
         """Check if the compound operation is empty."""
+
+    def clear(self) -> None:
+        """Clear all operations in the compound operation."""
 
     def add_control(self, control: Control) -> None:
         """Add a control to the operation.

--- a/src/mqt/core/plugins/qiskit/__init__.py
+++ b/src/mqt/core/plugins/qiskit/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""MQT Qiskit Plugin."""
+
+from __future__ import annotations
+
+from .mqt_to_qiskit import mqt_to_qiskit
+from .qiskit_to_mqt import qiskit_to_mqt
+
+__all__ = [
+    "mqt_to_qiskit",
+    "qiskit_to_mqt",
+]

--- a/src/mqt/core/plugins/qiskit/mqt_to_qiskit.py
+++ b/src/mqt/core/plugins/qiskit/mqt_to_qiskit.py
@@ -1,0 +1,353 @@
+# Copyright (c) 2025 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Functionality for translating from the MQT to Qiskit."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from qiskit.circuit import AncillaRegister, ClassicalRegister, Clbit, QuantumCircuit, QuantumRegister, Qubit
+from qiskit.circuit.library import (
+    DCXGate,
+    ECRGate,
+    HGate,
+    IGate,
+    PhaseGate,
+    RXGate,
+    RXXGate,
+    RYGate,
+    RYYGate,
+    RZGate,
+    RZXGate,
+    RZZGate,
+    SdgGate,
+    SGate,
+    SwapGate,
+    SXdgGate,
+    SXGate,
+    TdgGate,
+    TGate,
+    U2Gate,
+    U3Gate,
+    XGate,
+    XXMinusYYGate,
+    XXPlusYYGate,
+    YGate,
+    ZGate,
+    iSwapGate,
+)
+from qiskit.transpiler.layout import Layout, TranspileLayout
+
+from ...ir import Permutation
+from ...ir.operations import (
+    ClassicControlledOperation,
+    CompoundOperation,
+    Control,
+    NonUnitaryOperation,
+    Operation,
+    OpType,
+    StandardOperation,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from qiskit.circuit.singleton import SingletonGate
+
+    from ...ir import QuantumComputation
+
+__all__ = ["mqt_to_qiskit"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def _translate_controls(controls: set[Control], qubit_map: Mapping[int, Qubit]) -> tuple[list[Qubit], str]:
+    """Translate a set of :class:`~mqt.core.ir.operations.Control` to Qiskit.
+
+    Args:
+        controls: The controls to translate.
+        qubit_map: A mapping from qubit indices to Qiskit :class:`~qiskit.circuit.Qubit`.
+
+    Returns:
+        A tuple containing the translated qubits and control states.
+    """
+    qubits: list[Qubit] = []
+    ctrl_state: str = ""
+    for control in controls:
+        qubit = qubit_map[control.qubit]
+        qubits.append(qubit)
+        # MSB to the left
+        ctrl_state = "1" + ctrl_state if control.type_ == Control.Type.Pos else "0" + ctrl_state
+    return qubits, ctrl_state
+
+
+def _translate_targets(targets: Sequence[int], qubit_map: Mapping[int, Qubit]) -> list[Qubit]:
+    """Translate a sequence of target qubit indices to a list of Qiskit :class:`~qiskit.circuit.Qubit`.
+
+    Args:
+        targets: The target qubit indices to translate.
+        qubit_map: A mapping from qubit indices to Qiskit :class:`~qiskit.circuit.Qubit`.
+
+    Returns:
+        The translated qubits.
+    """
+    return [qubit_map[target] for target in targets]
+
+
+def _add_standard_operation(circ: QuantumCircuit, op: StandardOperation, qubit_map: Mapping[int, Qubit]) -> None:
+    """Add a :class:`~mqt.core.ir.operations.StandardOperation`.
+
+    Args:
+        circ: The Qiskit circuit to add the operation to.
+        op: The MQT operation to add.
+        qubit_map: A mapping from qubit indices to Qiskit :class:`~qiskit.circuit.Qubit`.
+
+    Raises:
+        TypeError: If the operation type is not supported.
+    """
+    targets = _translate_targets(op.targets, qubit_map)
+
+    if op.type_ == OpType.barrier:
+        circ.barrier(targets)
+        return
+
+    controls, ctrl_state = _translate_controls(op.controls, qubit_map)
+
+    gate_map_singleton: dict[OpType, SingletonGate] = {
+        OpType.i: IGate(),
+        OpType.x: XGate(),
+        OpType.y: YGate(),
+        OpType.z: ZGate(),
+        OpType.h: HGate(),
+        OpType.s: SGate(),
+        OpType.sdg: SdgGate(),
+        OpType.t: TGate(),
+        OpType.tdg: TdgGate(),
+        OpType.sx: SXGate(),
+        OpType.sxdg: SXdgGate(),
+        OpType.dcx: DCXGate(),
+        OpType.ecr: ECRGate(),
+        OpType.swap: SwapGate(),
+        OpType.iswap: iSwapGate(),
+    }
+
+    if op.type_ in gate_map_singleton:
+        gate = gate_map_singleton[op.type_]
+        if len(controls) == 0:
+            circ.append(gate, targets)
+        else:
+            circ.append(gate.control(len(controls), ctrl_state=ctrl_state), [*controls, *targets])
+        return
+
+    gate_map_single_param: dict[OpType, type] = {
+        OpType.rx: RXGate,
+        OpType.ry: RYGate,
+        OpType.rz: RZGate,
+        OpType.p: PhaseGate,
+        OpType.rxx: RXXGate,
+        OpType.ryy: RYYGate,
+        OpType.rzz: RZZGate,
+        OpType.rzx: RZXGate,
+    }
+
+    if op.type_ in gate_map_single_param:
+        gate = gate_map_single_param[op.type_]
+        parameter = op.parameter[0]
+        if len(controls) == 0:
+            circ.append(gate(parameter), targets)
+        else:
+            circ.append(gate(parameter).control(len(controls), ctrl_state=ctrl_state), [*controls, *targets])
+        return
+
+    gate_map_two_param: dict[OpType, type] = {
+        OpType.u2: U2Gate,
+        OpType.xx_plus_yy: XXPlusYYGate,
+        OpType.xx_minus_yy: XXMinusYYGate,
+    }
+
+    if op.type_ in gate_map_two_param:
+        gate = gate_map_two_param[op.type_]
+        parameter1, parameter2 = op.parameter
+        if len(controls) == 0:
+            circ.append(gate(parameter1, parameter2), targets)
+        else:
+            circ.append(
+                gate(parameter1, parameter2).control(len(controls), ctrl_state=ctrl_state), [*controls, *targets]
+            )
+        return
+
+    gate_map_three_param: dict[OpType, type] = {
+        OpType.u: U3Gate,
+    }
+
+    if op.type_ in gate_map_three_param:
+        gate = gate_map_three_param[op.type_]
+        parameter1, parameter2, parameter3 = op.parameter
+        if len(controls) == 0:
+            circ.append(gate(parameter1, parameter2, parameter3), targets)
+        else:
+            circ.append(
+                gate(parameter1, parameter2, parameter3).control(len(controls), ctrl_state=ctrl_state),
+                [*controls, *targets],
+            )
+        return
+
+    msg = f"Unsupported operation type: {op.type_}"
+    raise TypeError(msg)
+
+
+def _add_non_unitary_operation(
+    circ: QuantumCircuit, op: NonUnitaryOperation, qubit_map: Mapping[int, Qubit], clbit_map: Mapping[int, Clbit]
+) -> None:
+    """Add a :class:`~mqt.core.ir.operations.NonUnitaryOperation`.
+
+    Args:
+        circ: The Qiskit circuit to add the operation to.
+        op: The MQT operation to add.
+        qubit_map: A mapping from qubit indices to Qiskit :class:`~qiskit.circuit.Qubit`.
+        clbit_map: A mapping from classical bit indices to Qiskit :class:`~qiskit.circuit.Clbit`.
+    """
+    if op.type_ == OpType.measure:
+        for qubit, clbit in zip(op.targets, op.classics):
+            circ.measure(qubit_map[qubit], clbit_map[clbit])
+        return
+
+    if op.type_ == OpType.reset:
+        for qubit in op.targets:
+            circ.reset(qubit_map[qubit])
+        return
+
+
+def _add_compound_operation(
+    circ: QuantumCircuit, op: CompoundOperation, qubit_map: Mapping[int, Qubit], clbit_map: Mapping[int, Clbit]
+) -> None:
+    """Add a :class:`~mqt.core.ir.operations.CompoundOperation`.
+
+    Args:
+        circ: The Qiskit circuit to add the operation to.
+        op: The MQT operation to add.
+        qubit_map: A mapping from qubit indices to Qiskit :class:`~qiskit.circuit.Qubit`.
+        clbit_map: A mapping from classical bit indices to Qiskit :class:`~qiskit.circuit.Clbit`.
+    """
+    inner_circ = QuantumCircuit(*circ.qregs, *circ.cregs)
+    for inner_op in op:
+        _add_operation(inner_circ, inner_op, qubit_map, clbit_map)
+    circ.append(inner_circ.to_instruction(), circ.qubits, circ.clbits)
+
+
+def _add_operation(
+    circ: QuantumCircuit, op: Operation, qubit_map: Mapping[int, Qubit], clbit_map: Mapping[int, Clbit]
+) -> None:
+    """Add an operation to a Qiskit circuit.
+
+    Args:
+        circ: The Qiskit circuit to add the operation to.
+        op: The MQT operation to add.
+        qubit_map: A mapping from qubit indices to Qiskit :class:`~qiskit.circuit.Qubit`.
+        clbit_map: A mapping from classical bit indices to Qiskit :class:`~qiskit.circuit.Clbit`.
+
+    Raises:
+        TypeError: If the operation type is not supported.
+        NotImplementedError: If the operation type is not yet supported.
+    """
+    if isinstance(op, StandardOperation):
+        _add_standard_operation(circ, op, qubit_map)
+    elif isinstance(op, NonUnitaryOperation):
+        _add_non_unitary_operation(circ, op, qubit_map, clbit_map)
+    elif isinstance(op, CompoundOperation):
+        _add_compound_operation(circ, op, qubit_map, clbit_map)
+    elif isinstance(op, ClassicControlledOperation):
+        msg = "Conversion of classic-controlled operations to Qiskit is not yet supported."
+        raise NotImplementedError(msg)
+    else:
+        msg = f"Unsupported operation type: {type(op)}"
+        raise TypeError(msg)
+
+
+def mqt_to_qiskit(qc: QuantumComputation, *, set_layout: bool = False) -> QuantumCircuit:
+    """Convert a :class:`~mqt.core.ir.QuantumComputation` to a Qiskit :class:`~qiskit.circuit.QuantumCircuit`.
+
+    Args:
+        qc: The MQT circuit to convert.
+        set_layout: If true, the :attr:`~qiskit.circuit.QuantumCircuit.layout` property is populated with the
+                    initial layout and output permutation of the MQT circuit.
+
+    Returns:
+        The converted circuit.
+
+    Raises:
+        NotImplementedError: If the MQT circuit contains variables.
+    """
+    if not qc.is_variable_free():
+        msg = "Converting symbolic circuits with variables to Qiskit is not yet supported."
+        raise NotImplementedError(msg)
+
+    circ = QuantumCircuit()
+
+    if qc.name is not None:
+        circ.name = qc.name
+
+    qregs = sorted((qc.qregs | qc.ancregs).values(), key=lambda reg: reg.start)
+    qubit_map: dict[int, Qubit] = {}
+    for qreg in qregs:
+        qiskit_reg = (
+            QuantumRegister(size=qreg.size, name=qreg.name)
+            if qreg.name in qc.qregs
+            else AncillaRegister(size=qreg.size, name=qreg.name)
+        )
+        circ.add_register(qiskit_reg)
+        for i, qubit in enumerate(qiskit_reg):
+            qubit_map[qreg.start + i] = qubit
+
+    cregs = sorted(qc.cregs.values(), key=lambda reg: reg.start)
+    clbit_map: dict[int, Clbit] = {}
+    for creg in cregs:
+        qiskit_creg = ClassicalRegister(size=creg.size, name=creg.name)
+        circ.add_register(qiskit_creg)
+        for i, clbit in enumerate(qiskit_creg):
+            clbit_map[creg.start + i] = clbit
+
+    for op in qc:
+        _add_operation(circ, op, qubit_map, clbit_map)
+
+    if not set_layout:
+        return circ
+
+    # create a list of physical qubits initialized to none, but with the correct length
+    p2v: list[Qubit | None] = [None] * len(circ.qubits)
+    # fill the list with the correct virtual qubits
+    for virtual, physical in qc.initial_layout.items():
+        p2v[virtual] = qubit_map[physical]
+    initial_layout = Layout().from_qubit_list(p2v, *circ.qregs)
+
+    # reconstruct the final layout, which is the permutation between the initial layout and the output permutation
+    permutation = Permutation()
+    for physical, virtual in qc.output_permutation.items():
+        # find the virtual qubit in the initial layout and store the corresponding physical qubit
+        for p, v in qc.initial_layout.items():
+            if v == virtual:
+                permutation[p] = physical
+                continue
+
+    p2v = [None] * len(circ.qubits)
+    # fill the list with the correct virtual qubits
+    for physical, virtual in permutation.items():
+        p2v[virtual] = qubit_map[physical]
+    final_layout = Layout().from_qubit_list(p2v, *circ.qregs)
+
+    circ._layout = TranspileLayout(  # noqa: SLF001
+        initial_layout=initial_layout,
+        input_qubit_mapping={qubit: idx for idx, qubit in qubit_map.items()},
+        final_layout=final_layout,
+        _input_qubit_count=qc.num_qubits,
+        _output_qubit_list=list(final_layout.get_virtual_bits()),
+    )
+
+    return circ

--- a/src/mqt/core/plugins/qiskit/qiskit_to_mqt.py
+++ b/src/mqt/core/plugins/qiskit/qiskit_to_mqt.py
@@ -5,7 +5,7 @@
 #
 # Licensed under the MIT License
 
-"""Functionality for interoperability with Qiskit."""
+"""Functionality for translating from Qiskit to the MQT."""
 
 from __future__ import annotations
 
@@ -15,8 +15,8 @@ from typing import TYPE_CHECKING, cast
 
 from qiskit.circuit import AncillaRegister, Clbit, Qubit
 
-from ..ir import QuantumComputation
-from ..ir.operations import (
+from ...ir import QuantumComputation
+from ...ir.operations import (
     CompoundOperation,
     Control,
     NonUnitaryOperation,
@@ -24,12 +24,19 @@ from ..ir.operations import (
     StandardOperation,
     SymbolicOperation,
 )
-from ..ir.symbolic import Expression, Term, Variable
+from ...ir.symbolic import Expression, Term, Variable
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
     from qiskit.circuit import Instruction, ParameterExpression, QuantumCircuit
+
+
+__all__ = ["qiskit_to_mqt"]
+
+
+def __dir__() -> list[str]:
+    return __all__
 
 
 def qiskit_to_mqt(circ: QuantumCircuit) -> QuantumComputation:
@@ -125,6 +132,8 @@ _NATIVELY_SUPPORTED_GATES = frozenset({
     "cx",
     "cy",
     "cz",
+    "cs",
+    "csdg",
     "cp",
     "cu1",
     "ch",
@@ -209,10 +218,10 @@ def _emplace_operation(
     if name in {"h", "ch"}:
         return _add_operation(qc, OpType.h, qargs, params, qubit_map)
 
-    if name == "s":
+    if name in {"s", "cs"}:
         return _add_operation(qc, OpType.s, qargs, params, qubit_map)
 
-    if name == "sdg":
+    if name in {"sdg", "csdg"}:
         return _add_operation(qc, OpType.sdg, qargs, params, qubit_map)
 
     if name == "t":
@@ -437,6 +446,3 @@ def _import_definition(
         )
         params.extend(new_params)
     return params
-
-
-__all__ = ["qiskit_to_mqt"]

--- a/src/python/ir/register_permutation.cpp
+++ b/src/python/ir/register_permutation.cpp
@@ -44,8 +44,12 @@ void registerPermutation(py::module& m) {
       .def("__delitem__",
            [](qc::Permutation& p, const qc::Qubit q) { p.erase(q); })
       .def("__len__", &qc::Permutation::size)
+      .def("__iter__",
+           [](const qc::Permutation& p) {
+             return py::make_key_iterator(p.begin(), p.end());
+           })
       .def(
-          "__iter__",
+          "items",
           [](const qc::Permutation& p) {
             return py::make_iterator(p.begin(), p.end());
           },

--- a/src/python/ir/register_quantum_computation.cpp
+++ b/src/python/ir/register_quantum_computation.cpp
@@ -195,6 +195,13 @@ void registerQuantumComputation(py::module& m) {
   qc.def("unify_quantum_registers",
          &qc::QuantumComputation::unifyQuantumRegisters, "name"_a = "q");
 
+  qc.def_property_readonly("qregs",
+                           &qc::QuantumComputation::getQuantumRegisters);
+  qc.def_property_readonly("cregs",
+                           &qc::QuantumComputation::getClassicalRegisters);
+  qc.def_property_readonly("ancregs",
+                           &qc::QuantumComputation::getAncillaRegisters);
+
   ///---------------------------------------------------------------------------
   ///               \n Input Layout and Output Permutation \n
   ///---------------------------------------------------------------------------

--- a/src/python/ir/register_registers.cpp
+++ b/src/python/ir/register_registers.cpp
@@ -21,7 +21,8 @@ void registerRegisters(py::module& m) {
   py::class_<qc::QuantumRegister>(m, "QuantumRegister")
       .def(py::init<const qc::Qubit, const std::size_t, const std::string&>(),
            "start"_a, "size"_a, "name"_a = "")
-      .def_property_readonly("name", &qc::QuantumRegister::getName)
+      .def_property_readonly(
+          "name", [](const qc::QuantumRegister& reg) { return reg.getName(); })
       .def_property(
           "start",
           [](const qc::QuantumRegister& reg) { return reg.getStartIndex(); },
@@ -33,7 +34,9 @@ void registerRegisters(py::module& m) {
           [](qc::QuantumRegister& reg, const std::size_t size) {
             reg.getSize() = size;
           })
-      .def_property_readonly("end", &qc::QuantumRegister::getEndIndex)
+      .def_property_readonly(
+          "end",
+          [](const qc::QuantumRegister& reg) { return reg.getEndIndex(); })
       .def(py::self == py::self)
       .def(py::self != py::self)
       .def(hash(py::self))
@@ -48,7 +51,9 @@ void registerRegisters(py::module& m) {
   py::class_<qc::ClassicalRegister>(m, "ClassicalRegister")
       .def(py::init<const qc::Bit, const std::size_t, const std::string&>(),
            "start"_a, "size"_a, "name"_a = "")
-      .def_property_readonly("name", &qc::ClassicalRegister::getName)
+      .def_property_readonly(
+          "name",
+          [](const qc::ClassicalRegister& reg) { return reg.getName(); })
       .def_property(
           "start",
           [](const qc::ClassicalRegister& reg) { return reg.getStartIndex(); },
@@ -61,7 +66,9 @@ void registerRegisters(py::module& m) {
           [](qc::ClassicalRegister& reg, const std::size_t size) {
             reg.getSize() = size;
           })
-      .def_property_readonly("end", &qc::ClassicalRegister::getEndIndex)
+      .def_property_readonly(
+          "end",
+          [](const qc::ClassicalRegister& reg) { return reg.getEndIndex(); })
       .def(py::self == py::self)
       .def(py::self != py::self)
       .def(hash(py::self))


### PR DESCRIPTION
## Description

This pull request introduces several changes to enhance Python interoperability and integration with Qiskit. Key updates include:
- Adding a method to natively export `QuantumComputations` objects to Qiskit `QuantumCircuit`.
- Exposing registers from `QuantumComputation` in the Python interface.
- Addressing issues with calling `name` and `end` on Python registers.
- Fixing the implementation of `__iter__` and providing `items` for `Permutation`.
- Enhancing `CompoundOperation` to implement the `MutableSequence[Operation]` interface.

These changes provide better usability and extend functionality when using the library in Python environments.

Fixes #35

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines