### PR TITLE
🔥 Remove `Teleportation` gate

### DIFF
--- a/include/mqt-core/ir/operations/OpType.inc
+++ b/include/mqt-core/ir/operations/OpType.inc
@@ -51,24 +51,23 @@ HANDLE_OP_TYPE(29, Compound, OpTypeNone, "compound")
 // Non Unitary Operations
 HANDLE_OP_TYPE(30, Measure, OpTypeNone, "measure")
 HANDLE_OP_TYPE(31, Reset, OpTypeNone, "reset")
-HANDLE_OP_TYPE(32, Teleportation, OpTypeNone, "teleportation")
 
 // Classically-controlled Operation
-HANDLE_OP_TYPE(33, ClassicControlled, OpTypeNone, "classic_controlled")
+HANDLE_OP_TYPE(32, ClassicControlled, OpTypeNone, "classic_controlled")
 
 // Noise operations
-HANDLE_OP_TYPE(34, ATrue, 0, "a_true")
-HANDLE_OP_TYPE(35, AFalse, 0, "a_false")
-HANDLE_OP_TYPE(36, MultiATrue, 0, "multi_a_true")
-HANDLE_OP_TYPE(37, MultiAFalse, 0, "multi_a_false")
+HANDLE_OP_TYPE(33, ATrue, 0, "a_true")
+HANDLE_OP_TYPE(34, AFalse, 0, "a_false")
+HANDLE_OP_TYPE(35, MultiATrue, 0, "multi_a_true")
+HANDLE_OP_TYPE(36, MultiAFalse, 0, "multi_a_false")
 
 // Neutral atom shuttling operations
-HANDLE_OP_TYPE(38, Move, 0, "move")
-HANDLE_OP_TYPE(39, AodActivate, 0, "aod_activate")
-HANDLE_OP_TYPE(40, AodDeactivate, 0, "aod_deactivate")
-HANDLE_OP_TYPE(41, AodMove, 0, "aod_move")
+HANDLE_OP_TYPE(37, Move, 0, "move")
+HANDLE_OP_TYPE(38, AodActivate, 0, "aod_activate")
+HANDLE_OP_TYPE(39, AodDeactivate, 0, "aod_deactivate")
+HANDLE_OP_TYPE(40, AodMove, 0, "aod_move")
 
-LAST_OP_TYPE(42)
+LAST_OP_TYPE(41)
 
 
 #undef OpTypeInv

--- a/include/mqt-core/ir/operations/StandardOperation.hpp
+++ b/include/mqt-core/ir/operations/StandardOperation.hpp
@@ -52,9 +52,6 @@ protected:
   void checkUgate();
   void setup();
 
-  void dumpOpenQASMTeleportation(std::ostream& of,
-                                 const QubitIndexToRegisterMap& qreg) const;
-
 public:
   StandardOperation() = default;
 

--- a/include/mqt-core/qasm3/StdGates.hpp
+++ b/include/mqt-core/qasm3/StdGates.hpp
@@ -99,9 +99,6 @@ const std::map<std::string, std::shared_ptr<Gate>> STANDARD_GATES = {
     {"c3sqrtx",
      std::make_shared<StandardGate>(StandardGate({3, 1, 0, qc::SXdg}))},
 
-    {"teleport", std::make_shared<StandardGate>(
-                     StandardGate({0, 3, 0, qc::Teleportation}))},
-
     {"swap", std::make_shared<StandardGate>(StandardGate({0, 2, 0, qc::SWAP}))},
     {"cswap",
      std::make_shared<StandardGate>(StandardGate({1, 2, 0, qc::SWAP}))},

--- a/src/ir/QuantumComputation.cpp
+++ b/src/ir/QuantumComputation.cpp
@@ -666,11 +666,6 @@ void QuantumComputation::dumpOpenQASM(std::ostream& of, bool openQASM3) const {
     of << "OPENQASM 2.0;\n";
     of << "include \"qelib1.inc\";\n";
   }
-  if (std::any_of(std::begin(ops), std::end(ops), [](const auto& op) {
-        return op->getType() == OpType::Teleportation;
-      })) {
-    of << "opaque teleport src, anc, tgt;\n";
-  }
 
   // combine qregs and ancregs
   auto combinedRegs = quantumRegisters;

--- a/src/ir/operations/OpType.cpp
+++ b/src/ir/operations/OpType.cpp
@@ -57,8 +57,6 @@ std::string shortName(const OpType opType) {
     return "msr";
   case Reset:
     return "rst";
-  case Teleportation:
-    return "tel";
   default:
     return toString(opType);
   }
@@ -130,7 +128,6 @@ OpType opTypeFromString(const std::string& opType) {
       {"measure", OpType::Measure},
       {"reset", OpType::Reset},
       {"barrier", OpType::Barrier},
-      {"teleportation", OpType::Teleportation},
       {"classic_controlled", OpType::ClassicControlled},
       {"compound", OpType::Compound},
       {"move", OpType::Move},

--- a/src/ir/operations/StandardOperation.cpp
+++ b/src/ir/operations/StandardOperation.cpp
@@ -280,8 +280,7 @@ void StandardOperation::dumpOpenQASM2(
   // safe the numbers of controls as a prefix to the operation name
   op << std::string(controls.size(), 'c');
 
-  const bool isSpecialGate =
-      type == Peres || type == Peresdg || type == Teleportation;
+  const bool isSpecialGate = type == Peres || type == Peresdg;
 
   if (!isSpecialGate) {
     // apply X operations to negate the respective controls
@@ -462,9 +461,6 @@ void StandardOperation::dumpGateType(
     of << " " << qubitMap.at(targets[1]).second << ", "
        << qubitMap.at(targets[0]).second << ";\n";
     return;
-  case Teleportation:
-    dumpOpenQASMTeleportation(of, qubitMap);
-    return;
   default:
     std::cerr << "gate type " << toString(type)
               << " could not be converted to OpenQASM\n.";
@@ -495,29 +491,6 @@ void StandardOperation::dumpGateType(
     }
   }
   of << ";\n";
-}
-
-void StandardOperation::dumpOpenQASMTeleportation(
-    std::ostream& of, const QubitIndexToRegisterMap& qubitMap) const {
-  if (!controls.empty() || targets.size() != 3) {
-    throw std::runtime_error("Teleportation needs three targets");
-  }
-  /*
-                                      ░      ┌───┐ ░ ┌─┐    ░
-                  |ψ⟩ q_0: ───────────░───■──┤ H ├─░─┤M├────░─────────────── |0⟩
-     or |1⟩ ┌───┐      ░ ┌─┴─┐└───┘ ░ └╥┘┌─┐ ░ |0⟩ a_0: ┤ H ├──■───░─┤ X
-     ├──────░──╫─┤M├─░─────────────── |0⟩ or |1⟩ └───┘┌─┴─┐ ░ └───┘      ░  ║
-     └╥┘ ░  ┌───┐  ┌───┐ |0⟩ a_1: ─────┤ X ├─░────────────░──╫──╫──░──┤ X ├──┤ Z
-     ├─ |ψ⟩ └───┘ ░            ░  ║  ║  ░  └─┬─┘  └─┬─┘ ║  ║    ┌──┴──┐   │
-                bitflip: 1/═══════════════════════════╩══╬════╡ = 1 ╞═══╪═══
-                                                      0  ║    └─────┘┌──┴──┐
-              phaseflip: 1/══════════════════════════════╩═══════════╡ = 1 ╞
-                                                         0           └─────┘
-          */
-  of << "// teleport q_0, a_0, a_1; q_0 --> a_1  via a_0\n";
-  of << "teleport " << qubitMap.at(targets[0]).second << ", "
-     << qubitMap.at(targets[1]).second << ", " << qubitMap.at(targets[2]).second
-     << ";\n";
 }
 
 auto StandardOperation::commutesAtQubit(const Operation& other,

--- a/src/mqt/core/ir/operations.pyi
+++ b/src/mqt/core/ir/operations.pyi
@@ -293,10 +293,6 @@ class OpType:
     See Also:
         :meth:`mqt.core.ir.QuantumComputation.tdg`
     """
-    teleportation: ClassVar[OpType]
-    """
-    A teleportation operation.
-    """
     u2: ClassVar[OpType]
     """
     A U2 gate.

--- a/src/python/ir/operations/register_optype.cpp
+++ b/src/python/ir/operations/register_optype.cpp
@@ -54,7 +54,6 @@ void registerOptype(const py::module& m) {
       .value("measure", qc::OpType::Measure)
       .value("reset", qc::OpType::Reset)
       .value("barrier", qc::OpType::Barrier)
-      .value("teleportation", qc::OpType::Teleportation)
       .value("classic_controlled", qc::OpType::ClassicControlled)
       .export_values()
       .def("__str__", [](const qc::OpType& op) { return qc::toString(op); })

--- a/test/ir/test_qasm3_parser.cpp
+++ b/test/ir/test_qasm3_parser.cpp
@@ -665,27 +665,6 @@ TEST_F(Qasm3ParserTest, ImportQasm3Qelib1) {
   EXPECT_EQ(out, expected);
 }
 
-TEST_F(Qasm3ParserTest, ImportQasm3Teleportation) {
-  const std::string testfile = "OPENQASM 3.0;\n"
-                               "include \"stdgates.inc\";\n"
-                               "opaque teleport src, anc, tgt;\n"
-                               "qubit[3] q;\n"
-                               "teleport q[0], q[1], q[2];\n";
-  const auto qc = qasm3::Importer::imports(testfile);
-
-  const std::string out = qc.toQASM();
-  const std::string expected =
-      "// i 0 1 2\n"
-      "// o 0 1 2\n"
-      "OPENQASM 3.0;\n"
-      "include \"stdgates.inc\";\n"
-      "opaque teleport src, anc, tgt;\n"
-      "qubit[3] q;\n"
-      "// teleport q_0, a_0, a_1; q_0 --> a_1  via a_0\n"
-      "teleport q[0], q[1], q[2];\n";
-  EXPECT_EQ(out, expected);
-}
-
 TEST_F(Qasm3ParserTest, ImportQasm3NestedGates) {
   const std::string testfile = "OPENQASM 3.0;\n"
                                "include \"stdgates.inc\";\n"

--- a/test/ir/test_qfr_functionality.cpp
+++ b/test/ir/test_qfr_functionality.cpp
@@ -691,18 +691,6 @@ TEST_F(QFRFunctionality, OpNameToTypeSimple) {
                std::invalid_argument);
 }
 
-TEST_F(QFRFunctionality, dumpAndImportTeleportation) {
-  QuantumComputation qc(3);
-  qc.emplace_back<StandardOperation>(Targets{0, 1, 2}, OpType::Teleportation);
-  std::stringstream ss;
-  qc.dumpOpenQASM(ss, false);
-  EXPECT_TRUE(ss.str().find("teleport") != std::string::npos);
-
-  auto qcImported = qasm3::Importer::import(ss);
-  ASSERT_EQ(qcImported.size(), 1);
-  EXPECT_EQ(qcImported.at(0)->getType(), OpType::Teleportation);
-}
-
 TEST_F(QFRFunctionality, addControlStandardOperation) {
   auto op = StandardOperation(0, OpType::X);
   op.addControl(1);


### PR DESCRIPTION
## Description

This PR removes the `Teleportation` gate from mqt-core in preparation for the v3 launch.
It was only ever used in one routing pass in MQT QMAP that is being phased out and was hardly documented.
Might as well remove it here. Removed code is debugged code 🤷🏼 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
