### PR TITLE
:building_construction: Enforce LLVM-20 when building MLIR subdirectory

### DIFF
--- a/.github/workflows/ci_mlir.yml
+++ b/.github/workflows/ci_mlir.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        llvm-version: [19, 20]
+        llvm-version: [20]
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -7,9 +7,13 @@
 
 # set the include directory for the build tree
 set(MQT_MLIR_INCLUDE_BUILD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+set(MQT_MLIR_MIN_VERSION 20.0)
 
 # MLIR must be installed on the system
 find_package(MLIR REQUIRED CONFIG)
+if(MLIR_VERSION VERSION_LESS MQT_MLIR_MIN_VERSION)
+  message(FATAL_ERROR "MLIR version must be at least ${MQT_MLIR_MIN_VERSION}")
+endif()
 message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 

--- a/mlir/lib/Dialect/MQTOpt/Transforms/MQTCoreRoundTrip.cpp
+++ b/mlir/lib/Dialect/MQTOpt/Transforms/MQTCoreRoundTrip.cpp
@@ -41,7 +41,7 @@ struct MQTCoreRoundTrip final : impl::MQTCoreRoundTripBase<MQTCoreRoundTrip> {
             // This was deprecated in LLVM@20, but the alternative does not yet
             // exist in LLVM@19.
             // NOLINTNEXTLINE(clang-diagnostic-deprecated-declarations)
-            mlir::applyPatternsAndFoldGreedily(op, std::move(patterns)))) {
+            mlir::applyPatternsGreedily(op, std::move(patterns)))) {
       signalPassFailure();
     }
   }


### PR DESCRIPTION
## Description

This PR updates the `CMakeLists.txt` file of the `mlir` subdirectory to now check whether the found MLIR package uses version `20.0` or newer. Otherwise, compilation stops.

Due to this change in compatibility, `llvm-19` was removed from the CI build matrix and transformation passes now use `applyPatternsGreedily` instead of `applyPatternsAndFoldGreedily`.

I suggest we wait until #892 is merged so that we can also fix the deprecated calls in there.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
