### PR TITLE
✨ Add a couple of NA Operations and `convertToLocal` Function

### DIFF
--- a/include/mqt-core/na/NAComputation.hpp
+++ b/include/mqt-core/na/NAComputation.hpp
@@ -106,10 +106,12 @@ public:
 
   /// Emplaces a new zone with the given name and returns a reference to the
   /// newly created zone.
-  /// @param name The name of the zone.
+  /// @param args The name of the zone and, optionally, the extent of the zone.
   /// @return A reference to the newly created zone.
-  auto emplaceBackZone(std::string name) -> const Zone& {
-    return *zones_.emplace_back(std::make_unique<Zone>(std::move(name)));
+  template <typename... Args>
+  auto emplaceBackZone(Args&&... args) -> const Zone& {
+    return *zones_.emplace_back(
+        std::make_unique<Zone>(std::forward<Args>(args)...));
   }
 
   /// Emplaces a new initial location for the given atom with the given location
@@ -178,5 +180,11 @@ public:
   /// @returns a pair of a Boolean indicating whether the NAComputation is valid
   /// and a string containing the error message if the NAComputation is invalid.
   [[nodiscard]] auto validate() const -> std::pair<bool, std::string>;
+
+  /// Calculates the position of each atom at every stage and replaces global
+  /// gates by local gates with the atoms that are affected by the global gate.
+  /// @param rydbergRange The range of the Rydberg interaction.
+  /// @note There is no way back after this function has been called.
+  auto convertToLocalGates(double rydbergRange) -> void;
 };
 } // namespace na

--- a/include/mqt-core/na/entities/Zone.hpp
+++ b/include/mqt-core/na/entities/Zone.hpp
@@ -13,7 +13,9 @@
 
 #pragma once
 
+#include <optional>
 #include <ostream>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -23,16 +25,50 @@ namespace na {
 /// To maintain the uniqueness of zones, the name of the zone should be unique
 /// for this zone.
 class Zone final {
+public:
+  /// A simple struct to represent the extent of a zone.
+  struct Extent {
+    double minX = 0.0;
+    double minY = 0.0;
+    double maxX = 0.0;
+    double maxY = 0.0;
+  };
+
+private:
   /// The identifier of the zone.
   std::string name_;
+  /// The extent of the zone.
+  std::optional<Extent> extent_;
 
 public:
   /// Creates a new zone with the given name.
   /// @param name The name of the zone.
   explicit Zone(std::string name) : name_(std::move(name)) {}
 
+  /// Creates a new zone with the given name.
+  /// @param name The name of the zone.
+  /// @param extent The extent of the zone.
+  Zone(std::string name, const Extent& extent)
+      : name_(std::move(name)), extent_(extent) {}
+
   /// Returns the name of the zone.
   [[nodiscard]] auto getName() const -> std::string { return name_; }
+
+  /// Returns the extent of the zone.
+  [[nodiscard]] const std::optional<Extent>& getExtent() const {
+    return extent_;
+  }
+
+  /// Sets the extent of the zone.
+  void setExtent(const Extent& extent) { extent_ = extent; }
+
+  [[nodiscard]] auto contains(const Location& location) const -> bool {
+    if (!extent_) {
+      throw std::runtime_error("Zone's extent is not set.");
+    }
+    return location.x >= extent_->minX && location.y >= extent_->minY &&
+           location.x <= extent_->maxX && location.y <= extent_->maxY;
+  }
 
   /// Prints the zone to the given output stream.
   /// @param os The output stream to print the zone to.

--- a/include/mqt-core/na/operations/GlobalCZOp.hpp
+++ b/include/mqt-core/na/operations/GlobalCZOp.hpp
@@ -13,8 +13,19 @@
 
 #pragma once
 
+#include "LocalCZOp.hpp"
+#include "LocalOp.hpp"
+#include "na/entities/Atom.hpp"
+#include "na/entities/Location.hpp"
 #include "na/entities/Zone.hpp"
 #include "na/operations/GlobalOp.hpp"
+
+#include <array>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <unordered_map>
+#include <vector>
 
 namespace na {
 /// Represents a global CZ operation in the NAComputation.
@@ -23,5 +34,34 @@ public:
   /// Creates a new CZ operation in the given zone.
   /// @param zone The zone the operation is applied to.
   explicit GlobalCZOp(const Zone& zone) : GlobalOp(zone, {}) { name_ = "cz"; }
+
+  /// Returns a local representation of the operation.
+  /// @param atomsLocations The locations of the atoms.
+  /// @param rydbergRange The range of the Rydberg interaction.
+  [[nodiscard]] auto
+  toLocal(const std::unordered_map<const Atom*, Location>& atomsLocations,
+          const double rydbergRange) const
+      -> std::unique_ptr<LocalOp> override {
+    // use a map here with the location as keys to ensure a deterministic order
+    // of the atoms
+    std::map<Location, const Atom*> affectedAtoms;
+    for (const auto& [atom, loc] : atomsLocations) {
+      if (zone_->contains(loc)) {
+        affectedAtoms.emplace(loc, atom);
+      }
+    }
+    std::vector<std::array<const Atom*, 2>> atomPairs;
+    for (auto it1 = affectedAtoms.cbegin(); it1 != affectedAtoms.cend();
+         ++it1) {
+      const auto& [loc1, atom1] = *it1;
+      for (auto it2 = std::next(it1); it2 != affectedAtoms.cend(); ++it2) {
+        const auto& [loc2, atom2] = *it2;
+        if ((loc1 - loc2).length() <= rydbergRange) {
+          atomPairs.emplace_back(std::array{atom1, atom2});
+        }
+      }
+    }
+    return std::make_unique<LocalCZOp>(atomPairs);
+  }
 };
 } // namespace na

--- a/include/mqt-core/na/operations/GlobalOp.hpp
+++ b/include/mqt-core/na/operations/GlobalOp.hpp
@@ -15,10 +15,15 @@
 #pragma once
 
 #include "Definitions.hpp"
+#include "LocalOp.hpp"
+#include "na/entities/Atom.hpp"
+#include "na/entities/Location.hpp"
 #include "na/entities/Zone.hpp"
 #include "na/operations/Op.hpp"
 
+#include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -53,5 +58,12 @@ public:
 
   /// Returns a string representation of the operation.
   [[nodiscard]] auto toString() const -> std::string override;
+
+  /// Returns a local representation of the operation.
+  /// @param atomsLocations The locations of the atoms.
+  /// @param rydbergRange The range of the Rydberg interaction.
+  [[nodiscard]] virtual auto
+  toLocal(const std::unordered_map<const Atom*, Location>& atomsLocations,
+          double rydbergRange) const -> std::unique_ptr<LocalOp> = 0;
 };
 } // namespace na

--- a/include/mqt-core/na/operations/GlobalRYOp.hpp
+++ b/include/mqt-core/na/operations/GlobalRYOp.hpp
@@ -14,8 +14,17 @@
 #pragma once
 
 #include "Definitions.hpp"
+#include "LocalOp.hpp"
+#include "LocalRYOp.hpp"
+#include "na/entities/Atom.hpp"
+#include "na/entities/Location.hpp"
 #include "na/entities/Zone.hpp"
 #include "na/operations/GlobalOp.hpp"
+
+#include <map>
+#include <memory>
+#include <unordered_map>
+#include <vector>
 
 namespace na {
 /// Represents a global RY operation in the NAComputation.
@@ -26,6 +35,27 @@ public:
   /// @param angle The angle of the operation.
   GlobalRYOp(const Zone& zone, qc::fp angle) : GlobalOp(zone, {angle}) {
     name_ = "ry";
+  }
+
+  /// Returns a local representation of the operation.
+  /// @param atomsLocations The locations of the atoms.
+  [[nodiscard]] auto
+  toLocal(const std::unordered_map<const Atom*, Location>& atomsLocations,
+          const double /* unused */) const
+      -> std::unique_ptr<LocalOp> override {
+    // make sure atoms are added always in the same order based on their
+    // location
+    std::map<Location, const Atom*> sortedAtoms;
+    for (const auto& [atom, loc] : atomsLocations) {
+      sortedAtoms.emplace(loc, atom);
+    }
+    std::vector<const Atom*> affectedAtoms;
+    for (const auto& [loc, atom] : sortedAtoms) {
+      if (zone_->contains(loc)) {
+        affectedAtoms.emplace_back(atom);
+      }
+    }
+    return std::make_unique<LocalRYOp>(affectedAtoms, params_.front());
   }
 };
 } // namespace na

--- a/include/mqt-core/na/operations/LocalCZOp.hpp
+++ b/include/mqt-core/na/operations/LocalCZOp.hpp
@@ -13,29 +13,33 @@
 
 #pragma once
 
-#include "Definitions.hpp"
 #include "na/entities/Atom.hpp"
 #include "na/operations/LocalOp.hpp"
 
+#include <array>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace na {
 /// Represents a local RZ operation in the NAComputation.
-class LocalRZOp final : public LocalOp {
+class LocalCZOp final : public LocalOp {
 public:
   /// Creates a new RZ operation with the given atoms and angle.
-  /// @param atom The atoms the operation is applied to.
-  /// @param angle The angle of the operation.
-  LocalRZOp(std::vector<const Atom*> atom, const qc::fp angle)
-      : LocalOp(std::move(atom), {angle}) {
-    name_ = "rz";
+  /// @param atoms The atoms the operation is applied to.
+  explicit LocalCZOp(const std::vector<std::array<const Atom*, 2>>& atoms)
+      : LocalOp(atoms, {}) {
+    name_ = "cz";
   }
 
   /// Creates a new RZ operation with the given atom and angle.
   /// @param atom The atom the operation is applied to.
-  /// @param angle The angle of the operation.
-  LocalRZOp(const Atom& atom, const qc::fp angle) : LocalRZOp({&atom}, angle) {}
+  explicit LocalCZOp(const std::array<const Atom*, 2>& atom)
+      : LocalCZOp(std::vector{atom}) {}
+
+  /// Creates a new RZ operation with the given atom and angle.
+  /// @param atom1 The atom the operation is applied to.
+  /// @param atom2 The atom the operation is applied to.
+  explicit LocalCZOp(const Atom& atom1, const Atom& atom2)
+      : LocalCZOp(std::vector{std::array{&atom1, &atom2}}) {}
 };
 } // namespace na

--- a/include/mqt-core/na/operations/LocalHOp.hpp
+++ b/include/mqt-core/na/operations/LocalHOp.hpp
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include "Definitions.hpp"
 #include "na/entities/Atom.hpp"
 #include "na/operations/LocalOp.hpp"
 
@@ -23,19 +22,17 @@
 
 namespace na {
 /// Represents a local RZ operation in the NAComputation.
-class LocalRZOp final : public LocalOp {
+class LocalHOp final : public LocalOp {
 public:
   /// Creates a new RZ operation with the given atoms and angle.
   /// @param atom The atoms the operation is applied to.
-  /// @param angle The angle of the operation.
-  LocalRZOp(std::vector<const Atom*> atom, const qc::fp angle)
-      : LocalOp(std::move(atom), {angle}) {
-    name_ = "rz";
+  explicit LocalHOp(std::vector<const Atom*> atom)
+      : LocalOp(std::move(atom), {}) {
+    name_ = "h";
   }
 
   /// Creates a new RZ operation with the given atom and angle.
   /// @param atom The atom the operation is applied to.
-  /// @param angle The angle of the operation.
-  LocalRZOp(const Atom& atom, const qc::fp angle) : LocalRZOp({&atom}, angle) {}
+  explicit LocalHOp(const Atom& atom) : LocalHOp({&atom}) {}
 };
 } // namespace na

--- a/include/mqt-core/na/operations/LocalOp.hpp
+++ b/include/mqt-core/na/operations/LocalOp.hpp
@@ -18,6 +18,10 @@
 #include "na/entities/Atom.hpp"
 #include "na/operations/Op.hpp"
 
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <ostream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -32,13 +36,27 @@ protected:
   /// The parameters of the operation.
   std::vector<qc::fp> params_;
   /// The atoms the operation is applied to.
-  std::vector<const Atom*> atoms_;
+  /// @details This is a two-dimensional vector, where the first dimension
+  /// represents the different (sets of) atoms the operation is applied to, and
+  /// the second dimension represents the individual atoms in each set.
+  /// For a one-qubit operation, the second dimension will always have size 1.
+  /// For a two-qubit operation, e.g., CZ, the second dimension will have
+  /// size 2.
+  /// @note It is a variable length vector as the NAComputation might support,
+  /// e.g., MCZ gates (multiple controlled Z gates) in the future.
+  std::vector<std::vector<const Atom*>> atoms_;
 
   /// Creates a new local operation with the given atoms and parameters.
   /// @param atoms The atoms the operation is applied to.
   /// @param params The parameters of the operation.
-  LocalOp(std::vector<const Atom*> atoms, std::vector<qc::fp> params)
-      : params_(std::move(params)), atoms_(std::move(atoms)) {}
+  LocalOp(const std::vector<const Atom*>& atoms, std::vector<qc::fp> params);
+
+  /// Creates a new local operation with the given atoms and parameters.
+  /// @param atoms The atoms the operation is applied to.
+  /// @param params The parameters of the operation.
+  template <size_t N>
+  LocalOp(const std::vector<std::array<const Atom*, N>>& atoms,
+          std::vector<qc::fp> params);
 
 public:
   LocalOp() = delete;
@@ -51,5 +69,23 @@ public:
 
   /// Returns a string representation of the operation.
   [[nodiscard]] auto toString() const -> std::string override;
+
+private:
+  /// Print the parameters of the operation to the output stream.
+  static auto printParams(const std::vector<qc::fp>& params, std::ostream& os)
+      -> void;
+
+  /// Print the atoms of the operation to the output stream.
+  static auto printAtoms(const std::vector<const Atom*>& atoms,
+                         std::ostream& os) -> void;
 };
+template <size_t N>
+LocalOp::LocalOp(const std::vector<std::array<const Atom*, N>>& atoms,
+                 std::vector<qc::fp> params)
+    : params_(std::move(params)) {
+  std::transform(atoms.cbegin(), atoms.cend(), std::back_inserter(atoms_),
+                 [](const auto& a) {
+                   return std::vector<const Atom*>(a.cbegin(), a.cend());
+                 });
+}
 } // namespace na

--- a/include/mqt-core/na/operations/LocalRXOp.hpp
+++ b/include/mqt-core/na/operations/LocalRXOp.hpp
@@ -23,19 +23,19 @@
 
 namespace na {
 /// Represents a local RZ operation in the NAComputation.
-class LocalRZOp final : public LocalOp {
+class LocalRXOp final : public LocalOp {
 public:
   /// Creates a new RZ operation with the given atoms and angle.
   /// @param atom The atoms the operation is applied to.
   /// @param angle The angle of the operation.
-  LocalRZOp(std::vector<const Atom*> atom, const qc::fp angle)
+  LocalRXOp(std::vector<const Atom*> atom, const qc::fp angle)
       : LocalOp(std::move(atom), {angle}) {
-    name_ = "rz";
+    name_ = "rx";
   }
 
   /// Creates a new RZ operation with the given atom and angle.
   /// @param atom The atom the operation is applied to.
   /// @param angle The angle of the operation.
-  LocalRZOp(const Atom& atom, const qc::fp angle) : LocalRZOp({&atom}, angle) {}
+  LocalRXOp(const Atom& atom, const qc::fp angle) : LocalRXOp({&atom}, angle) {}
 };
 } // namespace na

--- a/include/mqt-core/na/operations/LocalRYOp.hpp
+++ b/include/mqt-core/na/operations/LocalRYOp.hpp
@@ -18,7 +18,6 @@
 #include "na/operations/LocalOp.hpp"
 
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace na {
@@ -28,8 +27,8 @@ public:
   /// Creates a new RZ operation with the given atoms and angle.
   /// @param atom The atoms the operation is applied to.
   /// @param angle The angle of the operation.
-  LocalRYOp(std::vector<const Atom*> atom, const qc::fp angle)
-      : LocalOp(std::move(atom), {angle}) {
+  LocalRYOp(const std::vector<const Atom*>& atom, const qc::fp angle)
+      : LocalOp(atom, {angle}) {
     name_ = "ry";
   }
 

--- a/include/mqt-core/na/operations/LocalRYOp.hpp
+++ b/include/mqt-core/na/operations/LocalRYOp.hpp
@@ -23,19 +23,19 @@
 
 namespace na {
 /// Represents a local RZ operation in the NAComputation.
-class LocalRZOp final : public LocalOp {
+class LocalRYOp final : public LocalOp {
 public:
   /// Creates a new RZ operation with the given atoms and angle.
   /// @param atom The atoms the operation is applied to.
   /// @param angle The angle of the operation.
-  LocalRZOp(std::vector<const Atom*> atom, const qc::fp angle)
+  LocalRYOp(std::vector<const Atom*> atom, const qc::fp angle)
       : LocalOp(std::move(atom), {angle}) {
-    name_ = "rz";
+    name_ = "ry";
   }
 
   /// Creates a new RZ operation with the given atom and angle.
   /// @param atom The atom the operation is applied to.
   /// @param angle The angle of the operation.
-  LocalRZOp(const Atom& atom, const qc::fp angle) : LocalRZOp({&atom}, angle) {}
+  LocalRYOp(const Atom& atom, const qc::fp angle) : LocalRYOp({&atom}, angle) {}
 };
 } // namespace na

--- a/include/mqt-core/na/operations/LocalXOp.hpp
+++ b/include/mqt-core/na/operations/LocalXOp.hpp
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include "Definitions.hpp"
 #include "na/entities/Atom.hpp"
 #include "na/operations/LocalOp.hpp"
 
@@ -23,19 +22,17 @@
 
 namespace na {
 /// Represents a local RZ operation in the NAComputation.
-class LocalRZOp final : public LocalOp {
+class LocalXOp final : public LocalOp {
 public:
   /// Creates a new RZ operation with the given atoms and angle.
   /// @param atom The atoms the operation is applied to.
-  /// @param angle The angle of the operation.
-  LocalRZOp(std::vector<const Atom*> atom, const qc::fp angle)
-      : LocalOp(std::move(atom), {angle}) {
-    name_ = "rz";
+  explicit LocalXOp(std::vector<const Atom*> atom)
+      : LocalOp(std::move(atom), {}) {
+    name_ = "x";
   }
 
   /// Creates a new RZ operation with the given atom and angle.
   /// @param atom The atom the operation is applied to.
-  /// @param angle The angle of the operation.
-  LocalRZOp(const Atom& atom, const qc::fp angle) : LocalRZOp({&atom}, angle) {}
+  explicit LocalXOp(const Atom& atom) : LocalXOp({&atom}) {}
 };
 } // namespace na

--- a/include/mqt-core/na/operations/LocalYOp.hpp
+++ b/include/mqt-core/na/operations/LocalYOp.hpp
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include "Definitions.hpp"
 #include "na/entities/Atom.hpp"
 #include "na/operations/LocalOp.hpp"
 
@@ -23,19 +22,17 @@
 
 namespace na {
 /// Represents a local RZ operation in the NAComputation.
-class LocalRZOp final : public LocalOp {
+class LocalYOp final : public LocalOp {
 public:
   /// Creates a new RZ operation with the given atoms and angle.
   /// @param atom The atoms the operation is applied to.
-  /// @param angle The angle of the operation.
-  LocalRZOp(std::vector<const Atom*> atom, const qc::fp angle)
-      : LocalOp(std::move(atom), {angle}) {
-    name_ = "rz";
+  explicit LocalYOp(std::vector<const Atom*> atom)
+      : LocalOp(std::move(atom), {}) {
+    name_ = "y";
   }
 
   /// Creates a new RZ operation with the given atom and angle.
   /// @param atom The atom the operation is applied to.
-  /// @param angle The angle of the operation.
-  LocalRZOp(const Atom& atom, const qc::fp angle) : LocalRZOp({&atom}, angle) {}
+  explicit LocalYOp(const Atom& atom) : LocalYOp({&atom}) {}
 };
 } // namespace na

--- a/include/mqt-core/na/operations/LocalZOp.hpp
+++ b/include/mqt-core/na/operations/LocalZOp.hpp
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include "Definitions.hpp"
 #include "na/entities/Atom.hpp"
 #include "na/operations/LocalOp.hpp"
 
@@ -23,19 +22,17 @@
 
 namespace na {
 /// Represents a local RZ operation in the NAComputation.
-class LocalRZOp final : public LocalOp {
+class LocalZOp final : public LocalOp {
 public:
   /// Creates a new RZ operation with the given atoms and angle.
   /// @param atom The atoms the operation is applied to.
-  /// @param angle The angle of the operation.
-  LocalRZOp(std::vector<const Atom*> atom, const qc::fp angle)
-      : LocalOp(std::move(atom), {angle}) {
-    name_ = "rz";
+  explicit LocalZOp(std::vector<const Atom*> atom)
+      : LocalOp(std::move(atom), {}) {
+    name_ = "z";
   }
 
   /// Creates a new RZ operation with the given atom and angle.
   /// @param atom The atom the operation is applied to.
-  /// @param angle The angle of the operation.
-  LocalRZOp(const Atom& atom, const qc::fp angle) : LocalRZOp({&atom}, angle) {}
+  explicit LocalZOp(const Atom& atom) : LocalZOp({&atom}) {}
 };
 } // namespace na

--- a/src/na/NAComputation.cpp
+++ b/src/na/NAComputation.cpp
@@ -20,7 +20,6 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <iostream>
 #include <map>
 #include <sstream>
 #include <string>
@@ -223,10 +222,10 @@ auto NAComputation::validate() const -> std::pair<bool, std::string> {
       // Local Operations
       //===----------------------------------------------------------------===//
       const auto& opAtoms = op->as<LocalOp>().getAtoms();
-      for (std::size_t i = 0; i < opAtoms.size(); ++i) {
-        const auto* a = opAtoms[i];
-        for (std::size_t j = i + 1; j < opAtoms.size(); ++j) {
-          if (const auto* b = opAtoms[j]; a == b) {
+      std::unordered_set<const Atom*> usedAtoms;
+      for (const auto& atoms : opAtoms) {
+        for (const auto* const atom : atoms) {
+          if (!usedAtoms.emplace(atom).second) {
             ss << "Error in op number " << counter
                << " (two atoms identical)\n";
             return {false, ss.str()};

--- a/src/na/operations/LocalOp.cpp
+++ b/src/na/operations/LocalOp.cpp
@@ -9,34 +9,67 @@
 
 #include "na/operations/LocalOp.hpp"
 
+#include "Definitions.hpp"
+#include "na/entities/Atom.hpp"
+
+#include <algorithm>
+#include <cstddef>
 #include <iomanip>
 #include <ios>
+#include <iterator>
+#include <ostream>
 #include <sstream>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace na {
+auto LocalOp::printParams(const std::vector<qc::fp>& params, std::ostream& os)
+    -> void {
+  if (!params.empty()) {
+    for (const auto& p : params) {
+      os << p << " ";
+    }
+  }
+}
+auto LocalOp::printAtoms(const std::vector<const Atom*>& atoms,
+                         std::ostream& os) -> void {
+  if (atoms.size() == 1) {
+    os << *(atoms.front());
+  } else {
+    os << "{";
+    for (size_t i = 0; i < atoms.size(); ++i) {
+      // skip comma in first iteration
+      if (i > 0) {
+        os << ", ";
+      }
+      os << *atoms[i];
+    }
+    os << "}";
+  }
+}
+LocalOp::LocalOp(const std::vector<const Atom*>& atoms,
+                 std::vector<qc::fp> params)
+    : params_(std::move(params)) {
+  std::transform(
+      atoms.cbegin(), atoms.cend(), std::back_inserter(atoms_),
+      [](const auto* const a) { return std::vector<const Atom*>{a}; });
+}
 auto LocalOp::toString() const -> std::string {
   std::stringstream ss;
   ss << std::setprecision(5) << std::fixed;
-  ss << "@+ " << name_;
+  ss << "@+ " << name_ << " ";
   if (atoms_.size() == 1) {
-    if (!params_.empty()) {
-      for (const auto& p : params_) {
-        ss << " " << p;
-      }
-    }
-    ss << " " << *(atoms_.front());
+    printParams(params_, ss);
+    printAtoms(atoms_.front(), ss);
     return ss.str();
   }
-  ss << " [\n";
-  for (const auto* const atom : atoms_) {
+  ss << "[\n";
+  for (const auto& atoms : atoms_) {
     ss << "    ";
-    if (!params_.empty()) {
-      for (const auto& p : params_) {
-        ss << p << " ";
-      }
-    }
-    ss << *atom << "\n";
+    printParams(params_, ss);
+    printAtoms(atoms, ss);
+    ss << "\n";
   }
   ss << "]";
   return ss.str();

--- a/test/na/test_nacomputation.cpp
+++ b/test/na/test_nacomputation.cpp
@@ -15,7 +15,14 @@
 #include "na/operations/GlobalCZOp.hpp"
 #include "na/operations/GlobalRYOp.hpp"
 #include "na/operations/LoadOp.hpp"
+#include "na/operations/LocalCZOp.hpp"
+#include "na/operations/LocalHOp.hpp"
+#include "na/operations/LocalRXOp.hpp"
+#include "na/operations/LocalRYOp.hpp"
 #include "na/operations/LocalRZOp.hpp"
+#include "na/operations/LocalXOp.hpp"
+#include "na/operations/LocalYOp.hpp"
+#include "na/operations/LocalZOp.hpp"
 #include "na/operations/MoveOp.hpp"
 #include "na/operations/StoreOp.hpp"
 
@@ -49,6 +56,55 @@ TEST(NAComputation, Location) {
   EXPECT_DOUBLE_EQ((Location{0, 0}).getEuclideanDistance(loc), 5.0);
   EXPECT_DOUBLE_EQ((Location{0, 0}).getManhattanDistanceX(loc), 3);
   EXPECT_DOUBLE_EQ((Location{0, 0}).getManhattanDistanceY(loc), 4);
+}
+
+TEST(NAComputation, LocalRXOp) {
+  const Atom atom("atom");
+  const LocalRXOp op(atom, 0.0);
+  EXPECT_EQ(op.toString(), "@+ rx 0.00000 atom");
+}
+
+TEST(NAComputation, LocalRYOp) {
+  const Atom atom("atom");
+  const LocalRYOp op(atom, 0.0);
+  EXPECT_EQ(op.toString(), "@+ ry 0.00000 atom");
+}
+
+TEST(NAComputation, LocalRZOp) {
+  const Atom atom("atom");
+  const LocalRZOp op(atom, 0.0);
+  EXPECT_EQ(op.toString(), "@+ rz 0.00000 atom");
+}
+
+TEST(NAComputation, LocalXOp) {
+  const Atom atom("atom");
+  const LocalXOp op(atom);
+  EXPECT_EQ(op.toString(), "@+ x atom");
+}
+
+TEST(NAComputation, LocalYOp) {
+  const Atom atom("atom");
+  const LocalYOp op(atom);
+  EXPECT_EQ(op.toString(), "@+ y atom");
+}
+
+TEST(NAComputation, LocalZOp) {
+  const Atom atom("atom");
+  const LocalZOp op(atom);
+  EXPECT_EQ(op.toString(), "@+ z atom");
+}
+
+TEST(NAComputation, LocalHOp) {
+  const Atom atom("atom");
+  const LocalHOp op(atom);
+  EXPECT_EQ(op.toString(), "@+ h atom");
+}
+
+TEST(NAComputation, LocalCZOp) {
+  const Atom atom1("atom1");
+  const Atom atom2("atom2");
+  const LocalCZOp op(atom1, atom2);
+  EXPECT_EQ(op.toString(), "@+ cz {atom1, atom2}");
 }
 
 TEST(NAComputation, General) {


### PR DESCRIPTION
## Description

Even though neutral atom quantum computers usually only support `CZ`, `RZ`, `RX`, and `RY` gates where some of them must be global on a zone, we need more gates (Clifford Gates) for a project, where the `NAComputation` is used as an exchange format and not supposed to be executed on the hardware. Hence, this PR adds the missing operations to the infrastructure.

Additionally, this project will only handle local gates. Therefore, we add a function to the `NAComputation` that converts all global gates to respective local gates. To facilitate this, we need to know the extent of the zone to evaluate whether an atom is affected by a global gate or not. Additionally, for entangling gates, like `cz`, we also need to know the `radbergRadius` to evaluate which atoms interact with each other. All necessary changes are added to the corresponding classes.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
