### PR TITLE
🩹 Add `insert_or_assign` method to `Permutation` class

### DIFF
--- a/include/mqt-core/ir/Permutation.hpp
+++ b/include/mqt-core/ir/Permutation.hpp
@@ -142,12 +142,21 @@ public:
     return permutation.emplace(std::forward<Args>(args)...);
   }
 
+  // NOLINTBEGIN(readability-identifier-naming)
+
   /// Inserts in-place if the key does not exist, does nothing otherwise
   template <class... Args>
-  // NOLINTNEXTLINE(readability-identifier-naming)
   auto try_emplace(const Qubit key, Args&&... args) -> auto {
     return permutation.try_emplace(key, std::forward<Args>(args)...);
   }
+
+  /// Inserts an element or assigns to the current element if the key already
+  /// exists
+  auto insert_or_assign(const Qubit key, const Qubit value) -> auto {
+    return permutation.insert_or_assign(key, value);
+  }
+
+  // NOLINTEND(readability-identifier-naming)
 
   /// Erases elements
   auto erase(const Qubit qubit) -> std::size_t {


### PR DESCRIPTION
## Description

Fixes an oversight when switching from directly inheriting from `std::map` for the `qc::Permutation` class. One of the downstream packages (https://github.com/cda-tum/mqt-syrec) relied on the `insert_or_assign` method being available.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
