### PR TITLE
♻️ Remove template parameter from MemoryManager and adjacent classes

### DIFF
--- a/include/mqt-core/dd/CachedEdge.hpp
+++ b/include/mqt-core/dd/CachedEdge.hpp
@@ -25,7 +25,7 @@ struct vNode; // NOLINT(readability-identifier-naming)
 struct mNode; // NOLINT(readability-identifier-naming)
 struct dNode; // NOLINT(readability-identifier-naming)
 class ComplexNumbers;
-template <typename T> class MemoryManager;
+class MemoryManager;
 
 template <typename T>
 using isVector = std::enable_if_t<std::is_same_v<T, vNode>, bool>;
@@ -125,7 +125,7 @@ template <typename Node> struct CachedEdge {
    */
   template <typename T = Node, isVector<T> = true>
   static CachedEdge normalize(Node* p, const std::array<CachedEdge, RADIX>& e,
-                              MemoryManager<Node>& mm, ComplexNumbers& cn);
+                              MemoryManager& mm, ComplexNumbers& cn);
 
   /**
    * @brief Get a normalized (density) matrix) DD from a fresh node and a list
@@ -140,7 +140,7 @@ template <typename Node> struct CachedEdge {
    */
   template <typename T = Node, isMatrixVariant<T> = true>
   static CachedEdge normalize(Node* p, const std::array<CachedEdge, NEDGE>& e,
-                              MemoryManager<Node>& mm, ComplexNumbers& cn);
+                              MemoryManager& mm, ComplexNumbers& cn);
 
   /**
    * @brief Check whether the matrix represented by the DD is the identity.

--- a/include/mqt-core/dd/Edge.hpp
+++ b/include/mqt-core/dd/Edge.hpp
@@ -26,7 +26,7 @@ struct vNode;
 struct mNode;
 struct dNode;
 class ComplexNumbers;
-template <typename T> class MemoryManager;
+class MemoryManager;
 
 template <typename T>
 using isVector = std::enable_if_t<std::is_same_v<T, vNode>, bool>;
@@ -153,7 +153,7 @@ public:
    */
   template <typename T = Node, isVector<T> = true>
   static Edge<Node> normalize(Node* p, const std::array<Edge<Node>, RADIX>& e,
-                              MemoryManager<Node>& mm, ComplexNumbers& cn);
+                              MemoryManager& mm, ComplexNumbers& cn);
 
   /**
    * @brief Get a single element of the vector represented by the DD
@@ -230,7 +230,7 @@ public:
    */
   template <typename T = Node, isMatrixVariant<T> = true>
   static Edge<Node> normalize(Node* p, const std::array<Edge<Node>, NEDGE>& e,
-                              MemoryManager<Node>& mm, ComplexNumbers& cn);
+                              MemoryManager& mm, ComplexNumbers& cn);
 
   /**
    * @brief Check whether the matrix represented by the DD is the identity

--- a/include/mqt-core/dd/LinkedListBase.hpp
+++ b/include/mqt-core/dd/LinkedListBase.hpp
@@ -7,38 +7,37 @@
  * Licensed under the MIT License
  */
 
+/** @file
+ * @brief Linked list functionality required for UniqueTable and MemoryManager.
+ */
+
 #pragma once
 
-#include "dd/DDDefinitions.hpp"
-
-#include <array>
-#include <cstddef>
 namespace dd {
 
 /**
- * @brief Members required UniqueTable and MemoryManager
+ * @brief A class to provide a base for linked list objects
  */
 struct LLBase {
   /**
-   * @brief The pointer tho the next object
-   * @details The next pointer is used to from linked lists. Classes that should
-   * be used in a linked list must solely inherit from this class. Other code in
-   * mqt-core relies on this assumption that all objects in a linked list are of
-   * the exact same type.
+   * @brief The pointer to the next object
+   * @details The next pointer is used to form linked lists of objects.
+   * Classes used in a linked list must solely inherit from this class.
+   * Other code in mqt-core relies on the assumption that all objects in a
+   * linked list are of the same type.
    */
-
-  LLBase* next_ = nullptr; // used to link nodes in unique table
+  LLBase* next_ = nullptr;
 
   /**
-   * @brief default method to get the next object
+   * @brief Default getter for the next object
    * @details Classes that inherit from LLBase should implement their own next()
    * method to return the next object in the list with a specialized return
    * type.
    * @return LLBase*
    */
-  LLBase* next() const noexcept { return next_; }
+  [[nodiscard]] LLBase* next() const noexcept { return next_; }
 
-  // set the pointer to the next object
+  /// Setter for the next object
   void setNext(LLBase* n) noexcept { next_ = n; }
 };
 

--- a/include/mqt-core/dd/LinkedListBase.hpp
+++ b/include/mqt-core/dd/LinkedListBase.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Chair for Design Automation, TUM
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#pragma once
+
+#include "dd/DDDefinitions.hpp"
+
+#include <array>
+#include <cstddef>
+namespace dd {
+
+/**
+ * @brief Members required UniqueTable and MemoryManager
+ */
+struct LLBase {
+  /**
+   * @brief The pointer tho the next object
+   * @details The next pointer is used to from linked lists. Classes that should
+   * be used in a linked list must solely inherit from this class. Other code in
+   * mqt-core relies on this assumption that all objects in a linked list are of
+   * the exact same type.
+   */
+
+  LLBase* next_ = nullptr; // used to link nodes in unique table
+
+  /**
+   * @brief default method to get the next object
+   * @details Classes that inherit from LLBase should implement their own next()
+   * method to return the next object in the list with a specialized return
+   * type.
+   * @return LLBase*
+   */
+  LLBase* next() const noexcept { return next_; }
+
+  // set the pointer to the next object
+  void setNext(LLBase* n) noexcept { next_ = n; }
+};
+
+} // namespace dd

--- a/include/mqt-core/dd/MemoryManager.hpp
+++ b/include/mqt-core/dd/MemoryManager.hpp
@@ -71,7 +71,7 @@ public:
   template <class T>
   static MemoryManager
   create(const std::size_t initialAllocationSize = INITIAL_ALLOCATION_SIZE) {
-    return MemoryManager(sizeof(T), initialAllocationSize);
+    return {sizeof(T), initialAllocationSize};
   }
 
   /// default destructor

--- a/include/mqt-core/dd/MemoryManager.hpp
+++ b/include/mqt-core/dd/MemoryManager.hpp
@@ -10,17 +10,23 @@
 #pragma once
 
 #include "dd/DDDefinitions.hpp"
+#include "dd/LinkedListBase.hpp"
 #include "dd/statistics/MemoryManagerStatistics.hpp"
 
+#include <cassert>
 #include <cstddef>
 #include <type_traits>
 #include <vector>
 
 namespace dd {
 
+// forward declarations
+struct LLBase;
+
 /**
- * @brief A memory manager for objects of type T.
- * @details The class manages a collection of objects of type T. The objects are
+ * @brief A memory manager for objects of the same type that inherit from
+ * `LLBase`.
+ * @details The class manages a collection of objects. The objects are
  * stored in contiguous chunks of memory. The manager supports reclaiming
  * objects that are no longer in use. This is done by maintaining a linked list
  * of available objects. When an object is no longer in use, it is added to the
@@ -33,15 +39,17 @@ namespace dd {
  * of objects at once and reusing them. This is especially useful for objects
  * that are frequently created and destroyed, such as decision diagram nodes,
  * edge weights, etc.
- * @tparam T The type of objects to manage.
  */
-template <typename T> class MemoryManager {
-  static_assert(std::is_same_v<decltype(T::next), T*>,
-                "T must have a `next` member of type T*");
-  static_assert(std::is_same_v<decltype(T::ref), RefCount>,
-                "T must have a `ref` member of type RefCount");
+class MemoryManager {
+  MemoryManager(unsigned entrySize, const std::size_t initialAllocationSize);
 
 public:
+  // delete copy/move construction and assignment
+  MemoryManager(const MemoryManager&) = delete;
+  MemoryManager& operator=(const MemoryManager&) = delete;
+  MemoryManager(MemoryManager&&) = delete;
+  MemoryManager& operator=(MemoryManager&&) = delete;
+
   /**
    * @brief The number of initially allocated entries.
    * @details The number of initially allocated entries is the number of entries
@@ -60,15 +68,13 @@ public:
   static constexpr double GROWTH_FACTOR = 2U;
 
   /**
-   * @brief Construct a new MemoryManager object
+   * @brief Construct a new MemoryManager object for objects of type T.
    * @param initialAllocationSize The initial number of entries to allocate
    */
-  explicit MemoryManager(
-      const std::size_t initialAllocationSize = INITIAL_ALLOCATION_SIZE)
-      : chunks(1, std::vector<T>(initialAllocationSize)),
-        chunkIt(chunks[0].begin()), chunkEndIt(chunks[0].end()) {
-    stats.numAllocations = 1U;
-    stats.numAllocated = initialAllocationSize;
+  template <class T>
+  static MemoryManager
+  Create(const std::size_t initialAllocationSize = INITIAL_ALLOCATION_SIZE) {
+    return MemoryManager(sizeof(T), initialAllocationSize);
   }
 
   /// default destructor
@@ -79,28 +85,40 @@ public:
    * @details If an entry is available for reuse, it is returned. Otherwise, an
    * entry from the pre-allocated chunks is returned. If no entry is available,
    * a new chunk is allocated.
+   * @tparam T The type of the entry.
    * @return A pointer to an entry.
    */
-  [[nodiscard]] T* get();
+  template <class T> [[nodiscard]] T* get() {
+    static_assert(std::is_base_of_v<LLBase, T>,
+                  "T must be derived from LLBase");
+    assert(sizeof(T) == entrySize && "Cannot get entry of different size");
+
+    return static_cast<T*>(get());
+  }
+
+  LLBase* get();
 
   /**
    * @brief Return an entry to the manager.
    * @details The entry is added to the list of available entries. The entry
-   * must not be used after it has been returned to the manager. Entries should
-   * have a reference count of 0 when they are returned to the manager. If not,
-   * this indicates a reference counting error.
+   * must not be used after it has been returned to the manager.
    * @param entry A pointer to an entry that is no longer in use.
    */
-  void returnEntry(T* entry) noexcept;
+  template <class T> void returnEntry(T* entry) noexcept {
+    static_assert(std::is_base_of_v<LLBase, T>,
+                  "T must be derived from LLBase");
+    returnEntry(static_cast<LLBase*>(entry));
+  }
+
+  void returnEntry(LLBase* entry) noexcept;
 
   /**
    * @brief Reset the manager.
-   * @details Drops all but the first chunk and resets the reference counts of
-   * all entries to 0. If `resizeToTotal` is set to true, the first chunk is
-   * resized to the total number of entries. This increases memory locality
-   * and reduces the number of allocations when the manager is used again.
-   * However, it might also require a huge contiguous block of memory to be
-   * allocated.
+   * @details Drops all but the first chunk. If `resizeToTotal` is set to true,
+   * the first chunk is resized to the total number of entries. This increases
+   * memory locality and reduces the number of allocations when the manager is
+   * used again. However, it might also require a huge contiguous block of
+   * memory to be allocated.
    * @param resizeToTotal If set to true, the first chunk is resized to the
    * total number of entries.
    */
@@ -114,24 +132,20 @@ private:
    * @brief Check whether an entry is available for reuse
    * @return true if an entry is available for reuse, false otherwise
    */
-  [[nodiscard]] bool entryAvailableForReuse() const noexcept {
-    return available != nullptr;
-  }
+  bool entryAvailableForReuse() const noexcept;
 
   /**
    * @brief Get an entry from the list of available entries
    * @return A pointer to an entry ready for reuse
    */
-  [[nodiscard]] T* getEntryFromAvailableList() noexcept;
+  LLBase* getEntryFromAvailableList() noexcept;
 
   /**
    * @brief Check whether an entry is available in the current chunk
    * @return true if an entry is available in the current chunk, false
    * otherwise
    */
-  [[nodiscard]] bool entryAvailableInChunk() const noexcept {
-    return chunkIt != chunkEndIt;
-  }
+  bool entryAvailableInChunk() const noexcept;
 
   /// Allocate a new chunk of memory
   void allocateNewChunk();
@@ -140,41 +154,43 @@ private:
    * @brief Get an entry from the current chunk
    * @return A pointer to an entry from the current chunk
    */
-  [[nodiscard]] T* getEntryFromChunk() noexcept;
+  [[nodiscard]] LLBase* getEntryFromChunk() noexcept;
 
+  const unsigned entrySize;
+  using chunk_t = std::vector<std::byte>;
   /**
    * @brief A linked list of entries that are available for (re-)use
    * @details The MemoryManager maintains a linked list of entries that are
    * available for (re-)use. This list is implemented as a singly linked list
-   * using the `next` member of the entries. The `available` member points to
+   * using the `next()` mothod of the entries. The `available` member points to
    * the first entry in the list. If the list is empty, `available` is
    * `nullptr`.
    */
-  T* available{};
+  LLBase* available;
 
   /**
    * @brief The storage for the entries
    * @details The MemoryManager maintains a vector of chunks. Each chunk is a
    * vector of entries. Entries in a chunk are allocated contiguously.
    */
-  std::vector<std::vector<T>> chunks;
+  std::vector<chunk_t> chunks;
 
   /**
    * @brief Iterator to the next available entry in the current chunk
    * @details This iterator points to the next available entry in the current
    * chunk. If the current chunk is full, it points to the end of the chunk.
    */
-  typename std::vector<T>::iterator chunkIt;
+  typename chunk_t::iterator chunkIt;
 
   /**
    * @brief Iterator to the end of the current chunk
    * @details This iterator points to the end of the current chunk. It is used
    * to determine whether the current chunk is full.
    */
-  typename std::vector<T>::iterator chunkEndIt;
+  typename chunk_t::iterator chunkEndIt;
 
   /// Memory manager statistics
-  MemoryManagerStatistics<T> stats{};
+  MemoryManagerStatistics stats;
 };
 
 } // namespace dd

--- a/include/mqt-core/dd/MemoryManager.hpp
+++ b/include/mqt-core/dd/MemoryManager.hpp
@@ -94,8 +94,6 @@ public:
     return static_cast<T*>(get());
   }
 
-  LLBase* get();
-
   /**
    * @brief Return an entry to the manager.
    * @details The entry is added to the list of available entries. The entry
@@ -126,6 +124,9 @@ public:
   [[nodiscard]] const auto& getStats() const noexcept { return stats; }
 
 private:
+  /// Get an entry from the manager
+  [[nodiscard]] LLBase* get();
+
   /**
    * @brief Check whether an entry is available for reuse
    * @return true if an entry is available for reuse, false otherwise

--- a/include/mqt-core/dd/MemoryManager.hpp
+++ b/include/mqt-core/dd/MemoryManager.hpp
@@ -44,11 +44,9 @@ class MemoryManager {
   MemoryManager(unsigned entrySize, const std::size_t initialAllocationSize);
 
 public:
-  // delete copy/move construction and assignment
+  // delete copy construction and assignment
   MemoryManager(const MemoryManager&) = delete;
   MemoryManager& operator=(const MemoryManager&) = delete;
-  MemoryManager(MemoryManager&&) = delete;
-  MemoryManager& operator=(MemoryManager&&) = delete;
 
   /**
    * @brief The number of initially allocated entries.

--- a/include/mqt-core/dd/MemoryManager.hpp
+++ b/include/mqt-core/dd/MemoryManager.hpp
@@ -159,7 +159,7 @@ private:
    * @brief A linked list of entries that are available for (re-)use
    * @details The MemoryManager maintains a linked list of entries that are
    * available for (re-)use. This list is implemented as a singly linked list
-   * using the `next()` mothod of the entries. The `available` member points to
+   * using the `next()` method of the entries. The `available` member points to
    * the first entry in the list. If the list is empty, `available` is
    * `nullptr`.
    */

--- a/include/mqt-core/dd/MemoryManager.hpp
+++ b/include/mqt-core/dd/MemoryManager.hpp
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "dd/DDDefinitions.hpp"
-#include "dd/LinkedListBase.hpp"
 #include "dd/statistics/MemoryManagerStatistics.hpp"
 
 #include <cassert>
@@ -99,15 +98,9 @@ public:
    * @brief Return an entry to the manager.
    * @details The entry is added to the list of available entries. The entry
    * must not be used after it has been returned to the manager.
-   * @param entry A pointer to an entry that is no longer in use.
+   * @param entry A reference to an entry that is no longer in use.
    */
-  template <class T> void returnEntry(T* entry) noexcept {
-    static_assert(std::is_base_of_v<LLBase, T>,
-                  "T must be derived from LLBase");
-    returnEntry(static_cast<LLBase*>(entry));
-  }
-
-  void returnEntry(LLBase* entry) noexcept;
+  void returnEntry(LLBase& entry) noexcept;
 
   /**
    * @brief Reset the manager.

--- a/include/mqt-core/dd/MemoryManager.hpp
+++ b/include/mqt-core/dd/MemoryManager.hpp
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include "dd/DDDefinitions.hpp"
 #include "dd/statistics/MemoryManagerStatistics.hpp"
 
 #include <cassert>

--- a/include/mqt-core/dd/Node.hpp
+++ b/include/mqt-core/dd/Node.hpp
@@ -22,31 +22,45 @@
 namespace dd {
 
 /**
- * @brief Base class for all DD nodes
- * @details This class is used to store common information for all DD nodes. The
- * `flags` field is an exception, but it allows to reuse functionality for
- * different node types. Data Layout |8|4|2|1| = 15B (space for one more byte)
+ * @brief Base class for all DD nodes.
+ * @details This class is used to store common information for all DD nodes.
+ * The `flags` makes the implicit padding explicit and can be used for storing
+ * node properties.
+ * Data Layout (8)|(4|2|2) = 16B.
  */
-struct NodeBase : public LLBase {
-  RefCount ref = 0; // reference count
-  Qubit v{};        // variable index
+struct NodeBase : LLBase {
+  /// Reference count
+  RefCount ref = 0;
+  /// Variable index
+  Qubit v{};
 
-  std::uint8_t flags =
-      0; // not required for all node types, but padding is required either way
-  // 32 = unused (was used to mark a node which is symmetric)
-  // 16 = unused (was used to mark a node resembling the identity)
-  // 8 = marks a reduced dm node,
-  // 4 = marks a dm (tmp flag),
-  // 2 = mark first path edge (tmp flag),
-  // 1 = mark path is conjugated (tmp flag)
+  /**
+   * @brief Flags for node properties
+   * @details Not required for all node types, but padding is required either
+   * way.
+   *
+   * 0b1000 = marks a reduced dm node,
+   *  0b100 = marks a dm (tmp flag),
+   *   0b10 = mark first path edge (tmp flag),
+   *    0b1 = mark path is conjugated (tmp flag)
+   */
+  std::uint16_t flags = 0;
 
-  NodeBase* next() const noexcept {
-    return static_cast<NodeBase*>(LLBase::next());
+  /// Getter for the next object.
+  [[nodiscard]] NodeBase* next() const noexcept {
+    return static_cast<NodeBase*>(next_);
   }
 
-  static bool isTerminal(const NodeBase* p) noexcept {
-    // some nodes (dNode) use bottom bits to store flags. As all nodes are >= 8
-    // byte aligned, so these bits can be ignored in all cases
+  /**
+   * @brief Check if a node is terminal
+   * @details Generally, a node is terminal if it is nullptr.
+   * Some nodes (dNode) encode additional information in the least significant
+   * bits of the pointer. These bits are masked out before checking for
+   * terminal nodes.
+   * @param p The node to check
+   * @return true if the node is terminal, false otherwise.
+   */
+  [[nodiscard]] static bool isTerminal(const NodeBase* p) noexcept {
     return (reinterpret_cast<std::uintptr_t>(p) & (~7ULL)) == 0ULL;
   }
   static constexpr NodeBase* getTerminal() noexcept { return nullptr; }
@@ -54,13 +68,16 @@ struct NodeBase : public LLBase {
 
 /**
  * @brief A vector DD node
- * @details Data Layout 8|4|2|1|1 (padding)|24|24 = 64B
+ * @details Data Layout (8)|(4|2|2)|(24|24) = 64B
  */
-struct vNode : public NodeBase {      // NOLINT(readability-identifier-naming)
+struct vNode final : NodeBase {       // NOLINT(readability-identifier-naming)
   std::array<Edge<vNode>, RADIX> e{}; // edges out of this node
 
-  vNode* next() const noexcept { return static_cast<vNode*>(NodeBase::next()); }
-
+  /// Getter for the next object
+  [[nodiscard]] vNode* next() const noexcept {
+    return static_cast<vNode*>(next_);
+  }
+  /// Getter for the terminal object
   static constexpr vNode* getTerminal() noexcept { return nullptr; }
 };
 using vEdge = Edge<vNode>;
@@ -68,13 +85,16 @@ using vCachedEdge = CachedEdge<vNode>;
 
 /**
  * @brief A matrix DD node
- * @details Data Layout 8|4|2|1|1 (padding)|24|24|24|24|= 112B
+ * @details Data Layout (8)|(4|2|2)|(24|24|24|24) = 112B
  */
-struct mNode : public NodeBase {      // NOLINT(readability-identifier-naming)
+struct mNode final : NodeBase {       // NOLINT(readability-identifier-naming)
   std::array<Edge<mNode>, NEDGE> e{}; // edges out of this node
 
-  mNode* next() const noexcept { return static_cast<mNode*>(NodeBase::next()); }
-
+  /// Getter for the next object
+  [[nodiscard]] mNode* next() const noexcept {
+    return static_cast<mNode*>(next_);
+  }
+  /// Getter for the terminal object
   static constexpr mNode* getTerminal() noexcept { return nullptr; }
 };
 using mEdge = Edge<mNode>;
@@ -82,13 +102,16 @@ using mCachedEdge = CachedEdge<mNode>;
 
 /**
  * @brief A density matrix DD node
- * @details Data Layout 8|4|2|1|1 (padding)|24|24|24|24|8|4|2|1| = 112B
+ * @details Data Layout (8)|(4|2|2)|(24|24|24|24) = 112B
  */
-struct dNode : public NodeBase {      // NOLINT(readability-identifier-naming)
+struct dNode final : NodeBase {       // NOLINT(readability-identifier-naming)
   std::array<Edge<dNode>, NEDGE> e{}; // edges out of this node
 
-  dNode* next() const noexcept { return static_cast<dNode*>(NodeBase::next()); }
-
+  /// Getter for the next object
+  [[nodiscard]] dNode* next() const noexcept {
+    return static_cast<dNode*>(next_);
+  }
+  /// Getter for the terminal object
   static constexpr dNode* getTerminal() noexcept { return nullptr; }
 
   [[nodiscard]] [[maybe_unused]] static constexpr bool
@@ -184,7 +207,7 @@ static inline dEdge densityFromMatrixEdge(const mEdge& e) {
  * @note Typically, you do not want to call this function directly. Instead,
  * use the UniqueTable::incRef(Node*) function.
  */
-[[nodiscard]] static inline bool incRef(NodeBase* p) noexcept {
+[[nodiscard]] static constexpr bool incRef(NodeBase* p) noexcept {
   if (p == nullptr || p->ref == std::numeric_limits<RefCount>::max()) {
     return false;
   }
@@ -202,7 +225,7 @@ static inline dEdge densityFromMatrixEdge(const mEdge& e) {
  * @note Typically, you do not want to call this function directly. Instead,
  * use the UniqueTable::decRef(Node*) function.
  */
-[[nodiscard]] static inline bool decRef(NodeBase* p) noexcept {
+[[nodiscard]] static constexpr bool decRef(NodeBase* p) noexcept {
   if (p == nullptr || p->ref == std::numeric_limits<RefCount>::max()) {
     return false;
   }

--- a/include/mqt-core/dd/Node.hpp
+++ b/include/mqt-core/dd/Node.hpp
@@ -48,6 +48,7 @@ struct NodeBase : LLBase {
 
   /// Getter for the next object.
   [[nodiscard]] NodeBase* next() const noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     return static_cast<NodeBase*>(next_);
   }
 
@@ -75,6 +76,7 @@ struct vNode final : NodeBase {       // NOLINT(readability-identifier-naming)
 
   /// Getter for the next object
   [[nodiscard]] vNode* next() const noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     return static_cast<vNode*>(next_);
   }
   /// Getter for the terminal object
@@ -92,6 +94,7 @@ struct mNode final : NodeBase {       // NOLINT(readability-identifier-naming)
 
   /// Getter for the next object
   [[nodiscard]] mNode* next() const noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     return static_cast<mNode*>(next_);
   }
   /// Getter for the terminal object
@@ -109,6 +112,7 @@ struct dNode final : NodeBase {       // NOLINT(readability-identifier-naming)
 
   /// Getter for the next object
   [[nodiscard]] dNode* next() const noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     return static_cast<dNode*>(next_);
   }
   /// Getter for the terminal object

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -141,17 +141,20 @@ private:
 
 public:
   /// The memory manager for vector nodes
-  MemoryManager<vNode> vMemoryManager{Config::UT_VEC_INITIAL_ALLOCATION_SIZE};
+  MemoryManager vMemoryManager{
+      MemoryManager::Create<vNode>(Config::UT_VEC_INITIAL_ALLOCATION_SIZE)};
   /// The memory manager for matrix nodes
-  MemoryManager<mNode> mMemoryManager{Config::UT_MAT_INITIAL_ALLOCATION_SIZE};
+  MemoryManager mMemoryManager{
+      MemoryManager::Create<mNode>(Config::UT_MAT_INITIAL_ALLOCATION_SIZE)};
   /// The memory manager for density matrix nodes
-  MemoryManager<dNode> dMemoryManager{Config::UT_DM_INITIAL_ALLOCATION_SIZE};
+  MemoryManager dMemoryManager{
+      MemoryManager::Create<dNode>(Config::UT_DM_INITIAL_ALLOCATION_SIZE)};
   /**
    * @brief The memory manager for complex numbers
    * @note The real and imaginary part of complex numbers are treated
    * separately. Hence, it suffices for the manager to only manage real numbers.
    */
-  MemoryManager<RealNumber> cMemoryManager;
+  MemoryManager cMemoryManager{MemoryManager::Create<RealNumber>()};
 
   /**
    * @brief Get the memory manager for a given type
@@ -184,11 +187,11 @@ public:
   }
 
   /// The unique table used for vector nodes
-  UniqueTable<vNode, Config::UT_VEC_NBUCKET> vUniqueTable{0U, vMemoryManager};
+  UniqueTable vUniqueTable{vMemoryManager, {0U, Config::UT_VEC_NBUCKET}};
   /// The unique table used for matrix nodes
-  UniqueTable<mNode, Config::UT_MAT_NBUCKET> mUniqueTable{0U, mMemoryManager};
+  UniqueTable mUniqueTable{mMemoryManager, {0U, Config::UT_MAT_NBUCKET}};
   /// The unique table used for density matrix nodes
-  UniqueTable<dNode, Config::UT_DM_NBUCKET> dUniqueTable{0U, dMemoryManager};
+  UniqueTable dUniqueTable{dMemoryManager, {0U, Config::UT_DM_NBUCKET}};
   /**
    * @brief The unique table used for complex numbers
    * @note The table actually only stores real numbers in the interval [0, 1],
@@ -988,7 +991,7 @@ public:
                               std::tuple_size_v<decltype(Node::e)>>& edges,
              [[maybe_unused]] const bool generateDensityMatrix = false) {
     auto& memoryManager = getMemoryManager<Node>();
-    auto p = memoryManager.get();
+    auto p = memoryManager.template get<Node>();
     assert(p->ref == 0U);
 
     p->v = var;

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -142,19 +142,19 @@ private:
 public:
   /// The memory manager for vector nodes
   MemoryManager vMemoryManager{
-      MemoryManager::Create<vNode>(Config::UT_VEC_INITIAL_ALLOCATION_SIZE)};
+      MemoryManager::create<vNode>(Config::UT_VEC_INITIAL_ALLOCATION_SIZE)};
   /// The memory manager for matrix nodes
   MemoryManager mMemoryManager{
-      MemoryManager::Create<mNode>(Config::UT_MAT_INITIAL_ALLOCATION_SIZE)};
+      MemoryManager::create<mNode>(Config::UT_MAT_INITIAL_ALLOCATION_SIZE)};
   /// The memory manager for density matrix nodes
   MemoryManager dMemoryManager{
-      MemoryManager::Create<dNode>(Config::UT_DM_INITIAL_ALLOCATION_SIZE)};
+      MemoryManager::create<dNode>(Config::UT_DM_INITIAL_ALLOCATION_SIZE)};
   /**
    * @brief The memory manager for complex numbers
    * @note The real and imaginary part of complex numbers are treated
    * separately. Hence, it suffices for the manager to only manage real numbers.
    */
-  MemoryManager cMemoryManager{MemoryManager::Create<RealNumber>()};
+  MemoryManager cMemoryManager{MemoryManager::create<RealNumber>()};
 
   /**
    * @brief Get the memory manager for a given type

--- a/include/mqt-core/dd/Package.hpp
+++ b/include/mqt-core/dd/Package.hpp
@@ -1011,7 +1011,7 @@ public:
             (es[0].w.exactlyOne() && es[1].w.exactlyZero() &&
              es[2].w.exactlyZero() && es[3].w.exactlyOne())) {
           auto* ptr = es[0].p;
-          memoryManager.returnEntry(e.p);
+          memoryManager.returnEntry(*e.p);
           return EdgeType<Node>{ptr, e.w};
         }
       }

--- a/include/mqt-core/dd/RealNumber.hpp
+++ b/include/mqt-core/dd/RealNumber.hpp
@@ -26,9 +26,10 @@ namespace dd {
  * be taken when accessing the value. The static functions in this struct
  * provide safe access to the value of a RealNumber* pointer.
  */
-struct RealNumber : public LLBase {
+struct RealNumber final : LLBase {
 
-  RealNumber* next() const noexcept {
+  /// Getter for the next object.
+  [[nodiscard]] RealNumber* next() const noexcept {
     return reinterpret_cast<RealNumber*>(next_);
   }
 

--- a/include/mqt-core/dd/RealNumber.hpp
+++ b/include/mqt-core/dd/RealNumber.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "dd/DDDefinitions.hpp"
+#include "dd/LinkedListBase.hpp"
 #include "mqt_core_dd_export.h"
 
 #include <istream>
@@ -25,7 +26,11 @@ namespace dd {
  * be taken when accessing the value. The static functions in this struct
  * provide safe access to the value of a RealNumber* pointer.
  */
-struct RealNumber {
+struct RealNumber : public LLBase {
+
+  RealNumber* next() const noexcept {
+    return reinterpret_cast<RealNumber*>(next_);
+  }
 
   /**
    * @brief Check whether the number points to the zero number.
@@ -216,14 +221,7 @@ struct RealNumber {
    * accessed using the static functions of this struct.
    */
   fp value{};
-  /**
-   * @brief The next pointer of the number.
-   * @details The next pointer is used to from linked lists.The next pointer
-   * is part of this class for efficiency reasons. It could be stored
-   * separately, but that would require many small allocations. This way, the
-   * entries can be allocated in chunks, which is much more efficient.
-   */
-  RealNumber* next{};
+
   /**
    * @brief The reference count of the number.
    * @details The reference count is used to determine whether a number is

--- a/include/mqt-core/dd/RealNumberUniqueTable.hpp
+++ b/include/mqt-core/dd/RealNumberUniqueTable.hpp
@@ -57,7 +57,7 @@ public:
    * @param manager The memory manager to use for allocating new numbers.
    * @param initialGCLim The initial garbage collection limit.
    */
-  explicit RealNumberUniqueTable(MemoryManager<RealNumber>& manager,
+  explicit RealNumberUniqueTable(MemoryManager& manager,
                                  std::size_t initialGCLim = INITIAL_GC_LIMIT);
 
   /**
@@ -176,7 +176,7 @@ private:
   std::array<RealNumber*, NBUCKET> tailTable{};
 
   /// A pointer to the memory manager for the numbers stored in the table.
-  MemoryManager<RealNumber>* memoryManager{};
+  MemoryManager* memoryManager{};
 
   /// A collection of statistics
   UniqueTableStatistics stats{};

--- a/include/mqt-core/dd/UniqueTable.hpp
+++ b/include/mqt-core/dd/UniqueTable.hpp
@@ -21,7 +21,6 @@
 #include <functional>
 #include <iostream>
 #include <nlohmann/json.hpp>
-#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -46,10 +45,10 @@ public:
     std::size_t nVars = 0U;
 
     /// The number of hash buckets to use (has to be a power of two)
-    const std::size_t nBuckets = 32768;
+    std::size_t nBuckets = 32768;
 
     /// The initial garbage collection limit
-    const std::size_t initialGCLimit = INITIAL_GC_LIMIT;
+    std::size_t initialGCLimit = INITIAL_GC_LIMIT;
   };
 
   /**
@@ -74,12 +73,12 @@ public:
   template <class Node> [[nodiscard]] std::size_t hash(const Node& p) {
     static_assert(std::is_base_of_v<NodeBase, Node>,
                   "Node must be derived from NodeBase");
-    const std::size_t MASK = cfg.nBuckets - 1;
+    const std::size_t mask = cfg.nBuckets - 1;
     std::size_t key = 0U;
     for (const auto& succ : p.e) {
       qc::hashCombine(key, std::hash<Edge<Node>>{}(succ));
     }
-    key &= MASK;
+    key &= mask;
     return key;
   }
 

--- a/include/mqt-core/dd/statistics/MemoryManagerStatistics.hpp
+++ b/include/mqt-core/dd/statistics/MemoryManagerStatistics.hpp
@@ -26,10 +26,10 @@ struct MemoryManagerStatistics final : Statistics {
    * @param entrySize The size of a single entry
    */
   explicit MemoryManagerStatistics(const std::size_t entrySize)
-      : entrySize(entrySize) {}
+      : entrySize_(entrySize) {}
 
   /// The size of a single entry
-  std::size_t entrySize;
+  std::size_t entrySize_;
 
   [[nodiscard]] double entryMemoryMIB() const;
 

--- a/include/mqt-core/dd/statistics/MemoryManagerStatistics.hpp
+++ b/include/mqt-core/dd/statistics/MemoryManagerStatistics.hpp
@@ -18,11 +18,21 @@ namespace dd {
 
 /**
  * @brief A utility class for storing statistics of a memory manager
- * @tparam T the type of entries managed by the memory manager
  */
-template <typename T> struct MemoryManagerStatistics : public Statistics {
+struct MemoryManagerStatistics : public Statistics {
+
+  /**
+   * @brief Construct a new Memory Manager Statistics object
+   * @param entrySize The size of a single entry
+   */
+  explicit MemoryManagerStatistics(std::size_t entrySize)
+      : entrySize(entrySize) {}
+
   /// The size of a single entry
-  std::size_t entrySize = sizeof(T);
+  const std::size_t entrySize;
+
+  double entryMemoryMIB() const;
+
   /// The number of allocations performed
   std::size_t numAllocations = 0U;
   /// The number of allocated entries
@@ -35,9 +45,6 @@ template <typename T> struct MemoryManagerStatistics : public Statistics {
   std::size_t peakNumUsed = 0U;
   /// The peak number of entries available for reuse
   std::size_t peakNumAvailableForReuse = 0U;
-
-  static constexpr auto ENTRY_MEMORY_MIB =
-      static_cast<double>(sizeof(T)) / static_cast<double>(1ULL << 20U);
 
   /// Get the number of available entries from memory chunks
   [[nodiscard]] std::size_t getNumAvailableFromChunks() const noexcept;

--- a/include/mqt-core/dd/statistics/MemoryManagerStatistics.hpp
+++ b/include/mqt-core/dd/statistics/MemoryManagerStatistics.hpp
@@ -19,19 +19,19 @@ namespace dd {
 /**
  * @brief A utility class for storing statistics of a memory manager
  */
-struct MemoryManagerStatistics : public Statistics {
+struct MemoryManagerStatistics final : Statistics {
 
   /**
    * @brief Construct a new Memory Manager Statistics object
    * @param entrySize The size of a single entry
    */
-  explicit MemoryManagerStatistics(std::size_t entrySize)
+  explicit MemoryManagerStatistics(const std::size_t entrySize)
       : entrySize(entrySize) {}
 
   /// The size of a single entry
-  const std::size_t entrySize;
+  std::size_t entrySize;
 
-  double entryMemoryMIB() const;
+  [[nodiscard]] double entryMemoryMIB() const;
 
   /// The number of allocations performed
   std::size_t numAllocations = 0U;

--- a/src/dd/CachedEdge.cpp
+++ b/src/dd/CachedEdge.cpp
@@ -36,7 +36,7 @@ template <typename T, isVector<T>>
 CachedEdge<Node>
 CachedEdge<Node>::normalize(Node* p,
                             const std::array<CachedEdge<Node>, RADIX>& e,
-                            MemoryManager<Node>& mm, ComplexNumbers& cn) {
+                            MemoryManager& mm, ComplexNumbers& cn) {
   assert(p != nullptr && "Node pointer passed to normalize is null.");
   const auto zero =
       std::array{e[0].w.approximatelyZero(), e[1].w.approximatelyZero()};
@@ -96,7 +96,7 @@ template <typename T, isMatrixVariant<T>>
 CachedEdge<Node>
 CachedEdge<Node>::normalize(Node* p,
                             const std::array<CachedEdge<Node>, NEDGE>& e,
-                            MemoryManager<Node>& mm, ComplexNumbers& cn) {
+                            MemoryManager& mm, ComplexNumbers& cn) {
   assert(p != nullptr && "Node pointer passed to normalize is null.");
   const auto zero =
       std::array{e[0].w.approximatelyZero(), e[1].w.approximatelyZero(),
@@ -161,17 +161,17 @@ template struct CachedEdge<dNode>;
 template CachedEdge<vNode>
 CachedEdge<vNode>::normalize(vNode* p,
                              const std::array<CachedEdge<vNode>, RADIX>& e,
-                             MemoryManager<vNode>& mm, ComplexNumbers& cn);
+                             MemoryManager& mm, ComplexNumbers& cn);
 
 template CachedEdge<mNode>
 CachedEdge<mNode>::normalize(mNode* p,
                              const std::array<CachedEdge<mNode>, NEDGE>& e,
-                             MemoryManager<mNode>& mm, ComplexNumbers& cn);
+                             MemoryManager& mm, ComplexNumbers& cn);
 
 template CachedEdge<dNode>
 CachedEdge<dNode>::normalize(dNode* p,
                              const std::array<CachedEdge<dNode>, NEDGE>& e,
-                             MemoryManager<dNode>& mm, ComplexNumbers& cn);
+                             MemoryManager& mm, ComplexNumbers& cn);
 
 } // namespace dd
 

--- a/src/dd/CachedEdge.cpp
+++ b/src/dd/CachedEdge.cpp
@@ -43,7 +43,7 @@ CachedEdge<Node>::normalize(Node* p,
 
   if (zero[0]) {
     if (zero[1]) {
-      mm.returnEntry(p);
+      mm.returnEntry(*p);
       return CachedEdge::zero();
     }
     p->e = {vEdge::zero(), {e[1].p, Complex::one()}};
@@ -103,7 +103,7 @@ CachedEdge<Node>::normalize(Node* p,
                  e[2].w.approximatelyZero(), e[3].w.approximatelyZero()};
 
   if (std::all_of(zero.begin(), zero.end(), [](auto b) { return b; })) {
-    mm.returnEntry(p);
+    mm.returnEntry(*p);
     return CachedEdge::zero();
   }
 

--- a/src/dd/Edge.cpp
+++ b/src/dd/Edge.cpp
@@ -110,7 +110,7 @@ template <class Node>
 template <typename T, isVector<T>>
 Edge<Node> Edge<Node>::normalize(Node* p,
                                  const std::array<Edge<Node>, RADIX>& e,
-                                 MemoryManager<Node>& mm, ComplexNumbers& cn) {
+                                 MemoryManager& mm, ComplexNumbers& cn) {
   assert(p != nullptr && "Node pointer passed to normalize is null.");
   const auto zero = std::array{e[0].w.exactlyZero(), e[1].w.exactlyZero()};
 
@@ -294,7 +294,7 @@ template <class Node>
 template <typename T, isMatrixVariant<T>>
 Edge<Node> Edge<Node>::normalize(Node* p,
                                  const std::array<Edge<Node>, NEDGE>& e,
-                                 MemoryManager<Node>& mm, ComplexNumbers& cn) {
+                                 MemoryManager& mm, ComplexNumbers& cn) {
   assert(p != nullptr && "Node pointer passed to normalize is null.");
   const auto zero = std::array{e[0].w.exactlyZero(), e[1].w.exactlyZero(),
                                e[2].w.exactlyZero(), e[3].w.exactlyZero()};
@@ -594,9 +594,10 @@ template struct Edge<vNode>;
 template struct Edge<mNode>;
 template struct Edge<dNode>;
 
-template Edge<vNode> Edge<vNode>::normalize<vNode, true>(
-    vNode* p, const std::array<Edge<vNode>, RADIX>& e, MemoryManager<vNode>& mm,
-    ComplexNumbers& cn);
+template Edge<vNode>
+Edge<vNode>::normalize<vNode, true>(vNode* p,
+                                    const std::array<Edge<vNode>, RADIX>& e,
+                                    MemoryManager& mm, ComplexNumbers& cn);
 template std::complex<fp>
 Edge<vNode>::getValueByIndex<vNode, true>(const std::size_t i) const;
 template CVec Edge<vNode>::getVector<vNode, true>(const fp threshold) const;
@@ -609,9 +610,10 @@ Edge<vNode>::traverseVector<vNode, true>(const std::complex<fp>& amp,
                                          const std::size_t i, AmplitudeFunc f,
                                          const fp threshold) const;
 
-template Edge<mNode> Edge<mNode>::normalize<mNode, true>(
-    mNode* p, const std::array<Edge<mNode>, NEDGE>& e, MemoryManager<mNode>& mm,
-    ComplexNumbers& cn);
+template Edge<mNode>
+Edge<mNode>::normalize<mNode, true>(mNode* p,
+                                    const std::array<Edge<mNode>, NEDGE>& e,
+                                    MemoryManager& mm, ComplexNumbers& cn);
 template std::complex<fp>
 Edge<mNode>::getValueByIndex<mNode, true>(const std::size_t numQubits,
                                           const std::size_t i,
@@ -627,9 +629,10 @@ template void Edge<mNode>::traverseMatrix<mNode, true>(
     const std::complex<fp>& amp, const std::size_t i, const std::size_t j,
     MatrixEntryFunc f, const std::size_t level, const fp threshold) const;
 
-template Edge<dNode> Edge<dNode>::normalize<dNode, true>(
-    dNode* p, const std::array<Edge<dNode>, NEDGE>& e, MemoryManager<dNode>& mm,
-    ComplexNumbers& cn);
+template Edge<dNode>
+Edge<dNode>::normalize<dNode, true>(dNode* p,
+                                    const std::array<Edge<dNode>, NEDGE>& e,
+                                    MemoryManager& mm, ComplexNumbers& cn);
 template CMat Edge<dNode>::getMatrix<dNode, true>(const std::size_t numQubits,
                                                   const fp threshold) const;
 template SparseCMat

--- a/src/dd/Edge.cpp
+++ b/src/dd/Edge.cpp
@@ -116,7 +116,7 @@ Edge<Node> Edge<Node>::normalize(Node* p,
 
   if (zero[0]) {
     if (zero[1]) {
-      mm.returnEntry(p);
+      mm.returnEntry(*p);
       return Edge::zero();
     }
     p->e = e;
@@ -300,7 +300,7 @@ Edge<Node> Edge<Node>::normalize(Node* p,
                                e[2].w.exactlyZero(), e[3].w.exactlyZero()};
 
   if (std::all_of(zero.begin(), zero.end(), [](auto b) { return b; })) {
-    mm.returnEntry(p);
+    mm.returnEntry(*p);
     return Edge::zero();
   }
 

--- a/src/dd/MemoryManager.cpp
+++ b/src/dd/MemoryManager.cpp
@@ -9,6 +9,8 @@
 
 #include "dd/MemoryManager.hpp"
 
+#include "dd/LinkedListBase.hpp"
+
 #include <cassert>
 #include <cstddef>
 
@@ -36,11 +38,9 @@ LLBase* MemoryManager::get() {
   return getEntryFromChunk();
 }
 
-void MemoryManager::returnEntry(LLBase* entry) noexcept {
-  assert(entry != nullptr);
-
-  entry->setNext(available);
-  available = entry;
+void MemoryManager::returnEntry(LLBase& entry) noexcept {
+  entry.setNext(available);
+  available = &entry;
   stats.trackReturnedEntry();
 }
 

--- a/src/dd/MemoryManager.cpp
+++ b/src/dd/MemoryManager.cpp
@@ -9,15 +9,22 @@
 
 #include "dd/MemoryManager.hpp"
 
-#include "dd/Node.hpp"
-#include "dd/RealNumber.hpp"
-
 #include <cassert>
 #include <cstddef>
 
 namespace dd {
 
-template <typename T> T* MemoryManager<T>::get() {
+MemoryManager::MemoryManager(unsigned entrySize,
+                             const std::size_t initialAllocationSize)
+    : entrySize(entrySize), available(nullptr),
+      chunks(1, chunk_t(initialAllocationSize * entrySize)),
+      chunkIt(chunks[0].begin()), chunkEndIt(chunks[0].end()),
+      stats(entrySize) {
+  stats.numAllocations = 1U;
+  stats.numAllocated = initialAllocationSize;
+}
+
+LLBase* MemoryManager::get() {
   if (entryAvailableForReuse()) {
     return getEntryFromAvailableList();
   }
@@ -29,22 +36,21 @@ template <typename T> T* MemoryManager<T>::get() {
   return getEntryFromChunk();
 }
 
-template <typename T> void MemoryManager<T>::returnEntry(T* entry) noexcept {
+void MemoryManager::returnEntry(LLBase* entry) noexcept {
   assert(entry != nullptr);
-  assert(entry->ref == 0);
-  entry->next = available;
+
+  entry->setNext(available);
   available = entry;
   stats.trackReturnedEntry();
 }
 
-template <typename T>
-void MemoryManager<T>::reset(const bool resizeToTotal) noexcept {
+void MemoryManager::reset(const bool resizeToTotal) noexcept {
   available = nullptr;
 
   auto numAllocations = stats.numAllocations;
   chunks.resize(1U);
   if (resizeToTotal) {
-    chunks[0].resize(stats.numAllocated);
+    chunks[0].resize(stats.numAllocated * entrySize);
     ++numAllocations;
   }
 
@@ -53,41 +59,48 @@ void MemoryManager<T>::reset(const bool resizeToTotal) noexcept {
 
   stats.reset();
   stats.numAllocations = numAllocations;
-  stats.numAllocated = chunks[0].size();
+  stats.numAllocated = chunks[0].size() / entrySize;
 }
 
-template <typename T>
-T* MemoryManager<T>::getEntryFromAvailableList() noexcept {
+bool MemoryManager::entryAvailableForReuse() const noexcept {
+  return available != nullptr;
+}
+
+LLBase* MemoryManager::getEntryFromAvailableList() noexcept {
   assert(entryAvailableForReuse());
+
   auto* entry = available;
-  available = available->next;
+  available = available->next();
   stats.trackReusedEntries();
   return entry;
 }
 
-template <typename T> void MemoryManager<T>::allocateNewChunk() {
+void MemoryManager::allocateNewChunk() {
   assert(!entryAvailableInChunk());
-  const auto newChunkSize = static_cast<std::size_t>(
-      GROWTH_FACTOR * static_cast<double>(chunks.back().size()));
-  chunks.emplace_back(newChunkSize);
+
+  const auto numPrevEntries = chunks.back().size() / entrySize;
+  const auto numNewEntries = static_cast<std::size_t>(
+      static_cast<double>(numPrevEntries) * GROWTH_FACTOR);
+
+  chunks.emplace_back(numNewEntries * entrySize);
   chunkIt = chunks.back().begin();
   chunkEndIt = chunks.back().end();
   ++stats.numAllocations;
-  stats.numAllocated += newChunkSize;
+  stats.numAllocated += numNewEntries;
 }
 
-template <typename T> T* MemoryManager<T>::getEntryFromChunk() noexcept {
+LLBase* MemoryManager::getEntryFromChunk() noexcept {
   assert(!entryAvailableForReuse());
   assert(entryAvailableInChunk());
+
   auto* entry = &(*chunkIt);
-  ++chunkIt;
+  chunkIt += entrySize;
   stats.trackUsedEntries();
-  return entry;
+  return reinterpret_cast<LLBase*>(entry);
 }
 
-template class MemoryManager<RealNumber>;
-template class MemoryManager<vNode>;
-template class MemoryManager<mNode>;
-template class MemoryManager<dNode>;
+[[nodiscard]] bool MemoryManager::entryAvailableInChunk() const noexcept {
+  return chunkIt != chunkEndIt;
+}
 
 } // namespace dd

--- a/src/dd/RealNumber.cpp
+++ b/src/dd/RealNumber.cpp
@@ -119,9 +119,9 @@ void RealNumber::readBinary(dd::fp& num, std::istream& is) {
 
 namespace constants {
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
-RealNumber zero{0., nullptr, 1U};
-RealNumber one{1., nullptr, 1U};
-RealNumber sqrt2over2{SQRT2_2, nullptr, 1U};
+RealNumber zero{{nullptr}, 0., 1U};
+RealNumber one{{nullptr}, 1., 1U};
+RealNumber sqrt2over2{{nullptr}, SQRT2_2, 1U};
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 } // namespace constants
 } // namespace dd

--- a/src/dd/RealNumberUniqueTable.cpp
+++ b/src/dd/RealNumberUniqueTable.cpp
@@ -165,7 +165,7 @@ std::size_t RealNumberUniqueTable::garbageCollect(const bool force) noexcept {
         } else {
           lastp->setNext(next);
         }
-        memoryManager->returnEntry(p);
+        memoryManager->returnEntry(*p);
         p = next;
         --stats.numEntries;
       } else {

--- a/src/dd/UniqueTable.cpp
+++ b/src/dd/UniqueTable.cpp
@@ -73,7 +73,7 @@ std::size_t UniqueTable::garbageCollect(bool force) {
           } else {
             lastp->setNext(next);
           }
-          memoryManager->returnEntry(p);
+          memoryManager->returnEntry(*p);
           p = next;
           --stat.numEntries;
         } else {

--- a/src/dd/UniqueTable.cpp
+++ b/src/dd/UniqueTable.cpp
@@ -9,6 +9,15 @@
 
 #include "dd/UniqueTable.hpp"
 
+#include "dd/MemoryManager.hpp"
+#include "dd/Node.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <nlohmann/json.hpp>
+#include <numeric>
+#include <string>
+
 namespace dd {
 
 UniqueTable::UniqueTable(MemoryManager& manager,

--- a/src/dd/UniqueTable.cpp
+++ b/src/dd/UniqueTable.cpp
@@ -11,7 +11,8 @@
 
 namespace dd {
 
-UniqueTable::UniqueTable(MemoryManager& manager, UniqueTableConfig config)
+UniqueTable::UniqueTable(MemoryManager& manager,
+                         const UniqueTableConfig& config)
     : cfg(config), gcLimit(config.initialGCLimit), memoryManager(&manager),
       tables(config.nVars), stats(config.nVars) {
   for (auto& stat : stats) {
@@ -20,7 +21,7 @@ UniqueTable::UniqueTable(MemoryManager& manager, UniqueTableConfig config)
   }
 }
 
-void UniqueTable::resize(std::size_t nVars) {
+void UniqueTable::resize(const std::size_t nVars) {
   cfg.nVars = nVars;
   tables.resize(nVars, Table(cfg.nBuckets));
   // TODO: if the new size is smaller than the old one we might have to
@@ -52,7 +53,7 @@ bool UniqueTable::possiblyNeedsCollection() const {
   return getNumEntries() >= gcLimit;
 }
 
-std::size_t UniqueTable::garbageCollect(bool force) {
+std::size_t UniqueTable::garbageCollect(const bool force) {
   const std::size_t numEntriesBefore = getNumEntries();
   if ((!force && numEntriesBefore < gcLimit) || numEntriesBefore == 0U) {
     return 0U;

--- a/src/dd/UniqueTable.cpp
+++ b/src/dd/UniqueTable.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2025 Chair for Design Automation, TUM
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "dd/UniqueTable.hpp"
+
+namespace dd {
+
+UniqueTable::UniqueTable(MemoryManager& manager, UniqueTableConfig config)
+    : cfg(config), gcLimit(config.initialGCLimit), memoryManager(&manager),
+      tables(config.nVars), stats(config.nVars) {
+  for (auto& stat : stats) {
+    stat.entrySize = sizeof(Bucket);
+    stat.numBuckets = cfg.nBuckets;
+  }
+}
+
+void UniqueTable::resize(std::size_t nVars) {
+  cfg.nVars = nVars;
+  tables.resize(nVars, Table(cfg.nBuckets));
+  // TODO: if the new size is smaller than the old one we might have to
+  // release the unique table entries for the superfluous variables
+  stats.resize(nVars);
+  for (auto& stat : stats) {
+    stat.entrySize = sizeof(Bucket);
+    stat.numBuckets = cfg.nBuckets;
+  }
+}
+
+bool UniqueTable::incRef(NodeBase* p) noexcept {
+  const auto inc = ::dd::incRef(p);
+  if (inc && p->ref == 1U) {
+    stats[p->v].trackActiveEntry();
+  }
+  return inc;
+}
+
+bool UniqueTable::decRef(NodeBase* p) noexcept {
+  const auto dec = ::dd::decRef(p);
+  if (dec && p->ref == 0U) {
+    --stats[p->v].numActiveEntries;
+  }
+  return dec;
+}
+
+bool UniqueTable::possiblyNeedsCollection() const {
+  return getNumEntries() >= gcLimit;
+}
+
+std::size_t UniqueTable::garbageCollect(bool force) {
+  const std::size_t numEntriesBefore = getNumEntries();
+  if ((!force && numEntriesBefore < gcLimit) || numEntriesBefore == 0U) {
+    return 0U;
+  }
+
+  std::size_t v = 0U;
+  for (auto& table : tables) {
+    auto& stat = stats[v];
+    ++stat.gcRuns;
+    for (auto& bucket : table) {
+      NodeBase* p = bucket;
+      NodeBase* lastp = nullptr;
+      while (p != nullptr) {
+        if (p->ref == 0) {
+          NodeBase* next = p->next();
+          if (lastp == nullptr) {
+            bucket = next;
+          } else {
+            lastp->setNext(next);
+          }
+          memoryManager->returnEntry(p);
+          p = next;
+          --stat.numEntries;
+        } else {
+          lastp = p;
+          p = p->next();
+        }
+      }
+    }
+    stat.numActiveEntries = stat.numEntries;
+    ++v;
+  }
+
+  // The garbage collection limit changes dynamically depending on the number
+  // of remaining (active) nodes. If it were not changed, garbage collection
+  // would run through the complete table on each successive call once the
+  // number of remaining entries reaches the garbage collection limit. It is
+  // increased whenever the number of remaining entries is rather close to the
+  // garbage collection threshold and decreased if the number of remaining
+  // entries is much lower than the current limit.
+  const auto numEntries = getNumEntries();
+  if (numEntries > gcLimit / 10 * 9) {
+    gcLimit = numEntries + cfg.initialGCLimit;
+  }
+  return numEntriesBefore - numEntries;
+}
+
+void UniqueTable::clear() {
+  // clear unique table buckets
+  for (auto& table : tables) {
+    for (auto& bucket : table) {
+      bucket = nullptr;
+    }
+  }
+  gcLimit = cfg.initialGCLimit;
+  for (auto& stat : stats) {
+    stat.reset();
+  }
+};
+
+const UniqueTableStatistics&
+UniqueTable::getStats(const std::size_t idx) const noexcept {
+  return stats.at(idx);
+}
+
+nlohmann::basic_json<>
+UniqueTable::getStatsJson(const bool includeIndividualTables) const {
+  if (std::all_of(stats.begin(), stats.end(),
+                  [](const UniqueTableStatistics& stat) {
+                    return stat.peakNumEntries == 0U;
+                  })) {
+    return "unused";
+  }
+
+  UniqueTableStatistics totalStats;
+  for (const auto& stat : stats) {
+    totalStats.entrySize = std::max(totalStats.entrySize, stat.entrySize);
+    totalStats.numBuckets += stat.numBuckets;
+    totalStats.numEntries += stat.numEntries;
+    totalStats.peakNumEntries += stat.peakNumEntries;
+    totalStats.collisions += stat.collisions;
+    totalStats.hits += stat.hits;
+    totalStats.lookups += stat.lookups;
+    totalStats.inserts += stat.inserts;
+    totalStats.numActiveEntries += stat.numActiveEntries;
+    totalStats.peakNumActiveEntries += stat.peakNumActiveEntries;
+    totalStats.gcRuns = std::max(totalStats.gcRuns, stat.gcRuns);
+  }
+
+  nlohmann::basic_json<> j;
+  j["total"] = totalStats.json();
+  if (includeIndividualTables) {
+    std::size_t v = 0U;
+    for (const auto& stat : stats) {
+      j[std::to_string(v)] = stat.json();
+      ++v;
+    }
+  }
+  return j;
+}
+
+std::size_t UniqueTable::getNumEntries() const noexcept {
+  return std::accumulate(
+      stats.begin(), stats.end(), std::size_t{0},
+      [](const std::size_t& sum, const UniqueTableStatistics& stat) {
+        return sum + stat.numEntries;
+      });
+}
+
+std::size_t UniqueTable::getNumActiveEntries() const noexcept {
+  return std::accumulate(
+      stats.begin(), stats.end(), std::size_t{0},
+      [](const std::size_t& sum, const UniqueTableStatistics& stat) {
+        return sum + stat.numActiveEntries;
+      });
+}
+
+std::size_t UniqueTable::getPeakNumActiveEntries() const noexcept {
+  return std::accumulate(
+      stats.begin(), stats.end(), std::size_t{0},
+      [](const std::size_t& sum, const UniqueTableStatistics& stat) {
+        return sum + stat.peakNumActiveEntries;
+      });
+}
+
+} // namespace dd

--- a/src/dd/statistics/MemoryManagerStatistics.cpp
+++ b/src/dd/statistics/MemoryManagerStatistics.cpp
@@ -20,7 +20,7 @@
 namespace dd {
 
 double MemoryManagerStatistics::entryMemoryMIB() const {
-  return static_cast<double>(entrySize) / (1ULL << 20U);
+  return static_cast<double>(entrySize_) / (1ULL << 20U);
 }
 
 std::size_t

--- a/src/dd/statistics/MemoryManagerStatistics.cpp
+++ b/src/dd/statistics/MemoryManagerStatistics.cpp
@@ -9,8 +9,6 @@
 
 #include "dd/statistics/MemoryManagerStatistics.hpp"
 
-#include "dd/Node.hpp"
-#include "dd/RealNumber.hpp"
 #include "dd/statistics/Statistics.hpp"
 
 #include <algorithm>

--- a/src/dd/statistics/MemoryManagerStatistics.cpp
+++ b/src/dd/statistics/MemoryManagerStatistics.cpp
@@ -19,69 +19,62 @@
 
 namespace dd {
 
-template <typename T>
+double MemoryManagerStatistics::entryMemoryMIB() const {
+  return static_cast<double>(entrySize) / (1ULL << 20U);
+}
+
 std::size_t
-MemoryManagerStatistics<T>::getNumAvailableFromChunks() const noexcept {
+MemoryManagerStatistics::getNumAvailableFromChunks() const noexcept {
   return getTotalNumAvailable() - numAvailableForReuse;
 }
 
-template <typename T>
-std::size_t MemoryManagerStatistics<T>::getTotalNumAvailable() const noexcept {
+std::size_t MemoryManagerStatistics::getTotalNumAvailable() const noexcept {
   return numAllocated - numUsed;
 }
 
-template <typename T>
-double MemoryManagerStatistics<T>::getUsageRatio() const noexcept {
+double MemoryManagerStatistics::getUsageRatio() const noexcept {
   return static_cast<double>(numUsed) / static_cast<double>(numAllocated);
 }
 
-template <typename T>
-double MemoryManagerStatistics<T>::getAllocatedMemoryMiB() const noexcept {
-  return static_cast<double>(numAllocated) * ENTRY_MEMORY_MIB;
+double MemoryManagerStatistics::getAllocatedMemoryMiB() const noexcept {
+  return static_cast<double>(numAllocated) * entryMemoryMIB();
 }
 
-template <typename T>
-double MemoryManagerStatistics<T>::getUsedMemoryMiB() const noexcept {
-  return static_cast<double>(numUsed) * ENTRY_MEMORY_MIB;
+double MemoryManagerStatistics::getUsedMemoryMiB() const noexcept {
+  return static_cast<double>(numUsed) * entryMemoryMIB();
 }
 
-template <typename T>
-double MemoryManagerStatistics<T>::getPeakUsedMemoryMiB() const noexcept {
-  return static_cast<double>(peakNumUsed) * ENTRY_MEMORY_MIB;
+double MemoryManagerStatistics::getPeakUsedMemoryMiB() const noexcept {
+  return static_cast<double>(peakNumUsed) * entryMemoryMIB();
 }
 
-template <typename T>
-void MemoryManagerStatistics<T>::trackUsedEntries(
+void MemoryManagerStatistics::trackUsedEntries(
     const std::size_t numEntries) noexcept {
   numUsed += numEntries;
   peakNumUsed = std::max(peakNumUsed, numUsed);
 }
 
-template <typename T>
-void MemoryManagerStatistics<T>::trackReusedEntries(
+void MemoryManagerStatistics::trackReusedEntries(
     const std::size_t numEntries) noexcept {
   numUsed += numEntries;
   peakNumUsed = std::max(peakNumUsed, numUsed);
   numAvailableForReuse -= numEntries;
 }
 
-template <typename T>
-void MemoryManagerStatistics<T>::trackReturnedEntry() noexcept {
+void MemoryManagerStatistics::trackReturnedEntry() noexcept {
   ++numAvailableForReuse;
   peakNumAvailableForReuse =
       std::max(peakNumAvailableForReuse, numAvailableForReuse);
   --numUsed;
 }
-
-template <typename T> void MemoryManagerStatistics<T>::reset() noexcept {
+void MemoryManagerStatistics::reset() noexcept {
   numAllocations = 0U;
   numAllocated = 0U;
   numUsed = 0U;
   numAvailableForReuse = 0U;
 }
 
-template <typename T>
-nlohmann::basic_json<> MemoryManagerStatistics<T>::json() const {
+nlohmann::basic_json<> MemoryManagerStatistics::json() const {
   if (peakNumUsed == 0) {
     return "unused";
   }
@@ -102,8 +95,4 @@ nlohmann::basic_json<> MemoryManagerStatistics<T>::json() const {
   return j;
 }
 
-template struct MemoryManagerStatistics<RealNumber>;
-template struct MemoryManagerStatistics<vNode>;
-template struct MemoryManagerStatistics<mNode>;
-template struct MemoryManagerStatistics<dNode>;
 } // namespace dd

--- a/test/dd/test_complex.cpp
+++ b/test/dd/test_complex.cpp
@@ -455,7 +455,7 @@ TEST_F(CNTest, ComplexTableAllocation) {
   // obtain entry
   auto* entry = mem.get<RealNumber>();
   // immediately return entry
-  mem.returnEntry(entry);
+  mem.returnEntry(*entry);
   EXPECT_EQ(mem.getStats().numAvailableForReuse, 1U);
   // obtain the same entry again, but this time from the available stack
   auto* entry2 = mem.get<RealNumber>();

--- a/test/dd/test_complex.cpp
+++ b/test/dd/test_complex.cpp
@@ -441,7 +441,7 @@ TEST_F(CNTest, ComplexTableAllocation) {
   }
 
   // trigger new allocation
-  const auto* num = mem.get();
+  const auto* num = mem.get<RealNumber>();
   ASSERT_NE(num, nullptr);
   EXPECT_EQ(mem.getStats().numAllocated,
             (1. + MemoryManager::GROWTH_FACTOR) * static_cast<fp>(allocs));
@@ -453,12 +453,12 @@ TEST_F(CNTest, ComplexTableAllocation) {
 
   EXPECT_EQ(mem.getStats().numAvailableForReuse, 0U);
   // obtain entry
-  auto* entry = mem.get();
+  auto* entry = mem.get<RealNumber>();
   // immediately return entry
   mem.returnEntry(entry);
   EXPECT_EQ(mem.getStats().numAvailableForReuse, 1U);
   // obtain the same entry again, but this time from the available stack
-  auto* entry2 = mem.get();
+  auto* entry2 = mem.get<RealNumber>();
   EXPECT_EQ(entry, entry2);
 }
 

--- a/test/dd/test_complex.cpp
+++ b/test/dd/test_complex.cpp
@@ -28,7 +28,7 @@ using namespace dd;
 
 class CNTest : public testing::Test {
 protected:
-  MemoryManager mm{MemoryManager::Create<dd::RealNumber>()};
+  MemoryManager mm{MemoryManager::create<RealNumber>()};
   RealNumberUniqueTable ut{mm};
   ComplexNumbers cn{ut};
 };
@@ -431,7 +431,7 @@ TEST_F(CNTest, MaxRefCountReached) {
 }
 
 TEST_F(CNTest, ComplexTableAllocation) {
-  auto mem = MemoryManager::Create<RealNumber>();
+  auto mem = MemoryManager::create<RealNumber>();
   auto allocs = mem.getStats().numAllocated;
   std::cout << allocs << "\n";
   std::vector<RealNumber*> nums{allocs};

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -957,7 +957,7 @@ TEST(DDPackageTest, PackageReset) {
 
   const auto& unique = dd->mUniqueTable.getTables();
   const auto& table = unique[0];
-  auto ihash = dd->mUniqueTable.hash(xGate.p);
+  auto ihash = dd->mUniqueTable.hash(*xGate.p);
   const auto* node = table[ihash];
   std::cout << ihash << ": " << reinterpret_cast<uintptr_t>(xGate.p) << "\n";
   // node should be the first in this unique table bucket

--- a/test/dd/test_package.cpp
+++ b/test/dd/test_package.cpp
@@ -469,7 +469,7 @@ TEST(DDPackageTest, StateGenerationManipulation) {
                               {dd::BasisStates::zero, dd::BasisStates::one,
                                dd::BasisStates::plus, dd::BasisStates::minus,
                                dd::BasisStates::left, dd::BasisStates::right});
-  dd->vUniqueTable.print();
+  dd->vUniqueTable.print<dd::vNode>();
   dd->decRef(e);
   dd->decRef(f);
 }
@@ -957,7 +957,7 @@ TEST(DDPackageTest, PackageReset) {
 
   const auto& unique = dd->mUniqueTable.getTables();
   const auto& table = unique[0];
-  auto ihash = decltype(dd->mUniqueTable)::hash(xGate.p);
+  auto ihash = dd->mUniqueTable.hash(xGate.p);
   const auto* node = table[ihash];
   std::cout << ihash << ": " << reinterpret_cast<uintptr_t>(xGate.p) << "\n";
   // node should be the first in this unique table bucket
@@ -1007,14 +1007,14 @@ TEST(DDPackageTest, UniqueTableAllocation) {
   std::vector<dd::vNode*> nodes{allocs};
   // get all the nodes that are pre-allocated
   for (auto i = 0U; i < allocs; ++i) {
-    nodes[i] = dd->vMemoryManager.get();
+    nodes[i] = dd->vMemoryManager.template get<dd::vNode>();
   }
 
   // trigger new allocation
-  const auto* node = dd->vMemoryManager.get();
+  const auto* node = dd->vMemoryManager.template get<dd::vNode>();
   ASSERT_NE(node, nullptr);
   EXPECT_EQ(dd->vMemoryManager.getStats().numAllocated,
-            (1. + dd::MemoryManager<dd::vNode>::GROWTH_FACTOR) *
+            (1. + dd::MemoryManager::GROWTH_FACTOR) *
                 static_cast<double>(allocs));
 
   // clearing the unique table should reduce the allocated size to the original
@@ -1110,12 +1110,12 @@ TEST(DDPackageTest, NearZeroNormalize) {
   auto dd = std::make_unique<dd::Package<>>(2);
   const dd::fp nearZero = dd::RealNumber::eps / 10;
   dd::vEdge ve{};
-  ve.p = dd->vMemoryManager.get();
+  ve.p = dd->vMemoryManager.template get<dd::vNode>();
   ve.p->v = 1;
   ve.w = dd::Complex::one();
   std::array<dd::vCachedEdge, dd::RADIX> edges{};
   for (auto& edge : edges) {
-    edge.p = dd->vMemoryManager.get();
+    edge.p = dd->vMemoryManager.template get<dd::vNode>();
     edge.p->v = 0;
     edge.w = nearZero;
     edge.p->e = {dd::vEdge::one(), dd::vEdge::one()};
@@ -1126,7 +1126,7 @@ TEST(DDPackageTest, NearZeroNormalize) {
 
   std::array<dd::vEdge, dd::RADIX> edges2{};
   for (auto& edge : edges2) {
-    edge.p = dd->vMemoryManager.get();
+    edge.p = dd->vMemoryManager.template get<dd::vNode>();
     edge.p->v = 0;
     edge.w = dd->cn.lookup(nearZero);
     edge.p->e = {dd::vEdge::one(), dd::vEdge::one()};
@@ -1136,12 +1136,12 @@ TEST(DDPackageTest, NearZeroNormalize) {
   EXPECT_TRUE(veNormalized.isZeroTerminal());
 
   dd::mEdge me{};
-  me.p = dd->mMemoryManager.get();
+  me.p = dd->mMemoryManager.template get<dd::mNode>();
   me.p->v = 1;
   me.w = dd::Complex::one();
   std::array<dd::mCachedEdge, dd::NEDGE> edges3{};
   for (auto& edge : edges3) {
-    edge.p = dd->mMemoryManager.get();
+    edge.p = dd->mMemoryManager.template get<dd::mNode>();
     edge.p->v = 0;
     edge.w = nearZero;
     edge.p->e = {dd::mEdge::one(), dd::mEdge::one(), dd::mEdge::one(),
@@ -1151,10 +1151,10 @@ TEST(DDPackageTest, NearZeroNormalize) {
       dd::mCachedEdge::normalize(me.p, edges3, dd->mMemoryManager, dd->cn);
   EXPECT_EQ(meNormalizedCached, dd::mCachedEdge::zero());
 
-  me.p = dd->mMemoryManager.get();
+  me.p = dd->mMemoryManager.template get<dd::mNode>();
   std::array<dd::mEdge, 4> edges4{};
   for (auto& edge : edges4) {
-    edge.p = dd->mMemoryManager.get();
+    edge.p = dd->mMemoryManager.template get<dd::mNode>();
     edge.p->v = 0;
     edge.w = dd->cn.lookup(nearZero, 0.);
     edge.p->e = {dd::mEdge::one(), dd::mEdge::one(), dd::mEdge::one(),


### PR DESCRIPTION
## Description

Main Changes:
- Remove template from MemoryManagerStatistics
   -> only used to get size of an object, replaced by a member field that specifies the size of the object that is being tracked
- Separate next pointer for linked lists in base class
   -> allows to use memory manager with static_cast to base class without templates
- Separate common members in Node classes into base class
   -> allows to move some methods of UniqueTable into source files. Some methods are still explicitly templated if exact node data (e.g. equality of nodes) is required
   
 This also decreases code size :)

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

(will solve the linter errors on sunday if you want to go down the route of more runtime config and less templating)
